### PR TITLE
[codex] Fix SecureStore auth restore failures

### DIFF
--- a/expo/context/auth.tsx
+++ b/expo/context/auth.tsx
@@ -95,7 +95,6 @@ interface AuthContextValue {
     email: string;
     password: string;
     confirmPassword: string;
-    confirmPassword: string;
     redirectTo: string | undefined;
   }) => AuthMethodResponse;
   logout: () => AuthMethodResponse;

--- a/expo/context/auth.tsx
+++ b/expo/context/auth.tsx
@@ -95,6 +95,7 @@ interface AuthContextValue {
     email: string;
     password: string;
     confirmPassword: string;
+    confirmPassword: string;
     redirectTo: string | undefined;
   }) => AuthMethodResponse;
   logout: () => AuthMethodResponse;
@@ -417,9 +418,15 @@ export function AuthProvider(props: React.PropsWithChildren) {
   );
 
   useMountEffect(function setupSession() {
-    void supabase.auth.getSession().then(({ data: { session } }) => {
-      handleSessionChange(session);
-    });
+    void supabase.auth
+      .getSession()
+      .then(({ data: { session } }) => {
+        handleSessionChange(session);
+      })
+      .catch((error) => {
+        console.warn('Failed to restore session:', error);
+        handleSessionChange(null);
+      });
 
     const {
       data: { subscription },

--- a/expo/hooks/useStorageState.tsx
+++ b/expo/hooks/useStorageState.tsx
@@ -4,6 +4,10 @@ import { Platform } from 'react-native';
 
 type UseStateHook<T> = [[boolean, T | null], (value: T | null) => void];
 
+const secureStoreOptions: SecureStore.SecureStoreOptions = {
+  keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK,
+};
+
 function useAsyncState<T>(
   initialValue: [boolean, T | null] = [true, null],
 ): UseStateHook<T> {
@@ -29,9 +33,9 @@ export async function setStorageItemAsync(key: string, value: string | null) {
     }
   } else {
     if (value == null) {
-      await SecureStore.deleteItemAsync(key);
+      await SecureStore.deleteItemAsync(key, secureStoreOptions);
     } else {
-      await SecureStore.setItemAsync(key, value);
+      await SecureStore.setItemAsync(key, value, secureStoreOptions);
     }
   }
 }
@@ -51,9 +55,14 @@ export function useStorageState(key: string): UseStateHook<string> {
         console.error('Local storage is unavailable:', e);
       }
     } else {
-      SecureStore.getItemAsync(key).then((value) => {
-        setState(value);
-      });
+      SecureStore.getItemAsync(key, secureStoreOptions)
+        .then((value) => {
+          setState(value);
+        })
+        .catch((error) => {
+          console.warn('Secure storage is unavailable:', error);
+          setState(null);
+        });
     }
   }, [key]);
 
@@ -61,7 +70,9 @@ export function useStorageState(key: string): UseStateHook<string> {
   const setValue = React.useCallback(
     (value: string | null) => {
       setState(value);
-      setStorageItemAsync(key, value);
+      void setStorageItemAsync(key, value).catch((error) => {
+        console.warn('Secure storage is unavailable:', error);
+      });
     },
     [key],
   );

--- a/expo/lib/supabase.test.ts
+++ b/expo/lib/supabase.test.ts
@@ -1,0 +1,72 @@
+import * as SecureStore from 'expo-secure-store';
+import AsyncStorage from 'expo-sqlite/kv-store';
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({
+    auth: {
+      startAutoRefresh: jest.fn(),
+      stopAutoRefresh: jest.fn(),
+    },
+  })),
+}));
+
+jest.mock('react-native-url-polyfill/auto', () => ({}));
+jest.mock('react-native-get-random-values', () => ({}));
+
+jest.mock('expo-secure-store', () => ({
+  __esModule: true,
+  AFTER_FIRST_UNLOCK: 'AFTER_FIRST_UNLOCK',
+  deleteItemAsync: jest.fn(),
+  getItemAsync: jest.fn(),
+  setItemAsync: jest.fn(),
+}));
+
+const mockAsyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+const mockSecureStore = SecureStore as jest.Mocked<typeof SecureStore>;
+const { LargeSecureStore } =
+  jest.requireActual<typeof import('./supabase')>('./supabase');
+
+describe('LargeSecureStore', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns null when SecureStore cannot read the encryption key', async () => {
+    mockAsyncStorage.getItem.mockResolvedValue('encrypted-session');
+    mockSecureStore.getItemAsync.mockRejectedValue(
+      new Error('User interaction is not allowed.'),
+    );
+
+    await expect(
+      new LargeSecureStore().getItem('supabase.auth.token'),
+    ).resolves.toBeNull();
+
+    expect(mockSecureStore.getItemAsync).toHaveBeenCalledWith(
+      'supabase.auth.token',
+      { keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK },
+    );
+    expect(console.warn).toHaveBeenCalledWith(
+      'Unable to read secure auth storage:',
+      expect.any(Error),
+    );
+  });
+
+  it('stores encryption keys with after-first-unlock keychain accessibility', async () => {
+    await new LargeSecureStore().setItem('supabase.auth.token', 'session');
+
+    expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith(
+      'supabase.auth.token',
+      expect.any(String),
+      { keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK },
+    );
+    expect(mockAsyncStorage.setItem).toHaveBeenCalledWith(
+      'supabase.auth.token',
+      expect.any(String),
+    );
+  });
+});

--- a/expo/lib/supabase.ts
+++ b/expo/lib/supabase.ts
@@ -1,18 +1,21 @@
-import "react-native-url-polyfill/auto";
-import "react-native-get-random-values";
+import 'react-native-url-polyfill/auto';
+import 'react-native-get-random-values';
 
-import { createClient } from "@supabase/supabase-js";
-import * as aesjs from "aes-js";
-import * as SecureStore from "expo-secure-store";
-import AsyncStorage from "expo-sqlite/kv-store";
-import { AppState } from "react-native";
+import type { Database } from '@packages/database/index';
+import { createClient } from '@supabase/supabase-js';
+import * as aesjs from 'aes-js';
+import * as SecureStore from 'expo-secure-store';
+import AsyncStorage from 'expo-sqlite/kv-store';
+import { AppState } from 'react-native';
 
-import type { Database } from "@packages/database/index";
+const secureStoreOptions: SecureStore.SecureStoreOptions = {
+  keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK,
+};
 
 // As Expo's SecureStore does not support values larger than 2048
 // bytes, an AES-256 key is generated and stored in SecureStore, while
 // it is used to encrypt/decrypt values stored in AsyncStorage.
-class LargeSecureStore {
+export class LargeSecureStore {
   private async _encrypt(key: string, value: string) {
     const encryptionKey = crypto.getRandomValues(new Uint8Array(256 / 8));
 
@@ -25,13 +28,17 @@ class LargeSecureStore {
     await SecureStore.setItemAsync(
       key,
       aesjs.utils.hex.fromBytes(encryptionKey),
+      secureStoreOptions,
     );
 
     return aesjs.utils.hex.fromBytes(encryptedBytes);
   }
 
   private async _decrypt(key: string, value: string) {
-    const encryptionKeyHex = await SecureStore.getItemAsync(key);
+    const encryptionKeyHex = await SecureStore.getItemAsync(
+      key,
+      secureStoreOptions,
+    );
     if (!encryptionKeyHex) {
       return encryptionKeyHex;
     }
@@ -51,12 +58,17 @@ class LargeSecureStore {
       return encrypted;
     }
 
-    return await this._decrypt(key, encrypted);
+    try {
+      return await this._decrypt(key, encrypted);
+    } catch (error) {
+      console.warn('Unable to read secure auth storage:', error);
+      return null;
+    }
   }
 
   async removeItem(key: string) {
     await AsyncStorage.removeItem(key);
-    await SecureStore.deleteItemAsync(key);
+    await SecureStore.deleteItemAsync(key, secureStoreOptions);
   }
 
   async setItem(key: string, value: string) {
@@ -67,8 +79,8 @@ class LargeSecureStore {
 }
 
 export const supabase = createClient<Database>(
-  process.env.EXPO_PUBLIC_SUPABASE_URL || "",
-  process.env.EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY || "",
+  process.env.EXPO_PUBLIC_SUPABASE_URL || '',
+  process.env.EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY || '',
   {
     auth: {
       storage: new LargeSecureStore(),
@@ -79,8 +91,8 @@ export const supabase = createClient<Database>(
   },
 );
 
-AppState.addEventListener("change", (state) => {
-  if (state === "active") {
+AppState.addEventListener('change', (state) => {
+  if (state === 'active') {
     supabase.auth.startAutoRefresh();
   } else {
     supabase.auth.stopAutoRefresh();


### PR DESCRIPTION
## Summary

Fixes the iOS SecureStore auth restore failure seen in Sentry: `getValueWithKeyAsync` rejecting with `User interaction is not allowed`.

## What changed

- Uses `SecureStore.AFTER_FIRST_UNLOCK` for auth encryption keys and direct SecureStore state reads/writes.
- Makes Supabase auth storage return `null` instead of throwing when the encryption key cannot be read.
- Catches auth session restore failures so `sessionLoading` is cleared instead of producing an unhandled rejection.
- Adds regression tests for the SecureStore read failure and keychain accessibility option.

## Impact

This is a JS-only change. It should not require a new native development client build; it can ship through the usual JS update path if runtime compatibility allows it.

## Validation

- `pnpm --dir expo exec jest --runInBand --no-watchman`
- `pnpm --dir expo exec eslint lib/supabase.ts hooks/useStorageState.tsx context/auth.tsx lib/supabase.test.ts`
- Prettier on touched files

## Notes

Local `git push` over SSH failed in this environment with `Permission denied (publickey)`, so the remote branch contents were created through the Codex GitHub connector as requested.