### PR TITLE
Show membership payment review state

### DIFF
--- a/expo/app/(tabs)/organizations.tsx
+++ b/expo/app/(tabs)/organizations.tsx
@@ -13,14 +13,13 @@ import {
   type LucideIcon,
 } from 'lucide-react-native';
 import React from 'react';
-import {
-  Pressable,
-  RefreshControl,
-  ScrollView,
-  View,
-} from 'react-native';
+import { Pressable, RefreshControl, ScrollView, View } from 'react-native';
 
 import { useAuth } from '~/context/auth';
+import { getManualPaymentRouteParams } from '~/lib/manual-payment';
+import { getMembershipDisplayState } from '~/lib/membership-display-state';
+import { fetchPaymentUnderReview } from '~/lib/payment-review';
+import { queryKeys as appQueryKeys } from '~/lib/query-keys';
 import { supabase } from '~/lib/supabase';
 import { cn } from '~/lib/utils';
 
@@ -30,6 +29,7 @@ import { BecomeMemberCard } from '~/components/organizations/become-member-card'
 import { News } from '~/components/organizations/News';
 import { OrganizationErrorState } from '~/components/organizations/organization-error-state';
 import { OrganizationLoadingState } from '~/components/organizations/organization-loading-state';
+import { PaymentUnderReviewCard } from '~/components/organizations/payment-under-review-card';
 import { Subscription } from '~/components/organizations/Subscription';
 import { Icon } from '~/components/ui/icon';
 import { Skeleton } from '~/components/ui/skeleton';
@@ -56,7 +56,25 @@ function OrganizationDetailsPage() {
 
   const { data: organization, isLoading } = useOrganization(ORG_SLUG);
 
-  const { data: isMember } = useIsMember(ORG_SLUG);
+  const { data: isMember, isLoading: isMemberLoading } = useIsMember(ORG_SLUG);
+  const {
+    data: paymentUnderReview,
+    isError: paymentReviewError,
+    isLoading: paymentReviewLoading,
+    refetch: refetchPaymentReview,
+  } = useQuery({
+    queryKey: appQueryKeys.paymentReview.byOrgUser(ORG_SLUG, session?.user.id),
+    queryFn: () => fetchPaymentUnderReview(ORG_SLUG, session!.user.id),
+    enabled: Boolean(session?.user.id && !isMember),
+  });
+  const membershipDisplayState = getMembershipDisplayState({
+    hasPaymentUnderReview: Boolean(paymentUnderReview),
+    isMember,
+    isMemberLoading,
+    isSignedIn: Boolean(session?.user),
+    paymentReviewError,
+    paymentReviewLoading,
+  });
 
   const onRefresh = async () => {
     setRefreshing(true);
@@ -70,8 +88,28 @@ function OrganizationDetailsPage() {
       queryClient.invalidateQueries({
         queryKey: queryKeys.organizations.memberCount(ORG_SLUG),
       }),
+      queryClient.invalidateQueries({
+        queryKey: appQueryKeys.paymentReview.byOrgUser(
+          ORG_SLUG,
+          session?.user.id,
+        ),
+      }),
     ]);
     setRefreshing(false);
+  };
+
+  const handlePaymentUnderReviewPress = () => {
+    if (!paymentUnderReview) return;
+
+    router.push({
+      pathname: '/payment',
+      params: getManualPaymentRouteParams({
+        amount: paymentUnderReview.amount,
+        paymentId: paymentUnderReview.id,
+        paymentContext: 'new_member',
+        slug: organization?.slug ?? ORG_SLUG,
+      }),
+    });
   };
 
   const handleBecomeMemberPress = () => {
@@ -138,8 +176,28 @@ function OrganizationDetailsPage() {
         </View>
 
         {/* Membership Section */}
-        {isMember ? (
+        {membershipDisplayState === 'loading' ? (
+          <Skeleton className="h-[200px] w-full rounded-xl bg-gray-200" />
+        ) : membershipDisplayState === 'active-member' ? (
           <Subscription organization={organization} />
+        ) : membershipDisplayState === 'payment-review-error' ? (
+          <View className="gap-3 rounded-xl border border-red-200 bg-white p-6">
+            <Text className="text-lg font-bold text-gray-900">
+              Não foi possível verificar sua associação
+            </Text>
+            <Text className="text-gray-600">
+              Tente novamente para consultar o status do seu pagamento.
+            </Text>
+            <Pressable
+              accessibilityRole="button"
+              onPress={() => refetchPaymentReview()}
+              className="items-center rounded-lg bg-gray-900 px-4 py-3"
+            >
+              <Text className="font-bold text-white">Tentar novamente</Text>
+            </Pressable>
+          </View>
+        ) : membershipDisplayState === 'payment-under-review' ? (
+          <PaymentUnderReviewCard onPress={handlePaymentUnderReviewPress} />
         ) : (
           <BecomeMemberCard onPress={handleBecomeMemberPress} />
         )}

--- a/expo/app/payment.tsx
+++ b/expo/app/payment.tsx
@@ -182,6 +182,11 @@ export default function PaymentScreen() {
       await queryClient.invalidateQueries({
         queryKey: queryKeys.subscription.all,
       });
+      if (slug && profile?.id) {
+        await queryClient.invalidateQueries({
+          queryKey: queryKeys.paymentReview.byOrgUser(slug, profile.id),
+        });
+      }
 
       if (paymentContext === 'new_member') {
         router.replace('/(tabs)/organizations');
@@ -488,6 +493,9 @@ const PaymentStatusSubscription = ({
               queryKey: queryKeys.subscription.all,
             });
             if (slug && profileId) {
+              queryClient.invalidateQueries({
+                queryKey: queryKeys.paymentReview.byOrgUser(slug, profileId),
+              });
               queryClient.invalidateQueries({
                 queryKey: queryKeys.organizations.isMember(slug, profileId),
               });

--- a/expo/components/organizations/payment-under-review-card.tsx
+++ b/expo/components/organizations/payment-under-review-card.tsx
@@ -1,6 +1,6 @@
 import SlacCabeMaisImage from '~/assets/images/slac-cabe-mais.png';
 import { Image } from 'expo-image';
-import { CheckIcon, ChevronRightIcon, Clock3Icon } from 'lucide-react-native';
+import { CheckIcon, ChevronRightIcon } from 'lucide-react-native';
 import React from 'react';
 import { View } from 'react-native';
 
@@ -35,15 +35,12 @@ export function PaymentUnderReviewCard({
       />
 
       <View className="gap-5 p-6">
-        <View className="flex-row items-center justify-between">
+        <View className="flex-row items-center">
           <View className="flex-row items-center gap-2 rounded-full bg-emerald-400/15 px-3 py-1.5">
             <Icon as={CheckIcon} size={14} color="#6EE7B7" strokeWidth={2.5} />
             <Text className="text-xs font-bold text-emerald-200">
               Confirmação recebida
             </Text>
-          </View>
-          <View className="size-10 items-center justify-center rounded-full border border-white/10 bg-white/10">
-            <Icon as={Clock3Icon} size={20} color="#FAFAFA" />
           </View>
         </View>
 

--- a/expo/components/organizations/payment-under-review-card.tsx
+++ b/expo/components/organizations/payment-under-review-card.tsx
@@ -2,8 +2,9 @@ import SlacCabeMaisImage from '~/assets/images/slac-cabe-mais.png';
 import { Image } from 'expo-image';
 import { CheckIcon, ChevronRightIcon, Clock3Icon } from 'lucide-react-native';
 import React from 'react';
-import { Pressable, View } from 'react-native';
+import { View } from 'react-native';
 
+import { Button } from '~/components/ui/button';
 import { Icon } from '~/components/ui/icon';
 import { Text } from '~/components/ui/text';
 
@@ -34,45 +35,46 @@ export function PaymentUnderReviewCard({
       />
 
       <View className="gap-5 p-6">
-        <View className="flex-row items-center gap-2 self-start rounded-full bg-emerald-400/10 px-3 py-1.5">
-          <Icon as={CheckIcon} size={14} color="#6EE7B7" strokeWidth={2.5} />
-          <Text className="text-xs font-bold text-emerald-300">
-            Confirmação recebida
-          </Text>
-        </View>
-
-        <View className="max-w-[280px] gap-2">
-          <View className="flex-row items-center gap-3">
-            <View className="size-10 items-center justify-center rounded-full bg-white/10">
-              <Icon as={Clock3Icon} size={20} color="#F4F4F5" />
-            </View>
-            <Text className="flex-1 text-2xl font-black text-white">
-              Pagamento em análise
+        <View className="flex-row items-center justify-between">
+          <View className="flex-row items-center gap-2 rounded-full bg-emerald-400/15 px-3 py-1.5">
+            <Icon as={CheckIcon} size={14} color="#6EE7B7" strokeWidth={2.5} />
+            <Text className="text-xs font-bold text-emerald-200">
+              Confirmação recebida
             </Text>
           </View>
-          <Text className="text-[15px] font-medium leading-6 text-zinc-400">
+          <View className="size-10 items-center justify-center rounded-full border border-white/10 bg-white/10">
+            <Icon as={Clock3Icon} size={20} color="#FAFAFA" />
+          </View>
+        </View>
+
+        <View className="gap-2">
+          <Text className="text-2xl font-black text-white">
+            Pagamento em análise
+          </Text>
+          <Text className="text-[15px] font-medium leading-6 text-zinc-300">
             Seu aviso de pagamento foi registrado. Agora, a equipe da SL.A.C
             está conferindo o PIX.
           </Text>
-          <Text className="text-sm leading-5 text-zinc-500">
+          <Text className="text-sm leading-5 text-zinc-400">
             Você verá sua associação aqui assim que a confirmação for concluída.
           </Text>
         </View>
-      </View>
 
-      <Pressable
-        accessibilityRole="button"
-        onPress={onPress}
-        className="flex-row items-center justify-between border-t border-white/10 px-6 py-4 active:bg-white/5"
-      >
-        <View className="flex-row items-center gap-3">
-          <Text className="font-bold text-white">Ver pagamento</Text>
-          <View className="rounded-full bg-white/10 px-2 py-0.5">
-            <Text className="text-[11px] font-semibold text-zinc-400">PIX</Text>
+        <Button
+          size="lg"
+          accessibilityLabel="Ver detalhes do pagamento PIX"
+          className="h-12 w-full justify-between rounded-lg bg-white px-4 active:scale-[0.98] active:bg-zinc-100"
+          onPress={onPress}
+        >
+          <View className="flex-row items-center gap-2">
+            <Text className="font-bold text-zinc-950">Ver pagamento</Text>
+            <View className="rounded-full bg-zinc-200 px-2 py-0.5">
+              <Text className="text-[11px] font-bold text-zinc-600">PIX</Text>
+            </View>
           </View>
-        </View>
-        <Icon as={ChevronRightIcon} size={18} color="#A1A1AA" />
-      </Pressable>
+          <Icon as={ChevronRightIcon} size={18} color="#18181B" />
+        </Button>
+      </View>
     </View>
   );
 }

--- a/expo/components/organizations/payment-under-review-card.tsx
+++ b/expo/components/organizations/payment-under-review-card.tsx
@@ -1,0 +1,78 @@
+import SlacCabeMaisImage from '~/assets/images/slac-cabe-mais.png';
+import { Image } from 'expo-image';
+import { CheckIcon, ChevronRightIcon, Clock3Icon } from 'lucide-react-native';
+import React from 'react';
+import { Pressable, View } from 'react-native';
+
+import { Icon } from '~/components/ui/icon';
+import { Text } from '~/components/ui/text';
+
+type PaymentUnderReviewCardProps = {
+  onPress: () => void;
+};
+
+export function PaymentUnderReviewCard({
+  onPress,
+}: PaymentUnderReviewCardProps) {
+  return (
+    <View
+      className="relative overflow-hidden rounded-xl bg-zinc-900"
+      style={{ borderCurve: 'continuous' }}
+    >
+      <Image
+        source={SlacCabeMaisImage}
+        contentFit="contain"
+        style={{
+          height: 190,
+          opacity: 0.1,
+          position: 'absolute',
+          right: -48,
+          top: -32,
+          transform: [{ rotate: '18deg' }],
+          width: 190,
+        }}
+      />
+
+      <View className="gap-5 p-6">
+        <View className="flex-row items-center gap-2 self-start rounded-full bg-emerald-400/10 px-3 py-1.5">
+          <Icon as={CheckIcon} size={14} color="#6EE7B7" strokeWidth={2.5} />
+          <Text className="text-xs font-bold text-emerald-300">
+            Confirmação recebida
+          </Text>
+        </View>
+
+        <View className="max-w-[280px] gap-2">
+          <View className="flex-row items-center gap-3">
+            <View className="size-10 items-center justify-center rounded-full bg-white/10">
+              <Icon as={Clock3Icon} size={20} color="#F4F4F5" />
+            </View>
+            <Text className="flex-1 text-2xl font-black text-white">
+              Pagamento em análise
+            </Text>
+          </View>
+          <Text className="text-[15px] font-medium leading-6 text-zinc-400">
+            Seu aviso de pagamento foi registrado. Agora, a equipe da SL.A.C
+            está conferindo o PIX.
+          </Text>
+          <Text className="text-sm leading-5 text-zinc-500">
+            Você verá sua associação aqui assim que a confirmação for concluída.
+          </Text>
+        </View>
+      </View>
+
+      <Pressable
+        accessibilityRole="button"
+        onPress={onPress}
+        className="flex-row items-center justify-between border-t border-white/10 px-6 py-4 active:bg-white/5"
+      >
+        <View className="flex-row items-center gap-3">
+          <Text className="font-bold text-white">Ver pagamento</Text>
+          <View className="rounded-full bg-white/10 px-2 py-0.5">
+            <Text className="text-[11px] font-semibold text-zinc-400">PIX</Text>
+          </View>
+        </View>
+        <Icon as={ChevronRightIcon} size={18} color="#A1A1AA" />
+      </Pressable>
+    </View>
+  );
+}

--- a/expo/lib/membership-display-state.test.ts
+++ b/expo/lib/membership-display-state.test.ts
@@ -1,0 +1,46 @@
+import { getMembershipDisplayState } from './membership-display-state';
+
+const baseState = {
+  hasPaymentUnderReview: false,
+  isMember: false,
+  isMemberLoading: false,
+  isSignedIn: true,
+  paymentReviewError: false,
+  paymentReviewLoading: false,
+};
+
+describe('getMembershipDisplayState', () => {
+  it('gives an active membership precedence over stale payment query state', () => {
+    expect(
+      getMembershipDisplayState({
+        ...baseState,
+        isMember: true,
+        paymentReviewError: true,
+        paymentReviewLoading: true,
+      }),
+    ).toBe('active-member');
+  });
+
+  it.each([
+    [{ isMemberLoading: true }, 'loading'],
+    [{ paymentReviewLoading: true }, 'loading'],
+    [{ paymentReviewError: true }, 'payment-review-error'],
+    [{ hasPaymentUnderReview: true }, 'payment-under-review'],
+    [{}, 'become-member'],
+  ] as const)('selects the expected non-member state', (input, expected) => {
+    expect(getMembershipDisplayState({ ...baseState, ...input })).toBe(
+      expected,
+    );
+  });
+
+  it('shows the become-member state to signed-out users', () => {
+    expect(
+      getMembershipDisplayState({
+        ...baseState,
+        isMemberLoading: true,
+        isSignedIn: false,
+        paymentReviewError: true,
+      }),
+    ).toBe('become-member');
+  });
+});

--- a/expo/lib/membership-display-state.ts
+++ b/expo/lib/membership-display-state.ts
@@ -1,0 +1,30 @@
+export type MembershipDisplayState =
+  | 'active-member'
+  | 'become-member'
+  | 'loading'
+  | 'payment-review-error'
+  | 'payment-under-review';
+
+export function getMembershipDisplayState({
+  hasPaymentUnderReview,
+  isMember,
+  isMemberLoading,
+  isSignedIn,
+  paymentReviewError,
+  paymentReviewLoading,
+}: {
+  hasPaymentUnderReview: boolean;
+  isMember: boolean | undefined;
+  isMemberLoading: boolean;
+  isSignedIn: boolean;
+  paymentReviewError: boolean;
+  paymentReviewLoading: boolean;
+}): MembershipDisplayState {
+  if (!isSignedIn) return 'become-member';
+  if (isMemberLoading) return 'loading';
+  if (isMember) return 'active-member';
+  if (paymentReviewLoading) return 'loading';
+  if (paymentReviewError) return 'payment-review-error';
+  if (hasPaymentUnderReview) return 'payment-under-review';
+  return 'become-member';
+}

--- a/expo/lib/payment-review.test.ts
+++ b/expo/lib/payment-review.test.ts
@@ -1,0 +1,83 @@
+import { supabase } from '~/lib/supabase';
+
+import { fetchPaymentUnderReview } from './payment-review';
+
+jest.mock('~/lib/supabase', () => {
+  const chain = {
+    eq: jest.fn(),
+    limit: jest.fn(),
+    maybeSingle: jest.fn(),
+    not: jest.fn(),
+    order: jest.fn(),
+    select: jest.fn(),
+  };
+
+  for (const method of ['eq', 'limit', 'not', 'order', 'select'] as const) {
+    chain[method].mockReturnValue(chain);
+  }
+
+  return { supabase: { from: jest.fn(() => chain) } };
+});
+
+const mockFrom = jest.mocked(supabase.from);
+const mockChain = mockFrom('payments') as unknown as {
+  eq: jest.Mock;
+  limit: jest.Mock;
+  maybeSingle: jest.Mock;
+  not: jest.Mock;
+  order: jest.Mock;
+  select: jest.Mock;
+};
+
+describe('fetchPaymentUnderReview', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    for (const method of ['eq', 'limit', 'not', 'order', 'select'] as const) {
+      mockChain[method].mockReturnValue(mockChain);
+    }
+  });
+
+  it('returns the latest pending payment explicitly marked paid by the user', async () => {
+    mockChain.maybeSingle.mockResolvedValue({
+      data: {
+        amount: 36000,
+        id: 'payment-1',
+        user_marked_paid_at: '2026-07-10T12:00:00Z',
+      },
+      error: null,
+    });
+
+    await expect(fetchPaymentUnderReview('slac', 'user-1')).resolves.toEqual({
+      amount: 36000,
+      id: 'payment-1',
+      userMarkedPaidAt: '2026-07-10T12:00:00Z',
+    });
+
+    expect(mockFrom).toHaveBeenCalledWith('payments');
+    expect(mockChain.eq).toHaveBeenCalledWith('user_id', 'user-1');
+    expect(mockChain.eq).toHaveBeenCalledWith('status', 'pending');
+    expect(mockChain.eq).toHaveBeenCalledWith('organizations.slug', 'slac');
+    expect(mockChain.not).toHaveBeenCalledWith(
+      'user_marked_paid_at',
+      'is',
+      null,
+    );
+  });
+
+  it('returns null when no payment is under review', async () => {
+    mockChain.maybeSingle.mockResolvedValue({ data: null, error: null });
+
+    await expect(fetchPaymentUnderReview('slac', 'user-1')).resolves.toBeNull();
+  });
+
+  it('surfaces query errors', async () => {
+    mockChain.maybeSingle.mockResolvedValue({
+      data: null,
+      error: { message: 'query failed' },
+    });
+
+    await expect(fetchPaymentUnderReview('slac', 'user-1')).rejects.toThrow(
+      'query failed',
+    );
+  });
+});

--- a/expo/lib/payment-review.ts
+++ b/expo/lib/payment-review.ts
@@ -1,0 +1,32 @@
+import { supabase } from '~/lib/supabase';
+
+export type PaymentUnderReview = {
+  amount: number;
+  id: string;
+  userMarkedPaidAt: string;
+};
+
+export async function fetchPaymentUnderReview(
+  organizationSlug: string,
+  userId: string,
+): Promise<PaymentUnderReview | null> {
+  const { data, error } = await supabase
+    .from('payments')
+    .select('id, amount, user_marked_paid_at, organizations!inner(slug)')
+    .eq('user_id', userId)
+    .eq('status', 'pending')
+    .eq('organizations.slug', organizationSlug)
+    .not('user_marked_paid_at', 'is', null)
+    .order('user_marked_paid_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  if (!data?.user_marked_paid_at) return null;
+
+  return {
+    amount: data.amount,
+    id: data.id,
+    userMarkedPaidAt: data.user_marked_paid_at,
+  };
+}

--- a/expo/lib/query-keys.ts
+++ b/expo/lib/query-keys.ts
@@ -7,6 +7,11 @@ export const queryKeys = {
     byOrgUser: (organizationId: string, userId: string | undefined) =>
       [...queryKeys.subscription.all, organizationId, userId] as const,
   },
+  paymentReview: {
+    all: ['payment-review'] as const,
+    byOrgUser: (slug: string, userId: string | undefined) =>
+      [...queryKeys.paymentReview.all, slug, userId] as const,
+  },
   membershipApplication: {
     all: ['membership-application'] as const,
     byOrgUser: (


### PR DESCRIPTION
## Summary

- replace the misleading membership CTA after a user reports a manual PIX payment
- add a persisted payment-under-review query and deterministic membership display states
- redesign the pending-review card to match the existing SL.A.C membership and payment surfaces
- refresh the state after payment acknowledgement, settlement, and pull-to-refresh

## Design

The previous amber panel looked like a warning even though the user's action succeeded. The new card uses the app's charcoal membership language, a restrained emerald confirmation signal, the existing SL.A.C mark, and a quieter details row.

## Verification

- `pnpm --dir expo exec jest --runInBand --watchman=false payment-review membership-display-state`
- `pnpm --dir expo exec tsc --noEmit`
- ESLint on all touched Expo files
- `git diff --check`

Closes #199
