### PR TITLE
Improve subscription renewal billing and reminders

### DIFF
--- a/expo/components/organizations/Subscription.tsx
+++ b/expo/components/organizations/Subscription.tsx
@@ -7,6 +7,7 @@ import {
 import { useQuery } from '@tanstack/react-query';
 import {
   AlertCircle,
+  BellRing,
   CalendarCheck,
   CheckCircle,
   Clock,
@@ -38,6 +39,12 @@ import { Tables } from '~/utils/database.types';
 
 import { Button } from '~/components/ui/button';
 import { Text } from '~/components/ui/text';
+
+import {
+  findPendingRenewalPayment,
+  formatBillingAmount,
+  formatBillingDate,
+} from './subscription-billing';
 
 const fetchSubscriptionData = async (
   organizationId: string,
@@ -239,10 +246,14 @@ const MembershipStatusBadge = ({
 
 const PendingPaymentAlert = ({
   amount,
+  dueDate,
+  isRenewal,
   onPayPress,
   isPaying,
 }: {
   amount: number;
+  dueDate: string | null;
+  isRenewal: boolean;
   onPayPress: () => void;
   isPaying: boolean;
 }) => (
@@ -256,9 +267,15 @@ const PendingPaymentAlert = ({
       <View className="flex flex-row gap-4">
         <Clock className="text-amber-600 mt-0.5" size={24} />
         <View className="flex-1 gap-1">
-          <Text className="text-amber-800 font-bold">Pagamento Pendente</Text>
+          <Text className="text-amber-800 font-bold">
+            {isRenewal ? 'Próxima cobrança disponível' : 'Pagamento pendente'}
+          </Text>
           <Text className="text-amber-700">
-            Conclua seu pagamento para ativar sua assinatura!
+            {isRenewal
+              ? dueDate
+                ? `${formatBillingAmount(amount)} vence em ${dueDate}. Pague agora para renovar sem interrupções.`
+                : `${formatBillingAmount(amount)} já pode ser pago. Pague agora para renovar sem interrupções.`
+              : 'Conclua o pagamento para ativar sua assinatura.'}
           </Text>
         </View>
       </View>
@@ -272,7 +289,7 @@ const PendingPaymentAlert = ({
           <ActivityIndicator color="white" size="small" />
         ) : (
           <Text className="text-white font-bold text-center leading-5">
-            PAGAR AGORA • R$ {(amount / 100).toFixed(2)}
+            PAGAR AGORA • {formatBillingAmount(amount)}
           </Text>
         )}
       </Button>
@@ -375,12 +392,7 @@ export const Subscription = ({
   const lastSuccessfulPayment = payments?.find(
     (inv) => inv.status === 'succeeded',
   );
-  const pendingPayment = payments?.find(
-    (inv) =>
-      inv.status === 'pending' &&
-      (!lastSuccessfulPayment ||
-        new Date(inv.created_at) > new Date(lastSuccessfulPayment.created_at)),
-  );
+  const pendingPayment = findPendingRenewalPayment(payments ?? []);
   const daysUntilDue = subscription.current_period_end
     ? getDaysUntilDue(subscription.current_period_end)
     : null;
@@ -391,7 +403,7 @@ export const Subscription = ({
     daysUntilDue < 0;
 
   const isActive = subscription.status === 'active' && !isOverdue;
-  const shouldShowPendingPayment = Boolean(pendingPayment && !isActive);
+  const shouldShowPendingPayment = Boolean(pendingPayment);
 
   // Calculate pricing info
   const monthlyPrice = organization.monthly_price_amount
@@ -400,6 +412,13 @@ export const Subscription = ({
   const annualPrice = organization.annual_price_amount
     ? (organization.annual_price_amount / 100).toFixed(2)
     : null;
+  const configuredBillAmount =
+    subscription.plan_type === 'annual'
+      ? organization.annual_price_amount
+      : organization.monthly_price_amount;
+  const nextBillAmount = pendingPayment?.amount ?? configuredBillAmount;
+  const nextBillDate = formatBillingDate(subscription.current_period_end);
+  const hasStartedMembership = Boolean(lastSuccessfulPayment) || isActive;
 
   return (
     <>
@@ -422,6 +441,8 @@ export const Subscription = ({
           {shouldShowPendingPayment && pendingPayment && (
             <PendingPaymentAlert
               amount={pendingPayment.amount}
+              dueDate={nextBillDate}
+              isRenewal={hasStartedMembership}
               onPayPress={() =>
                 startPaymentMutation.mutate({
                   amount: pendingPayment.amount,
@@ -431,6 +452,39 @@ export const Subscription = ({
               isPaying={startPaymentMutation.isPending}
             />
           )}
+
+          {hasStartedMembership &&
+            !pendingPayment &&
+            nextBillAmount !== null && (
+              <View className="bg-blue-50 border border-blue-100 rounded-xl p-4 gap-3">
+                <View className="flex-row items-start gap-3">
+                  <View className="w-10 h-10 rounded-xl bg-blue-100 items-center justify-center">
+                    <CalendarCheck className="text-blue-700" size={20} />
+                  </View>
+                  <View className="flex-1 gap-1">
+                    <Text className="text-xs text-blue-700 font-bold uppercase tracking-wide">
+                      Próxima cobrança
+                    </Text>
+                    <Text className="text-2xl font-black text-gray-900">
+                      {formatBillingAmount(nextBillAmount)}
+                    </Text>
+                    <Text className="text-sm text-gray-700 font-semibold">
+                      {nextBillDate
+                        ? `Vencimento em ${nextBillDate}`
+                        : 'Data de vencimento a confirmar'}
+                    </Text>
+                  </View>
+                </View>
+
+                <View className="flex-row items-center gap-2 pt-3 border-t border-blue-100">
+                  <BellRing className="text-blue-700" size={16} />
+                  <Text className="text-xs text-blue-800 font-semibold flex-1">
+                    Você receberá um lembrete assim que o pagamento estiver
+                    disponível.
+                  </Text>
+                </View>
+              </View>
+            )}
 
           <View className="flex-row items-center">
             <View className="w-10 h-10 rounded-xl bg-purple-50 items-center justify-center mr-3">
@@ -550,7 +604,7 @@ export const Subscription = ({
                         </View>
                         <View className="flex-1">
                           <Text className="text-xl font-bold text-gray-900">
-                            R$ {(item.amount / 100).toFixed(2)}
+                            {formatBillingAmount(item.amount)}
                           </Text>
                           <Text className="text-xs text-gray-500 font-semibold mt-0.5">
                             {new Date(item.created_at).toLocaleDateString(

--- a/expo/components/organizations/subscription-billing.test.ts
+++ b/expo/components/organizations/subscription-billing.test.ts
@@ -1,0 +1,63 @@
+import {
+  findPendingRenewalPayment,
+  formatBillingAmount,
+  formatBillingDate,
+} from './subscription-billing';
+
+describe('subscription billing presentation', () => {
+  it('finds a renewal payment created after the latest successful payment', () => {
+    const payments = [
+      {
+        id: 'latest-renewal',
+        amount: 4500,
+        status: 'pending',
+        created_at: '2026-08-20T12:00:00.000Z',
+      },
+      {
+        id: 'last-paid-period',
+        amount: 4500,
+        status: 'succeeded',
+        created_at: '2026-07-20T12:00:00.000Z',
+      },
+      {
+        id: 'stale-pending',
+        amount: 4500,
+        status: 'pending',
+        created_at: '2026-06-20T12:00:00.000Z',
+      },
+    ];
+
+    expect(findPendingRenewalPayment(payments)?.id).toBe('latest-renewal');
+  });
+
+  it('returns the newest pending payment when there is no successful payment', () => {
+    const payments = [
+      {
+        id: 'older',
+        amount: 4500,
+        status: 'pending',
+        created_at: '2026-08-19T12:00:00.000Z',
+      },
+      {
+        id: 'newer',
+        amount: 4500,
+        status: 'pending',
+        created_at: '2026-08-20T12:00:00.000Z',
+      },
+    ];
+
+    expect(findPendingRenewalPayment(payments)?.id).toBe('newer');
+  });
+
+  it('formats the bill amount in Brazilian reais', () => {
+    expect(formatBillingAmount(4590)).toBe('R$\u00a045,90');
+  });
+
+  it('formats a valid billing date and safely handles missing dates', () => {
+    expect(formatBillingDate('2026-08-25T12:00:00.000Z')).toBe(
+      '25 de agosto de 2026',
+    );
+    expect(formatBillingDate(null)).toBeNull();
+    expect(formatBillingDate('not-a-date')).toBeNull();
+  });
+});

--- a/expo/components/organizations/subscription-billing.ts
+++ b/expo/components/organizations/subscription-billing.ts
@@ -1,0 +1,51 @@
+type BillingPayment = {
+  amount: number;
+  created_at: string;
+  id: string;
+  status: string;
+};
+
+export const findPendingRenewalPayment = <T extends BillingPayment>(
+  payments: T[],
+): T | undefined => {
+  const latestSuccessfulPaymentTime = payments
+    .filter((payment) => payment.status === 'succeeded')
+    .reduce(
+      (latest, payment) =>
+        Math.max(latest, new Date(payment.created_at).getTime()),
+      Number.NEGATIVE_INFINITY,
+    );
+
+  return payments
+    .filter(
+      (payment) =>
+        payment.status === 'pending' &&
+        new Date(payment.created_at).getTime() > latestSuccessfulPaymentTime,
+    )
+    .sort(
+      (left, right) =>
+        new Date(right.created_at).getTime() -
+        new Date(left.created_at).getTime(),
+    )[0];
+};
+
+export const formatBillingAmount = (amountInCents: number) =>
+  new Intl.NumberFormat('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amountInCents / 100);
+
+export const formatBillingDate = (date: string | null) => {
+  if (!date) return null;
+
+  const parsedDate = new Date(date);
+  if (Number.isNaN(parsedDate.getTime())) return null;
+
+  return new Intl.DateTimeFormat('pt-BR', {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+  }).format(parsedDate);
+};

--- a/expo/context/notifications.tsx
+++ b/expo/context/notifications.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from '@tanstack/react-query';
 import Constants from 'expo-constants';
 import * as Device from 'expo-device';
 import * as Notifications from 'expo-notifications';
@@ -5,7 +6,7 @@ import { Href, router } from 'expo-router';
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { Platform } from 'react-native';
 
-import { supabase } from '~/lib/supabase';
+import { registerPushTokenForProfile } from '~/lib/push-token-registration';
 
 import { useAuth } from './auth';
 import { useI18n } from './i18n';
@@ -93,7 +94,8 @@ async function registerForPushNotificationsAsync() {
         })
       ).data;
     } catch (e) {
-      token = `${e}`;
+      console.error('Failed to get an Expo push token:', e);
+      return;
     }
   } else {
     console.warn('Must use physical device for Push Notifications');
@@ -148,41 +150,25 @@ export function NotificationProvider({
     };
   }, []);
 
-  useEffect(() => {
-    async function manageToken() {
-      if (!expoPushToken) return;
+  useQuery({
+    queryKey: ['push-token-registration', expoPushToken, profile?.id, locale],
+    queryFn: async () => {
       try {
-        const { data } = await supabase
-          .from('push_tokens')
-          .select('*')
-          .eq('token', expoPushToken)
-          .single();
-
-        if (data) {
-          await supabase
-            .from('push_tokens')
-            .update({
-              token: expoPushToken,
-              profile_id: data.profile_id || profile?.id || null,
-              language: locale,
-              created_at: new Date().toISOString(),
-            })
-            .eq('id', data.id);
-          return;
-        }
-
-        await supabase.from('push_tokens').insert({
-          token: expoPushToken,
-          profile_id: profile?.id || null,
-          language: locale,
+        return await registerPushTokenForProfile({
+          expoPushToken,
+          locale,
+          profileId: profile?.id,
         });
       } catch (error) {
         console.error('Error managing push token:', error);
+        throw error;
       }
-    }
-
-    manageToken();
-  }, [expoPushToken, profile, locale]);
+    },
+    enabled: Boolean(expoPushToken && profile?.id),
+    refetchOnMount: 'always',
+    retry: 1,
+    staleTime: 0,
+  });
 
   const contextValue = {
     expoPushToken,

--- a/expo/lib/push-token-registration.test.ts
+++ b/expo/lib/push-token-registration.test.ts
@@ -1,0 +1,123 @@
+import { supabase } from '~/lib/supabase';
+
+import { registerPushTokenForProfile } from './push-token-registration';
+
+jest.mock('~/lib/supabase', () => {
+  const chain = {
+    eq: jest.fn(),
+    insert: jest.fn(),
+    maybeSingle: jest.fn(),
+    select: jest.fn(),
+    update: jest.fn(),
+  };
+
+  for (const method of ['eq', 'select', 'update'] as const) {
+    chain[method].mockReturnValue(chain);
+  }
+
+  return { supabase: { from: jest.fn(() => chain) } };
+});
+
+const mockFrom = jest.mocked(supabase.from);
+const mockChain = mockFrom('push_tokens') as unknown as {
+  eq: jest.Mock;
+  insert: jest.Mock;
+  maybeSingle: jest.Mock;
+  select: jest.Mock;
+  update: jest.Mock;
+};
+
+describe('registerPushTokenForProfile', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    for (const method of ['eq', 'select', 'update'] as const) {
+      mockChain[method].mockReturnValue(mockChain);
+    }
+  });
+
+  it('does not insert an unowned token while the profile is unavailable', async () => {
+    await expect(
+      registerPushTokenForProfile({
+        expoPushToken: 'ExponentPushToken[test]',
+        locale: 'pt',
+        profileId: undefined,
+      }),
+    ).resolves.toBe('skipped');
+
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it('inserts a new token with its signed-in owner', async () => {
+    mockChain.maybeSingle.mockResolvedValue({ data: null, error: null });
+    mockChain.insert.mockResolvedValue({ error: null });
+
+    await expect(
+      registerPushTokenForProfile({
+        expoPushToken: 'ExponentPushToken[test]',
+        locale: 'pt',
+        profileId: 'profile-1',
+      }),
+    ).resolves.toBe('inserted');
+
+    expect(mockChain.insert).toHaveBeenCalledWith({
+      language: 'pt',
+      profile_id: 'profile-1',
+      token: 'ExponentPushToken[test]',
+    });
+  });
+
+  it('updates only a token already owned by the signed-in profile', async () => {
+    mockChain.maybeSingle.mockResolvedValue({
+      data: { id: 12, profile_id: 'profile-1' },
+      error: null,
+    });
+
+    await expect(
+      registerPushTokenForProfile({
+        expoPushToken: 'ExponentPushToken[test]',
+        locale: 'en',
+        profileId: 'profile-1',
+      }),
+    ).resolves.toBe('updated');
+
+    expect(mockChain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ language: 'en' }),
+    );
+    expect(mockChain.eq).toHaveBeenLastCalledWith('id', 12);
+  });
+
+  it('does not reassign a token owned by another profile', async () => {
+    mockChain.maybeSingle.mockResolvedValue({
+      data: { id: 12, profile_id: 'profile-2' },
+      error: null,
+    });
+
+    await expect(
+      registerPushTokenForProfile({
+        expoPushToken: 'ExponentPushToken[test]',
+        locale: 'pt',
+        profileId: 'profile-1',
+      }),
+    ).rejects.toThrow(
+      'This push token is already associated with a different profile.',
+    );
+
+    expect(mockChain.update).not.toHaveBeenCalled();
+    expect(mockChain.insert).not.toHaveBeenCalled();
+  });
+
+  it('surfaces database failures', async () => {
+    mockChain.maybeSingle.mockResolvedValue({
+      data: null,
+      error: { message: 'lookup failed' },
+    });
+
+    await expect(
+      registerPushTokenForProfile({
+        expoPushToken: 'ExponentPushToken[test]',
+        locale: 'pt',
+        profileId: 'profile-1',
+      }),
+    ).rejects.toThrow('Could not look up the push token: lookup failed');
+  });
+});

--- a/expo/lib/push-token-registration.ts
+++ b/expo/lib/push-token-registration.ts
@@ -1,0 +1,72 @@
+import type { Locales } from '@packages/database/index';
+
+import { supabase } from '~/lib/supabase';
+
+type PushTokenRegistration = {
+  expoPushToken: string;
+  locale: Locales;
+  profileId: string | undefined;
+};
+
+export type PushTokenRegistrationResult = 'inserted' | 'skipped' | 'updated';
+
+/**
+ * Associates a device token only after the signed-in profile is available.
+ * Existing tokens are never reassigned client-side because the current RLS
+ * policy intentionally permits updates only by the owning profile.
+ */
+export async function registerPushTokenForProfile({
+  expoPushToken,
+  locale,
+  profileId,
+}: PushTokenRegistration): Promise<PushTokenRegistrationResult> {
+  if (!expoPushToken || !profileId) return 'skipped';
+
+  const { data: existingToken, error: selectError } = await supabase
+    .from('push_tokens')
+    .select('id, profile_id')
+    .eq('token', expoPushToken)
+    .maybeSingle();
+
+  if (selectError) {
+    throw new Error(`Could not look up the push token: ${selectError.message}`);
+  }
+
+  if (existingToken) {
+    if (existingToken.profile_id !== profileId) {
+      throw new Error(
+        'This push token is already associated with a different profile.',
+      );
+    }
+
+    const { error: updateError } = await supabase
+      .from('push_tokens')
+      .update({
+        language: locale,
+        created_at: new Date().toISOString(),
+      })
+      .eq('id', existingToken.id);
+
+    if (updateError) {
+      throw new Error(
+        `Could not update the push token: ${updateError.message}`,
+      );
+    }
+
+    return 'updated';
+  }
+
+  const { error: insertError } = await supabase.from('push_tokens').insert({
+    token: expoPushToken,
+    profile_id: profileId,
+    language: locale,
+  });
+
+  if (insertError) {
+    throw new Error(
+      `Could not register the push token: ${insertError.message}`,
+    );
+  }
+
+  return 'inserted';
+}

--- a/supabase/functions/generate-renewal-payments/README.md
+++ b/supabase/functions/generate-renewal-payments/README.md
@@ -1,13 +1,33 @@
 # Generate Renewal Payments Function
 
-This Edge Function is responsible for generating renewal payments for active subscriptions.
+This Edge Function is responsible for generating renewal payments for active
+subscriptions.
 
 ## Logic
 
-1.  It queries for `active` subscriptions where the `current_period_end` is within the next 7 days.
-2.  For each subscription, it checks if a `pending` renewal payment already exists.
-3.  If no pending payment exists, it fetches the correct price from the `organizations` table based on the subscription's `plan_type` (monthly or annual).
-4.  It then creates a new `payments` record with a `status` of `pending`.
+1. It queries for `active` subscriptions where the `current_period_end` is
+   within the next 7 days.
+2. For each subscription, it checks if a `pending` renewal payment already
+   exists.
+3. If no pending payment exists, it fetches the correct price from the
+   `organizations` table based on the subscription's `plan_type` (monthly or
+   annual).
+4. It then creates a new `payments` record with a `status` of `pending`.
+5. On that same run, it inserts a targeted, localized `notifications` row
+   containing the payment, subscription, and organization identifiers plus a
+   deep link to the payment screen.
+
+When a pending payment already has its renewal notification, both inserts are
+skipped so the daily job does not send repeat reminders. If payment creation
+succeeded but notification insertion failed, a later run detects the missing
+notification by payment ID and retries only that notification.
+
+## Push delivery
+
+The app's existing notification pipeline expects an `INSERT` Database Webhook on
+`public.notifications` to call the `push-notification` Edge Function. Ensure
+that webhook is configured in each deployed Supabase project; the webhook
+configuration is currently managed outside this repository.
 
 ## Deployment
 
@@ -21,7 +41,8 @@ supabase functions deploy generate-renewal-payments --project-ref <your-project-
 
 This function is designed to be run on a schedule (e.g., daily) using `pg_cron`.
 
-After deploying the function, create a new SQL migration in your `supabase/migrations` folder to set up the cron job.
+After deploying the function, create a new SQL migration in your
+`supabase/migrations` folder to set up the cron job.
 
 The migration should contain the following SQL:
 

--- a/supabase/functions/generate-renewal-payments/deno.json
+++ b/supabase/functions/generate-renewal-payments/deno.json
@@ -1,5 +1,6 @@
 {
   "imports": {
+    "@std/assert": "jsr:@std/assert@1.0.19",
     "@supabase": "jsr:@supabase/supabase-js@2.49.8"
   }
 }

--- a/supabase/functions/generate-renewal-payments/deno.lock
+++ b/supabase/functions/generate-renewal-payments/deno.lock
@@ -1,0 +1,117 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@std/assert@1.0.19": "1.0.19",
+    "jsr:@std/internal@^1.0.12": "1.0.14",
+    "jsr:@supabase/supabase-js@2.49.8": "2.49.8",
+    "npm:@supabase/auth-js@2.69.1": "2.69.1",
+    "npm:@supabase/functions-js@2.4.4": "2.4.4",
+    "npm:@supabase/node-fetch@2.6.15": "2.6.15",
+    "npm:@supabase/postgrest-js@1.19.4": "1.19.4",
+    "npm:@supabase/realtime-js@2.11.2": "2.11.2",
+    "npm:@supabase/storage-js@2.7.1": "2.7.1"
+  },
+  "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
+    },
+    "@supabase/supabase-js@2.49.8": {
+      "integrity": "fe1057c623e3297d627d8d795f8c8e7195b2973da8cec813f99e1484b6943b99",
+      "dependencies": [
+        "npm:@supabase/auth-js",
+        "npm:@supabase/functions-js",
+        "npm:@supabase/node-fetch",
+        "npm:@supabase/postgrest-js",
+        "npm:@supabase/realtime-js",
+        "npm:@supabase/storage-js"
+      ]
+    }
+  },
+  "npm": {
+    "@supabase/auth-js@2.69.1": {
+      "integrity": "sha512-FILtt5WjCNzmReeRLq5wRs3iShwmnWgBvxHfqapC/VoljJl+W8hDAyFmf1NVw3zH+ZjZ05AKxiKxVeb0HNWRMQ==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@supabase/functions-js@2.4.4": {
+      "integrity": "sha512-WL2p6r4AXNGwop7iwvul2BvOtuJ1YQy8EbOd0dhG1oN1q8el/BIRSFCFnWAMM/vJJlHWLi4ad22sKbKr9mvjoA==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@supabase/node-fetch@2.6.15": {
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "dependencies": [
+        "whatwg-url"
+      ]
+    },
+    "@supabase/postgrest-js@1.19.4": {
+      "integrity": "sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@supabase/realtime-js@2.11.2": {
+      "integrity": "sha512-u/XeuL2Y0QEhXSoIPZZwR6wMXgB+RQbJzG9VErA3VghVt7uRfSVsjeqd7m5GhX3JR6dM/WRmLbVR8URpDWG4+w==",
+      "dependencies": [
+        "@supabase/node-fetch",
+        "@types/phoenix",
+        "@types/ws",
+        "ws"
+      ]
+    },
+    "@supabase/storage-js@2.7.1": {
+      "integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@types/node@26.1.2": {
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "dependencies": [
+        "undici-types"
+      ]
+    },
+    "@types/phoenix@1.6.7": {
+      "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q=="
+    },
+    "@types/ws@8.18.1": {
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dependencies": [
+        "@types/node"
+      ]
+    },
+    "tr46@0.0.3": {
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "undici-types@8.3.0": {
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="
+    },
+    "webidl-conversions@3.0.1": {
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url@5.0.0": {
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": [
+        "tr46",
+        "webidl-conversions"
+      ]
+    },
+    "ws@8.21.3": {
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@std/assert@1.0.19",
+      "jsr:@supabase/supabase-js@2.49.8"
+    ]
+  }
+}

--- a/supabase/functions/generate-renewal-payments/index.ts
+++ b/supabase/functions/generate-renewal-payments/index.ts
@@ -1,6 +1,10 @@
 import { supabaseAdmin } from "../_shared/supabase-admin.ts";
-import type { Tables } from "../_shared/database.types.ts";
 import { corsHeaders } from "../_shared/cors.ts";
+import {
+  processSubscription,
+  type RenewalNotification,
+  type RenewalOrganization,
+} from "./renewal-payment.ts";
 
 // ---- UTILS -------------------------------------------------
 
@@ -30,10 +34,10 @@ async function fetchSubscriptionsDueForRenewal(renewalDate: Date) {
   return data ?? [];
 }
 
-async function hasPendingPayment(subscriptionId: string): Promise<boolean> {
+async function findPendingPayment(subscriptionId: string) {
   const { data, error } = await supabaseAdmin
     .from("payments")
-    .select("id")
+    .select("id, amount")
     .eq("subscription_id", subscriptionId)
     .eq("status", "pending")
     .limit(1)
@@ -42,20 +46,37 @@ async function hasPendingPayment(subscriptionId: string): Promise<boolean> {
   if (error) {
     throw new Error(`Failed checking pending payment: ${error.message}`);
   }
+  return data;
+}
+
+async function hasRenewalNotification(paymentId: string): Promise<boolean> {
+  const { data, error } = await supabaseAdmin
+    .from("notifications")
+    .select("id")
+    .contains("data", {
+      payment_id: paymentId,
+      type: "subscription_renewal_payment_ready",
+    })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed checking renewal notification: ${error.message}`);
+  }
   return !!data;
 }
 
 async function fetchOrganization(orgId: string) {
   const { data, error } = await supabaseAdmin
     .from("organizations")
-    .select("name, monthly_price_amount, annual_price_amount")
+    .select("name, slug, monthly_price_amount, annual_price_amount")
     .eq("id", orgId)
     .single();
 
   if (error) {
     throw new Error(`Failed to fetch organization ${orgId}: ${error.message}`);
   }
-  return data;
+  return data satisfies RenewalOrganization;
 }
 
 async function createPendingPayment({
@@ -85,74 +106,23 @@ async function createPendingPayment({
   return data;
 }
 
-async function createNotification({
-  user_id,
-  organizationName,
-  amount,
-}: {
-  user_id: string;
-  organizationName: string;
-  amount: number;
-}) {
-  const title = {
-    pt: `Fique em dia com sua assinatura ${organizationName}`,
-  };
-  const body = {
-    pt: `O pagamento de R$${(amount / 100).toFixed(2)} para o próximo período já está disponível. O vencimento é em 7 dias.`,
-  };
-
+async function createNotification(notification: RenewalNotification) {
   const { error } = await supabaseAdmin
     .from("notifications")
-    .insert({ title, body, user_id });
+    .insert(notification);
 
   if (error) throw new Error(`Failed to create notification: ${error.message}`);
 }
 
 // ---- CORE LOGIC --------------------------------------------
 
-async function processSubscription(
-  sub: Tables<"subscriptions">,
-): Promise<void> {
-  try {
-    if (await hasPendingPayment(sub.id)) {
-      console.log(`Subscription ${sub.id} already has a pending payment.`);
-      return;
-    }
-
-    const org = await fetchOrganization(sub.organization_id);
-    const amount = sub.plan_type === "annual"
-      ? org.annual_price_amount
-      : org.monthly_price_amount;
-
-    if (amount == null) {
-      console.error(
-        `Missing price for plan ${sub.plan_type} on subscription ${sub.id}`,
-      );
-      return;
-    }
-
-    const newPayment = await createPendingPayment({
-      organization_id: sub.organization_id,
-      user_id: sub.user_id,
-      subscription_id: sub.id,
-      amount,
-    });
-
-    console.log(
-      `Created pending payment ${newPayment.id} for subscription ${sub.id}.`,
-    );
-
-    await createNotification({
-      user_id: sub.user_id,
-      organizationName: org.name,
-      amount,
-    });
-
-    console.log(`Notification created for user ${sub.user_id}.`);
-  } catch (err) {
-    console.error(`Error processing subscription ${sub.id}:`, err);
-  }
-}
+const renewalPaymentDependencies = {
+  createNotification,
+  createPendingPayment,
+  fetchOrganization,
+  findPendingPayment,
+  hasRenewalNotification,
+};
 
 // ---- ENTRYPOINT --------------------------------------------
 
@@ -175,7 +145,11 @@ Deno.serve(async (req) => {
     }
 
     console.log(`Processing ${subscriptions.length} subscriptions...`);
-    await Promise.all(subscriptions.map(processSubscription));
+    await Promise.all(
+      subscriptions.map((subscription) =>
+        processSubscription(subscription, renewalPaymentDependencies)
+      ),
+    );
 
     console.log("Renewal check complete.");
     return jsonResponse({ message: "Renewal check complete." });

--- a/supabase/functions/generate-renewal-payments/renewal-payment.test.ts
+++ b/supabase/functions/generate-renewal-payments/renewal-payment.test.ts
@@ -1,0 +1,268 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import type { Tables } from "../_shared/database.types.ts";
+import {
+  buildRenewalNotification,
+  processSubscription,
+  type RenewalNotification,
+  type RenewalOrganization,
+  type RenewalPaymentDependencies,
+} from "./renewal-payment.ts";
+
+const subscription: Tables<"subscriptions"> = {
+  current_period_end: "2026-09-01T00:00:00.000Z",
+  id: "subscription-1",
+  organization_id: "organization-1",
+  plan_type: "monthly",
+  status: "active",
+  user_id: "user-1",
+};
+
+const organization: RenewalOrganization = {
+  annual_price_amount: 12000,
+  monthly_price_amount: 1290,
+  name: "Choose Life Club",
+  slug: "choose-life",
+};
+
+const quietLogger = {
+  error() {},
+  log() {},
+};
+
+Deno.test("builds a localized, actionable renewal notification", () => {
+  const notification = buildRenewalNotification({
+    amount: 1290,
+    organization,
+    paymentId: "payment-1",
+    subscription,
+  });
+
+  assertEquals(notification.user_id, "user-1");
+  assertEquals(notification.title, {
+    en: "Your next membership charge is ready",
+    pt: "Sua próxima cobrança está disponível",
+  });
+  assertStringIncludes(notification.body.pt, "R$\u00a012,90");
+  assertStringIncludes(notification.body.pt, "01/09/2026");
+  assertStringIncludes(notification.body.en, "R$12.90");
+  assertStringIncludes(notification.body.en, "09/01/2026");
+  assertEquals(notification.data, {
+    amount: "1290",
+    organization_id: "organization-1",
+    organization_slug: "choose-life",
+    payment_context: "subscription_renewal",
+    payment_id: "payment-1",
+    subscription_id: "subscription-1",
+    type: "subscription_renewal_payment_ready",
+    url:
+      "/payment?amount=1290&paymentContext=subscription_renewal&paymentId=payment-1&slug=choose-life",
+  });
+});
+
+Deno.test("uses the annual organization price for annual renewals", async () => {
+  const annualSubscription: Tables<"subscriptions"> = {
+    ...subscription,
+    plan_type: "annual",
+  };
+  let insertedAmount: number | null = null;
+  const insertedNotifications: RenewalNotification[] = [];
+  const dependencies: RenewalPaymentDependencies = {
+    findPendingPayment() {
+      return Promise.resolve(null);
+    },
+    hasRenewalNotification() {
+      return Promise.resolve(false);
+    },
+    fetchOrganization() {
+      return Promise.resolve(organization);
+    },
+    createPendingPayment(input) {
+      insertedAmount = input.amount;
+      return Promise.resolve({ id: "annual-payment" });
+    },
+    createNotification(notification) {
+      insertedNotifications.push(notification);
+      return Promise.resolve();
+    },
+  };
+
+  const result = await processSubscription(
+    annualSubscription,
+    dependencies,
+    quietLogger,
+  );
+
+  assertEquals(result, { paymentId: "annual-payment", status: "created" });
+  assertEquals(insertedAmount, 12000);
+  assertEquals(insertedNotifications.length, 1);
+  const insertedNotification = insertedNotifications[0];
+  assertEquals(insertedNotification.data.amount, "12000");
+  assertStringIncludes(insertedNotification.body.pt, "R$\u00a0120,00");
+});
+
+Deno.test("does not create a payment or notification when one is already pending", async () => {
+  const calls: string[] = [];
+  const dependencies: RenewalPaymentDependencies = {
+    findPendingPayment(subscriptionId) {
+      calls.push(`pending:${subscriptionId}`);
+      return Promise.resolve({ amount: 1290, id: "payment-1" });
+    },
+    hasRenewalNotification(paymentId) {
+      calls.push(`notification-check:${paymentId}`);
+      return Promise.resolve(true);
+    },
+    fetchOrganization() {
+      calls.push("organization");
+      return Promise.resolve(organization);
+    },
+    createPendingPayment() {
+      calls.push("payment");
+      return Promise.resolve({ id: "payment-1" });
+    },
+    createNotification() {
+      calls.push("notification");
+      return Promise.resolve();
+    },
+  };
+
+  const result = await processSubscription(
+    subscription,
+    dependencies,
+    quietLogger,
+  );
+
+  assertEquals(result, { status: "skipped_pending" });
+  assertEquals(calls, [
+    "pending:subscription-1",
+    "notification-check:payment-1",
+  ]);
+});
+
+Deno.test("retries only the notification when a pending payment was not notified", async () => {
+  const calls: string[] = [];
+  const dependencies: RenewalPaymentDependencies = {
+    findPendingPayment() {
+      calls.push("pending-check");
+      return Promise.resolve({ amount: 1290, id: "payment-1" });
+    },
+    hasRenewalNotification() {
+      calls.push("notification-check");
+      return Promise.resolve(false);
+    },
+    fetchOrganization() {
+      calls.push("organization");
+      return Promise.resolve(organization);
+    },
+    createPendingPayment() {
+      calls.push("payment");
+      return Promise.resolve({ id: "unexpected-payment" });
+    },
+    createNotification(notification) {
+      calls.push(`notification:${notification.data.payment_id}`);
+      return Promise.resolve();
+    },
+  };
+
+  const result = await processSubscription(
+    subscription,
+    dependencies,
+    quietLogger,
+  );
+
+  assertEquals(result, {
+    paymentId: "payment-1",
+    status: "notified_existing",
+  });
+  assertEquals(calls, [
+    "pending-check",
+    "notification-check",
+    "organization",
+    "notification:payment-1",
+  ]);
+});
+
+Deno.test("notifies the target user immediately after creating the renewal payment", async () => {
+  const calls: string[] = [];
+  const insertedNotifications: RenewalNotification[] = [];
+  const dependencies: RenewalPaymentDependencies = {
+    findPendingPayment() {
+      calls.push("pending-check");
+      return Promise.resolve(null);
+    },
+    hasRenewalNotification() {
+      return Promise.resolve(false);
+    },
+    fetchOrganization() {
+      calls.push("organization");
+      return Promise.resolve(organization);
+    },
+    createPendingPayment(input) {
+      calls.push("payment");
+      assertEquals(input, {
+        amount: 1290,
+        organization_id: "organization-1",
+        subscription_id: "subscription-1",
+        user_id: "user-1",
+      });
+      return Promise.resolve({ id: "payment-1" });
+    },
+    createNotification(notification) {
+      calls.push("notification");
+      insertedNotifications.push(notification);
+      return Promise.resolve();
+    },
+  };
+
+  const result = await processSubscription(
+    subscription,
+    dependencies,
+    quietLogger,
+  );
+
+  assertEquals(result, { paymentId: "payment-1", status: "created" });
+  assertEquals(calls, [
+    "pending-check",
+    "organization",
+    "payment",
+    "notification",
+  ]);
+  assertEquals(insertedNotifications.length, 1);
+  const insertedNotification = insertedNotifications[0];
+  assertEquals(insertedNotification.data.payment_id, "payment-1");
+  assertEquals(insertedNotification.data.subscription_id, "subscription-1");
+  assertEquals(insertedNotification.data.organization_id, "organization-1");
+});
+
+Deno.test("does not create a payment or notification when the plan has no price", async () => {
+  const calls: string[] = [];
+  const dependencies: RenewalPaymentDependencies = {
+    findPendingPayment() {
+      calls.push("pending-check");
+      return Promise.resolve(null);
+    },
+    hasRenewalNotification() {
+      return Promise.resolve(false);
+    },
+    fetchOrganization() {
+      calls.push("organization");
+      return Promise.resolve({ ...organization, monthly_price_amount: null });
+    },
+    createPendingPayment() {
+      calls.push("payment");
+      return Promise.resolve({ id: "payment-1" });
+    },
+    createNotification() {
+      calls.push("notification");
+      return Promise.resolve();
+    },
+  };
+
+  const result = await processSubscription(
+    subscription,
+    dependencies,
+    quietLogger,
+  );
+
+  assertEquals(result, { status: "skipped_missing_price" });
+  assertEquals(calls, ["pending-check", "organization"]);
+});

--- a/supabase/functions/generate-renewal-payments/renewal-payment.ts
+++ b/supabase/functions/generate-renewal-payments/renewal-payment.ts
@@ -1,0 +1,219 @@
+import type { Tables } from "../_shared/database.types.ts";
+
+type Subscription = Tables<"subscriptions">;
+
+export interface RenewalOrganization {
+  name: string;
+  slug: string;
+  monthly_price_amount: number | null;
+  annual_price_amount: number | null;
+}
+
+export interface RenewalNotification {
+  user_id: string;
+  title: { en: string; pt: string };
+  body: { en: string; pt: string };
+  data: {
+    amount: string;
+    organization_id: string;
+    organization_slug: string;
+    payment_context: "subscription_renewal";
+    payment_id: string;
+    subscription_id: string;
+    type: "subscription_renewal_payment_ready";
+    url: string;
+  };
+}
+
+export interface RenewalPaymentDependencies {
+  findPendingPayment(
+    subscriptionId: string,
+  ): Promise<{ amount: number; id: string } | null>;
+  hasRenewalNotification(paymentId: string): Promise<boolean>;
+  fetchOrganization(organizationId: string): Promise<RenewalOrganization>;
+  createPendingPayment(input: {
+    amount: number;
+    organization_id: string;
+    subscription_id: string;
+    user_id: string;
+  }): Promise<{ id: string }>;
+  createNotification(notification: RenewalNotification): Promise<void>;
+}
+
+interface RenewalLogger {
+  error(...data: unknown[]): void;
+  log(...data: unknown[]): void;
+}
+
+export type RenewalProcessingResult =
+  | { status: "created"; paymentId: string }
+  | { status: "failed"; error: unknown }
+  | { status: "notified_existing"; paymentId: string }
+  | { status: "skipped_pending" }
+  | { status: "skipped_missing_price" };
+
+function formatAmount(amount: number, locale: "en" | "pt"): string {
+  return new Intl.NumberFormat(locale === "pt" ? "pt-BR" : "en-US", {
+    currency: "BRL",
+    style: "currency",
+  }).format(amount / 100);
+}
+
+function formatDueDate(
+  currentPeriodEnd: string | null,
+  locale: "en" | "pt",
+): string | null {
+  if (!currentPeriodEnd) return null;
+
+  const dueDate = new Date(currentPeriodEnd);
+  if (Number.isNaN(dueDate.getTime())) return null;
+
+  return new Intl.DateTimeFormat(locale === "pt" ? "pt-BR" : "en-US", {
+    day: "2-digit",
+    month: "2-digit",
+    timeZone: "UTC",
+    year: "numeric",
+  }).format(dueDate);
+}
+
+export function buildRenewalPaymentUrl({
+  amount,
+  organizationSlug,
+  paymentId,
+}: {
+  amount: number;
+  organizationSlug: string;
+  paymentId: string;
+}): string {
+  const params = new URLSearchParams({
+    amount: String(amount),
+    paymentContext: "subscription_renewal",
+    paymentId,
+    slug: organizationSlug,
+  });
+
+  return `/payment?${params.toString()}`;
+}
+
+export function buildRenewalNotification({
+  amount,
+  organization,
+  paymentId,
+  subscription,
+}: {
+  amount: number;
+  organization: RenewalOrganization;
+  paymentId: string;
+  subscription: Subscription;
+}): RenewalNotification {
+  const amountPt = formatAmount(amount, "pt");
+  const amountEn = formatAmount(amount, "en");
+  const dueDatePt = formatDueDate(subscription.current_period_end, "pt");
+  const dueDateEn = formatDueDate(subscription.current_period_end, "en");
+
+  const bodyPt = dueDatePt
+    ? `A cobrança de ${amountPt} da sua assinatura ${organization.name} está disponível. Pague até ${dueDatePt}.`
+    : `A cobrança de ${amountPt} da sua assinatura ${organization.name} está disponível para pagamento.`;
+  const bodyEn = dueDateEn
+    ? `Your ${amountEn} renewal for ${organization.name} is ready. Pay by ${dueDateEn}.`
+    : `Your ${amountEn} renewal for ${organization.name} is ready to pay.`;
+
+  return {
+    user_id: subscription.user_id,
+    title: {
+      en: "Your next membership charge is ready",
+      pt: "Sua próxima cobrança está disponível",
+    },
+    body: { en: bodyEn, pt: bodyPt },
+    data: {
+      amount: String(amount),
+      organization_id: subscription.organization_id,
+      organization_slug: organization.slug,
+      payment_context: "subscription_renewal",
+      payment_id: paymentId,
+      subscription_id: subscription.id,
+      type: "subscription_renewal_payment_ready",
+      url: buildRenewalPaymentUrl({
+        amount,
+        organizationSlug: organization.slug,
+        paymentId,
+      }),
+    },
+  };
+}
+
+export async function processSubscription(
+  subscription: Subscription,
+  dependencies: RenewalPaymentDependencies,
+  logger: RenewalLogger = console,
+): Promise<RenewalProcessingResult> {
+  try {
+    const pendingPayment = await dependencies.findPendingPayment(
+      subscription.id,
+    );
+
+    if (pendingPayment) {
+      if (await dependencies.hasRenewalNotification(pendingPayment.id)) {
+        logger.log(
+          `Subscription ${subscription.id} already has a notified pending payment.`,
+        );
+        return { status: "skipped_pending" };
+      }
+    }
+
+    const organization = await dependencies.fetchOrganization(
+      subscription.organization_id,
+    );
+
+    if (pendingPayment) {
+      await dependencies.createNotification(
+        buildRenewalNotification({
+          amount: pendingPayment.amount,
+          organization,
+          paymentId: pendingPayment.id,
+          subscription,
+        }),
+      );
+      logger.log(
+        `Recovered missing notification for pending payment ${pendingPayment.id}.`,
+      );
+      return { status: "notified_existing", paymentId: pendingPayment.id };
+    }
+    const amount = subscription.plan_type === "annual"
+      ? organization.annual_price_amount
+      : organization.monthly_price_amount;
+
+    if (amount == null) {
+      logger.error(
+        `Missing price for plan ${subscription.plan_type} on subscription ${subscription.id}`,
+      );
+      return { status: "skipped_missing_price" };
+    }
+
+    const payment = await dependencies.createPendingPayment({
+      amount,
+      organization_id: subscription.organization_id,
+      subscription_id: subscription.id,
+      user_id: subscription.user_id,
+    });
+
+    logger.log(
+      `Created pending payment ${payment.id} for subscription ${subscription.id}.`,
+    );
+
+    await dependencies.createNotification(
+      buildRenewalNotification({
+        amount,
+        organization,
+        paymentId: payment.id,
+        subscription,
+      }),
+    );
+
+    logger.log(`Notification created for user ${subscription.user_id}.`);
+    return { status: "created", paymentId: payment.id };
+  } catch (error) {
+    logger.error(`Error processing subscription ${subscription.id}:`, error);
+    return { status: "failed", error };
+  }
+}

--- a/supabase/migrations/20260821000000_remove_orphaned_push_tokens.sql
+++ b/supabase/migrations/20260821000000_remove_orphaned_push_tokens.sql
@@ -1,0 +1,5 @@
+-- Tokens without a profile owner cannot receive user-targeted notifications.
+-- The updated app waits for a signed-in profile and will recreate these device
+-- tokens with the correct owner the next time it registers for notifications.
+delete from public.push_tokens
+where profile_id is null;

--- a/supabase/migrations/20260821000000_remove_orphaned_push_tokens.sql
+++ b/supabase/migrations/20260821000000_remove_orphaned_push_tokens.sql
@@ -1,5 +1,0 @@
--- Tokens without a profile owner cannot receive user-targeted notifications.
--- The updated app waits for a signed-in profile and will recreate these device
--- tokens with the correct owner the next time it registers for notifications.
-delete from public.push_tokens
-where profile_id is null;


### PR DESCRIPTION
## Summary

- show the next subscription charge amount and due date before renewal
- keep renewal payments visible and payable while the current membership period is active
- enqueue localized, actionable push notifications when renewal payments become available
- deep-link notification taps directly to the payment screen
- retry missing notifications without creating duplicate renewal payments
- register push tokens only after they have an authenticated profile owner
- remove legacy ownerless push-token rows so upgraded clients can register them correctly

## Testing

- 9 focused Expo/Jest tests
- 6 focused Deno tests
- Expo TypeScript check
- targeted Expo ESLint and Prettier checks
- Deno type check, lint, and formatting check
- git diff validation

## Deployment notes

- deploy the updated `generate-renewal-payments` Edge Function
- apply the orphaned push-token cleanup migration
- confirm the existing `notifications` INSERT → `push-notification` Database Webhook is configured in the deployed Supabase project