### PR TITLE
Implement immutable association application submission

### DIFF
--- a/expo/app/organizations/[slug]/onboarding.tsx
+++ b/expo/app/organizations/[slug]/onboarding.tsx
@@ -1,5 +1,4 @@
 import { useOrganization } from '@chooselife/ui';
-import type { StartSubscriptionResponse } from '@packages/database/functions.types';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import * as Haptics from 'expo-haptics';
 import { Redirect, useLocalSearchParams, useRouter } from 'expo-router';
@@ -22,16 +21,15 @@ import Animated, {
 
 import { useAuth } from '~/context/auth';
 import { useMountEffect } from '~/hooks/use-mount-effect';
-import { getManualPaymentRouteParams } from '~/lib/manual-payment';
+import { getPaymentObligationRouteParams } from '~/lib/manual-payment';
 import {
   fetchAddressByCep,
   fetchMembershipApplication,
-  submitMembershipApplication,
+  submitAssociationApplication,
   upsertMembershipApplicationDraft,
   type MembershipApplication,
 } from '~/lib/membership-application';
 import { queryKeys } from '~/lib/query-keys';
-import { supabase } from '~/lib/supabase';
 
 import {
   FocusedHeader,
@@ -71,11 +69,13 @@ const errorHaptic = () =>
 
 export default function OnboardingScreen() {
   const { session, sessionLoading, profile } = useAuth();
-  const { accepted_terms_at, plan_type, slug } = useLocalSearchParams<{
-    accepted_terms_at?: string;
-    plan_type?: PlanType;
-    slug: string;
-  }>();
+  const { accepted_terms_at, plan_type, slug, terms_version } =
+    useLocalSearchParams<{
+      accepted_terms_at?: string;
+      plan_type?: PlanType;
+      slug: string;
+      terms_version?: string;
+    }>();
   const {
     data: organization,
     isLoading,
@@ -109,7 +109,7 @@ export default function OnboardingScreen() {
         href={{
           pathname: '/(modals)/login',
           params: {
-            redirect_to: `/organizations/${slug}/onboarding?plan_type=${plan_type ?? 'monthly'}`,
+            redirect_to: `/organizations/${slug}/onboarding?plan_type=${plan_type ?? 'monthly'}${terms_version ? `&terms_version=${encodeURIComponent(terms_version)}` : ''}`,
           },
         }}
       />
@@ -142,6 +142,7 @@ export default function OnboardingScreen() {
       profileBirthday={profile?.birthday}
       profileName={profile?.name}
       slug={slug}
+      termsVersion={terms_version ?? organization.membership_terms_version}
       userId={session.user.id}
     />
   );
@@ -157,6 +158,7 @@ type OnboardingWizardProps = {
   profileBirthday?: string | null;
   profileName?: string | null;
   slug: string;
+  termsVersion: string;
   userId: string;
 };
 
@@ -170,6 +172,7 @@ function OnboardingWizard({
   profileBirthday,
   profileName,
   slug,
+  termsVersion,
   userId,
 }: OnboardingWizardProps) {
   const router = useRouter();
@@ -208,16 +211,9 @@ function OnboardingWizard({
   const [autofillKey, setAutofillKey] = useState(0);
   const [submitting, setSubmitting] = useState(false);
   const [success, setSuccess] = useState(false);
-  const [createdApplicationId, setCreatedApplicationId] = useState<
-    string | undefined
-  >();
-  const [createdSubmittedId, setCreatedSubmittedId] = useState<
-    string | undefined
-  >();
   const submitLockRef = useRef(false);
   const lastCepLookupRef = useRef<string | null>(null);
 
-  const applicationId = createdApplicationId ?? application?.id;
   const applicationQueryKey = queryKeys.membershipApplication.byOrgUser(
     organizationId,
     userId,
@@ -360,78 +356,16 @@ function OnboardingWizard({
         formToDraft(nextForm, organizationId, userId),
       ),
     onSuccess: (data) => {
-      setCreatedApplicationId(data.id);
       queryClient.setQueryData(applicationQueryKey, data);
     },
     retry: 1,
   });
 
   const submitMutation = useMutation({
-    mutationFn: submitMembershipApplication,
-    onSuccess: (data) => {
-      setCreatedSubmittedId(data?.id ?? applicationId);
-      void queryClient.invalidateQueries({ queryKey: applicationQueryKey });
-    },
-  });
-
-  const startSubscriptionMutation = useMutation({
-    mutationFn: async () => {
-      const { data: charge, error } =
-        await supabase.functions.invoke<StartSubscriptionResponse>(
-          'start-subscription',
-          {
-            body: { plan_type: planType, slug },
-          },
-        );
-
-      if (error) {
-        const errorContext = error.context;
-        if (errorContext && typeof errorContext.json === 'function') {
-          const errorData = await errorContext.json();
-          throw new Error(errorData?.error || error.message);
-        }
-        throw error;
-      }
-
-      if (!charge) {
-        throw new Error('Invalid response from start-subscription function');
-      }
-
-      return {
-        amount: 'amount' in charge ? charge.amount : undefined,
-        paymentId: charge.paymentId,
-      };
-    },
-    onSuccess: (data) => {
-      setSuccess(true);
-      void Haptics.notificationAsync(
-        Haptics.NotificationFeedbackType.Success,
-      ).catch(() => undefined);
-      void queryClient.invalidateQueries({
-        queryKey: queryKeys.subscription.all,
-      });
-      setTimeout(() => {
-        router.replace({
-          pathname: '/payment',
-          params: getManualPaymentRouteParams({
-            amount: data.amount,
-            paymentId: data.paymentId,
-            paymentContext: 'new_member',
-            slug,
-          }),
-        });
-      }, 1600);
-    },
-    // The function reuses an existing pending manual payment, so retrying once
-    // is safe when the first response is lost to a transient network failure.
+    mutationFn: submitAssociationApplication,
     retry: 1,
     retryDelay: 500,
   });
-
-
-  const submittedApplicationId =
-    createdSubmittedId ??
-    (application?.status === 'submitted' ? application.id : undefined);
 
   const getSubmittedApplicationId = () => {
     const cachedApplication =
@@ -439,12 +373,11 @@ function OnboardingWizard({
         applicationQueryKey,
       );
 
-    return (
-      submittedApplicationId ??
-      (cachedApplication?.status === 'submitted'
-        ? cachedApplication.id
-        : undefined)
-    );
+    return cachedApplication?.status === 'submitted'
+      ? cachedApplication.id
+      : application?.status === 'submitted'
+        ? application.id
+        : undefined;
   };
 
   const handleSubmit = async () => {
@@ -478,6 +411,11 @@ function OnboardingWizard({
       errorHaptic();
     };
 
+    let applicationForSubmission =
+      queryClient.getQueryData<MembershipApplication | null>(
+        applicationQueryKey,
+      );
+
     if (!getSubmittedApplicationId()) {
       const saved = await settle(saveMutation.mutateAsync(form));
       if (!saved.ok) {
@@ -488,43 +426,114 @@ function OnboardingWizard({
         return;
       }
 
-      const submitted = await settle(
-        submitMutation.mutateAsync(applicationId ?? saved.value.id),
-      );
-      if (!submitted.ok) {
-        // A lost response can happen after the RPC committed. Re-read the
-        // application before telling the user to retry a completed submit.
-        const reconciled = await settle(
-          fetchMembershipApplication(organizationId, userId),
-        );
-        if (!reconciled.ok || reconciled.value?.status !== 'submitted') {
-          console.error(
-            'Error submitting membership application:',
-            submitted.error,
-          );
-          fail(
-            'Não foi possível concluir seu cadastro. Verifique a conexão e tente novamente.',
-          );
-          return;
-        }
-
-        setCreatedSubmittedId(reconciled.value.id);
-        queryClient.setQueryData(applicationQueryKey, reconciled.value);
-      } else {
-        setCreatedSubmittedId(
-          submitted.value?.id ?? applicationId ?? saved.value.id,
-        );
-      }
+      applicationForSubmission = saved.value;
     }
 
-    const payment = await settle(startSubscriptionMutation.mutateAsync());
-    if (!payment.ok) {
-      console.error('Error starting membership payment:', payment.error);
+    if (!applicationForSubmission) {
+      applicationForSubmission = await queryClient.fetchQuery({
+        queryKey: applicationQueryKey,
+        queryFn: () => fetchMembershipApplication(organizationId, userId),
+      });
+    }
+
+    if (!applicationForSubmission?.draft_version) {
       fail(
-        'Seu cadastro foi concluído, mas não foi possível iniciar o pagamento. Tente novamente.',
+        'Não foi possível identificar a versão atual do cadastro. Atualize e tente novamente.',
       );
       return;
     }
+
+    const submission = await settle(
+      submitMutation.mutateAsync({
+        applicationId: applicationForSubmission.id,
+        draftVersion: applicationForSubmission.draft_version,
+        organizationId,
+        planType,
+        termsVersion,
+      }),
+    );
+    if (!submission.ok || !submission.value) {
+      // A lost response can happen after the command committed. Re-read the
+      // draft and retry with the same optimistic version; the server returns
+      // the original revision and obligation rather than creating another.
+      const reconciled = await settle(
+        fetchMembershipApplication(organizationId, userId),
+      );
+      if (!reconciled.ok || reconciled.value?.status !== 'submitted') {
+        console.error(
+          'Error submitting membership application:',
+          submission.ok ? 'empty response' : submission.error,
+        );
+        fail(
+          'Não foi possível concluir seu cadastro. Verifique a conexão e tente novamente.',
+        );
+        return;
+      }
+
+      const retriedSubmission = await settle(
+        submitMutation.mutateAsync({
+          applicationId: reconciled.value.id,
+          draftVersion: reconciled.value.draft_version,
+          organizationId,
+          planType,
+          termsVersion,
+        }),
+      );
+      if (!retriedSubmission.ok || !retriedSubmission.value) {
+        console.error(
+          'Error reconciling membership application submission:',
+          retriedSubmission.ok ? 'empty response' : retriedSubmission.error,
+        );
+        fail(
+          'Não foi possível concluir seu cadastro. Verifique a conexão e tente novamente.',
+        );
+        return;
+      }
+
+      const authoritativeSubmission = retriedSubmission.value;
+      queryClient.setQueryData(applicationQueryKey, reconciled.value);
+      setSuccess(true);
+      void Haptics.notificationAsync(
+        Haptics.NotificationFeedbackType.Success,
+      ).catch(() => undefined);
+      setTimeout(() => {
+        router.replace({
+          pathname: '/payment',
+          params: getPaymentObligationRouteParams({
+            amount: authoritativeSubmission.amount,
+            currency: authoritativeSubmission.currency,
+            obligationId: authoritativeSubmission.obligation_id,
+            slug,
+          }),
+        });
+      }, 1600);
+      setSubmitting(false);
+      submitLockRef.current = false;
+      return;
+    }
+
+    const authoritativeSubmission = submission.value;
+    setSuccess(true);
+    void Haptics.notificationAsync(
+      Haptics.NotificationFeedbackType.Success,
+    ).catch(() => undefined);
+    void queryClient.invalidateQueries({
+      queryKey: queryKeys.membershipApplication.byOrgUser(
+        organizationId,
+        userId,
+      ),
+    });
+    setTimeout(() => {
+      router.replace({
+        pathname: '/payment',
+        params: getPaymentObligationRouteParams({
+          amount: authoritativeSubmission.amount,
+          currency: authoritativeSubmission.currency,
+          obligationId: authoritativeSubmission.obligation_id,
+          slug,
+        }),
+      });
+    }, 1600);
 
     setSubmitting(false);
     submitLockRef.current = false;
@@ -589,10 +598,7 @@ function OnboardingWizard({
                   Toque em uma resposta para corrigir. Seu cadastro é enviado
                   uma única vez, na confirmação.
                 </Text>
-                <ReviewList
-                  items={getReviewRows(form)}
-                  onEdit={handleEdit}
-                />
+                <ReviewList items={getReviewRows(form)} onEdit={handleEdit} />
               </View>
             ) : question ? (
               <QuestionCard

--- a/expo/app/payment.tsx
+++ b/expo/app/payment.tsx
@@ -35,6 +35,18 @@ type PaymentInstructions = {
   user_marked_paid_at: string | null;
 };
 
+type ObligationInstructions = {
+  amount: number;
+  available_at: string;
+  currency: string;
+  obligation_id: string;
+  payment_method: string;
+  pix_copy_paste: string;
+  plan_type: 'monthly' | 'annual';
+  purpose: 'initial_admission';
+  status: 'available' | 'settled' | 'void';
+};
+
 function PaymentState({
   children,
   onClose,
@@ -87,10 +99,19 @@ const paymentInstructionsQueryKey = (paymentId: string | undefined) =>
 
 export default function PaymentScreen() {
   const router = useRouter();
-  const { amount, paymentId, paymentContext, slug } = useLocalSearchParams<{
+  const {
+    amount,
+    currency: routeCurrency,
+    obligationId,
+    paymentContext,
+    paymentId,
+    slug,
+  } = useLocalSearchParams<{
     amount?: string;
-    paymentId: string;
+    currency?: string;
+    obligationId?: string;
     paymentContext?: 'new_member' | 'subscription_renewal';
+    paymentId?: string;
     slug?: string;
   }>();
   const queryClient = useQueryClient();
@@ -128,16 +149,42 @@ export default function PaymentScreen() {
         }
       );
     },
-    enabled: Boolean(paymentId),
+    enabled: Boolean(paymentId && !obligationId),
+  });
+  const obligationInstructionsQuery = useQuery({
+    queryKey: ['payment-obligation-instructions', obligationId],
+    queryFn: async (): Promise<ObligationInstructions | null> => {
+      if (!obligationId) return null;
+
+      const { data, error } = await supabase.rpc(
+        'get_payment_obligation_instructions',
+        { p_obligation_id: obligationId },
+      );
+
+      if (error) throw error;
+
+      return data?.[0] ?? null;
+    },
+    enabled: Boolean(obligationId),
   });
   const paymentInstructions = paymentInstructionsQuery.data;
-  const amountInCents =
-    paymentInstructions?.amount ??
-    (Number.isFinite(routeAmountInCents) ? routeAmountInCents : null);
-  const formattedAmount = amountInCents
-    ? `R$ ${(amountInCents / 100).toFixed(2)}`
-    : null;
-  const manualPixCopyPaste = paymentInstructions?.pix_copy_paste ?? '';
+  const obligationInstructions = obligationInstructionsQuery.data;
+  const amountInCents = obligationId
+    ? (obligationInstructions?.amount ?? null)
+    : (paymentInstructions?.amount ??
+      (Number.isFinite(routeAmountInCents) ? routeAmountInCents : null));
+  const currency = obligationInstructions?.currency ?? routeCurrency ?? 'BRL';
+  const formattedAmount =
+    amountInCents === null
+      ? null
+      : new Intl.NumberFormat('pt-BR', {
+          currency,
+          minimumFractionDigits: 2,
+          style: 'currency',
+        }).format(amountInCents / 100);
+  const manualPixCopyPaste = obligationId
+    ? (obligationInstructions?.pix_copy_paste ?? '')
+    : (paymentInstructions?.pix_copy_paste ?? '');
   const hasManualPixInstructions = Boolean(manualPixCopyPaste);
 
   const handleClose = () => {
@@ -148,11 +195,13 @@ export default function PaymentScreen() {
     }
   };
 
-  const userMarkedPaidAt = paymentInstructions?.user_marked_paid_at ?? null;
+  const userMarkedPaidAt = obligationId
+    ? null
+    : (paymentInstructions?.user_marked_paid_at ?? null);
 
   const markPaidMutation = useMutation({
     mutationFn: async () => {
-      if (!paymentId) {
+      if (!paymentId || obligationId) {
         throw new Error('paymentId is required.');
       }
 
@@ -200,7 +249,14 @@ export default function PaymentScreen() {
   });
 
   const handleMarkPaid = async () => {
-    if (!paymentId || markPaidMutation.isPending || userMarkedPaidAt) return;
+    if (
+      !paymentId ||
+      obligationId ||
+      markPaidMutation.isPending ||
+      userMarkedPaidAt
+    ) {
+      return;
+    }
 
     markPaidMutation.mutate();
   };
@@ -239,7 +295,10 @@ export default function PaymentScreen() {
     );
   }
 
-  if (paymentInstructionsQuery.isLoading) {
+  if (
+    paymentInstructionsQuery.isLoading ||
+    obligationInstructionsQuery.isLoading
+  ) {
     return (
       <PaymentState onClose={handleClose}>
         <ActivityIndicator color="#FFFFFF" />
@@ -248,7 +307,7 @@ export default function PaymentScreen() {
     );
   }
 
-  if (!paymentId || !hasManualPixInstructions) {
+  if ((!paymentId && !obligationId) || !hasManualPixInstructions) {
     return (
       <PaymentState onClose={handleClose}>
         <Text className="text-white text-3xl font-bold text-center leading-9">
@@ -257,7 +316,8 @@ export default function PaymentScreen() {
         <Text className="text-white/65 text-[15px] text-center leading-6">
           O PIX da associação ainda não foi configurado no aplicativo.
         </Text>
-        {paymentInstructionsQuery.isError ? (
+        {paymentInstructionsQuery.isError ||
+        obligationInstructionsQuery.isError ? (
           <Text className="text-white/50 text-center text-sm">
             Não foi possível carregar os dados do pagamento.
           </Text>
@@ -278,11 +338,13 @@ export default function PaymentScreen() {
       manualPixCopyPaste={manualPixCopyPaste}
       markPaidError={markPaidMutation.isError}
       markingPaid={markPaidMutation.isPending}
+      canReportPayment={Boolean(paymentId && !obligationId)}
       onClose={handleClose}
       onMarkPaid={handleMarkPaid}
       onPaymentFailed={() => setPaymentStatus('FAILED')}
       onPaymentSucceeded={() => setPaymentStatus('SUCCESS')}
       paymentContext={paymentContext}
+      obligationId={obligationId}
       paymentId={paymentId}
       profileId={profile?.id}
       queryClient={queryClient}
@@ -295,6 +357,7 @@ export default function PaymentScreen() {
 }
 
 function ManualPixPayment({
+  canReportPayment,
   formattedAmount,
   insets,
   manualPixCopyPaste,
@@ -304,6 +367,7 @@ function ManualPixPayment({
   onMarkPaid,
   onPaymentFailed,
   onPaymentSucceeded,
+  obligationId,
   paymentContext,
   paymentId,
   profileId,
@@ -313,6 +377,7 @@ function ManualPixPayment({
   title,
   userMarkedPaidAt,
 }: {
+  canReportPayment: boolean;
   formattedAmount: string | null;
   insets: ReturnType<typeof useSafeAreaInsets>;
   manualPixCopyPaste: string;
@@ -322,8 +387,9 @@ function ManualPixPayment({
   onMarkPaid: () => void;
   onPaymentFailed: () => void;
   onPaymentSucceeded: () => void;
+  obligationId?: string;
   paymentContext?: 'new_member' | 'subscription_renewal';
-  paymentId: string;
+  paymentId?: string;
   profileId?: string;
   queryClient: ReturnType<typeof useQueryClient>;
   slug?: string;
@@ -334,7 +400,7 @@ function ManualPixPayment({
   return (
     <BgBlob>
       <PaymentStatusSubscription
-        key={`${paymentId}:${slug ?? ''}:${profileId ?? ''}:${paymentContext ?? ''}`}
+        key={`${paymentId ?? ''}:${obligationId ?? ''}:${slug ?? ''}:${profileId ?? ''}:${paymentContext ?? ''}`}
         paymentContext={paymentContext}
         paymentId={paymentId}
         profileId={profileId}
@@ -399,49 +465,57 @@ function ManualPixPayment({
               : 'Associação'}
           </Text>
           <Text className="text-white/65 text-center text-sm leading-5 mt-1">
-            Depois de pagar, toque em "Já paguei". A equipe confere o PIX e
-            aprova sua assinatura manualmente.
+            {canReportPayment
+              ? 'Depois de pagar, toque em "Já paguei". A equipe confere o PIX e aprova sua assinatura manualmente.'
+              : 'Depois de pagar, a associação confere o PIX e conclui a admissão manualmente.'}
           </Text>
         </Animated.View>
         <Animated.View
           entering={FadeIn.delay(900).duration(300)}
           className="mx-6 gap-3 mt-auto"
         >
-          <Pressable
-            onPress={onMarkPaid}
-            disabled={markingPaid || Boolean(userMarkedPaidAt)}
-            className={`rounded-full py-4 items-center justify-center ${userMarkedPaidAt ? 'bg-emerald-500/20' : 'bg-white'}`}
-            style={({ pressed }) => ({
-              opacity:
-                markingPaid || userMarkedPaidAt
-                  ? undefined
-                  : pressed
-                    ? 0.85
-                    : 1,
-            })}
-          >
-            {markingPaid ? (
-              <ActivityIndicator color="#000" />
-            ) : (
-              <View className="flex-row items-center gap-2">
-                {userMarkedPaidAt ? (
-                  <Icon as={CheckIcon} size={18} color="#34D399" />
-                ) : null}
-                <Text
-                  className={`text-[17px] font-bold ${userMarkedPaidAt ? 'text-emerald-300' : 'text-black'}`}
-                >
-                  {userMarkedPaidAt ? 'Pagamento informado' : 'Já paguei'}
-                </Text>
-              </View>
-            )}
-          </Pressable>
-          {userMarkedPaidAt ? (
+          {canReportPayment ? (
+            <Pressable
+              onPress={onMarkPaid}
+              disabled={markingPaid || Boolean(userMarkedPaidAt)}
+              className={`rounded-full py-4 items-center justify-center ${userMarkedPaidAt ? 'bg-emerald-500/20' : 'bg-white'}`}
+              style={({ pressed }) => ({
+                opacity:
+                  markingPaid || userMarkedPaidAt
+                    ? undefined
+                    : pressed
+                      ? 0.85
+                      : 1,
+              })}
+            >
+              {markingPaid ? (
+                <ActivityIndicator color="#000" />
+              ) : (
+                <View className="flex-row items-center gap-2">
+                  {userMarkedPaidAt ? (
+                    <Icon as={CheckIcon} size={18} color="#34D399" />
+                  ) : null}
+                  <Text
+                    className={`text-[17px] font-bold ${userMarkedPaidAt ? 'text-emerald-300' : 'text-black'}`}
+                  >
+                    {userMarkedPaidAt ? 'Pagamento informado' : 'Já paguei'}
+                  </Text>
+                </View>
+              )}
+            </Pressable>
+          ) : (
+            <Text className="text-white/65 text-center text-sm leading-5">
+              Depois de pagar, a associação receberá sua solicitação para
+              conferir o PIX e concluir a admissão.
+            </Text>
+          )}
+          {canReportPayment && userMarkedPaidAt ? (
             <Text className="text-white/50 text-center text-sm leading-5">
               Recebemos seu aviso. A associação vai conferir o pagamento e
               aprovar manualmente sua assinatura.
             </Text>
           ) : null}
-          {markPaidError ? (
+          {canReportPayment && markPaidError ? (
             <Text className="text-red-200 text-center text-sm leading-5">
               Não foi possível avisar a associação agora. Tente novamente.
             </Text>

--- a/expo/components/organizations/onboarding/form.test.ts
+++ b/expo/components/organizations/onboarding/form.test.ts
@@ -18,7 +18,10 @@ const findStep = (id: string) => {
   return question;
 };
 
-const findField = (stepId: string, fieldId: keyof MembershipApplicationForm) => {
+const findField = (
+  stepId: string,
+  fieldId: keyof MembershipApplicationForm,
+) => {
   const field = findStep(stepId).fields.find((item) => item.id === fieldId);
   if (!field) throw new Error(`Missing field ${fieldId} on step ${stepId}`);
   return field;
@@ -77,15 +80,15 @@ describe('membership onboarding steps', () => {
     const step = findStep('allergies');
     const answeredNo = { ...completeForm(), allergies_choice: 'no' as const };
 
-    expect(getVisibleFields(answeredNo, step).map((field) => field.id)).toEqual([
-      'allergies_choice',
-    ]);
+    expect(getVisibleFields(answeredNo, step).map((field) => field.id)).toEqual(
+      ['allergies_choice'],
+    );
     expect(getQuestionError(answeredNo, step)).toBeNull();
 
     const answeredYes = { ...completeForm(), allergies_choice: 'yes' as const };
-    expect(getVisibleFields(answeredYes, step).map((field) => field.id)).toEqual(
-      ['allergies_choice', 'allergies'],
-    );
+    expect(
+      getVisibleFields(answeredYes, step).map((field) => field.id),
+    ).toEqual(['allergies_choice', 'allergies']);
     expect(getQuestionError(answeredYes, step)).toBe('Descreva as alergias.');
   });
 
@@ -93,9 +96,9 @@ describe('membership onboarding steps', () => {
     const step = findStep('dietary');
     const answeredYes = { ...completeForm(), dietary_choice: 'yes' as const };
 
-    expect(getVisibleFields(answeredYes, step).map((field) => field.id)).toEqual(
-      ['dietary_choice', 'dietary_restrictions'],
-    );
+    expect(
+      getVisibleFields(answeredYes, step).map((field) => field.id),
+    ).toEqual(['dietary_choice', 'dietary_restrictions']);
     expect(getQuestionError(answeredYes, step)).toBe(
       'Descreva a restrição alimentar.',
     );
@@ -124,7 +127,10 @@ describe('membership onboarding steps', () => {
       'emergency_contact_phone',
     ]);
     expect(
-      getQuestionError({ ...completeForm(), emergency_contact_phone: '31' }, step),
+      getQuestionError(
+        { ...completeForm(), emergency_contact_phone: '31' },
+        step,
+      ),
     ).toBe('Informe um telefone com DDD.');
   });
 
@@ -133,9 +139,9 @@ describe('membership onboarding steps', () => {
 
     expect(form.allergies_choice).toBeNull();
     expect(form.dietary_choice).toBeNull();
-    expect(getFieldError(form, findField('allergies', 'allergies_choice'))).toBe(
-      'Escolha uma opção.',
-    );
+    expect(
+      getFieldError(form, findField('allergies', 'allergies_choice')),
+    ).toBe('Escolha uma opção.');
   });
 
   it('treats an explicit no as a valid rescue-course answer', () => {
@@ -144,9 +150,9 @@ describe('membership onboarding steps', () => {
 
     expect(getFieldError(form, field)).toBeNull();
     expect(getAnswerLabel(form, field)).toBe('Não');
-    expect(
-      getFieldError({ ...form, has_rescue_course: null }, field),
-    ).toBe('Escolha uma opção.');
+    expect(getFieldError({ ...form, has_rescue_course: null }, field)).toBe(
+      'Escolha uma opção.',
+    );
   });
 
   it('never blocks the flow on the optional blood type field', () => {
@@ -198,6 +204,8 @@ describe('membership onboarding steps', () => {
     const form = { ...completeForm(), has_rescue_course: false };
 
     expect(formToDraft(form, 'organization-id', 'user-id')).toMatchObject({
+      has_allergies: false,
+      has_dietary_restrictions: false,
       has_rescue_course: false,
       organization_id: 'organization-id',
       user_id: 'user-id',

--- a/expo/components/organizations/onboarding/form.ts
+++ b/expo/components/organizations/onboarding/form.ts
@@ -208,8 +208,7 @@ export const createInitialForm = ({
   profileBirthday?: string | null;
   profileName?: string | null;
 }): MembershipApplicationForm => ({
-  accepted_terms_at:
-    application?.accepted_terms_at ?? acceptedTermsAt ?? null,
+  accepted_terms_at: application?.accepted_terms_at ?? acceptedTermsAt ?? null,
   address_line: application?.address_line ?? '',
   allergies: application?.allergies ?? '',
   // A brand-new form must not pretend the health questions were answered, so
@@ -257,6 +256,7 @@ export const formToDraft = (
 ) => ({
   accepted_terms_at: form.accepted_terms_at,
   address_line: form.address_line.trim() || null,
+  has_allergies: form.allergies_choice === 'yes',
   allergies:
     form.allergies_choice === 'yes' ? form.allergies.trim() || null : null,
   birth_date: displayDateToIso(form.birth_date),
@@ -264,6 +264,7 @@ export const formToDraft = (
   blood_type: form.blood_type,
   city: form.city.trim() || null,
   cpf: digitsOnly(form.cpf) || null,
+  has_dietary_restrictions: form.dietary_choice === 'yes',
   dietary_restrictions:
     form.dietary_choice === 'yes'
       ? form.dietary_restrictions.trim() || null
@@ -369,7 +370,12 @@ const requiredPhone = (value: string) =>
 export const questions: Question[] = [
   {
     fields: [
-      { id: 'full_name', kind: 'text', reviewLabel: 'Nome completo', textContentType: 'name' },
+      {
+        id: 'full_name',
+        kind: 'text',
+        reviewLabel: 'Nome completo',
+        textContentType: 'name',
+      },
     ],
     id: 'full_name',
     prompt: 'Como devemos chamar você?',
@@ -805,4 +811,3 @@ export const getReviewRows = (form: MembershipApplicationForm): ReviewRow[] =>
       value: getAnswerLabel(form, field),
     })),
   );
-

--- a/expo/components/organizations/showcase-carousel/become-member-form.tsx
+++ b/expo/components/organizations/showcase-carousel/become-member-form.tsx
@@ -1,5 +1,4 @@
 import { ENABLE_MEMBERSHIP_REGISTRATION } from '@chooselife/ui';
-import type { StartSubscriptionResponse } from '@packages/database/functions.types';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import * as Haptics from 'expo-haptics';
 import { useRouter } from 'expo-router';
@@ -20,14 +19,14 @@ import Animated, {
 import { scheduleOnRN } from 'react-native-worklets';
 
 import { useAuth } from '~/context/auth';
-import { getManualPaymentRouteParams } from '~/lib/manual-payment';
+import { getPaymentObligationRouteParams } from '~/lib/manual-payment';
 import {
   fetchMembershipApplication,
+  submitAssociationApplication,
   type MembershipApplication,
 } from '~/lib/membership-application';
 import { queryKeys } from '~/lib/query-keys';
 import { getR2PublicUrl } from '~/lib/r2';
-import { supabase } from '~/lib/supabase';
 import { formatCurrency } from '~/utils';
 import { _layoutAnimation } from '~/utils/constants';
 import { Tables } from '~/utils/database.types';
@@ -81,48 +80,43 @@ export function BecomeMemberForm({
 
   const mutation = useMutation({
     mutationFn: async (values: { plan_type: PlanType }) => {
-      const { data: charge, error } =
-        await supabase.functions.invoke<StartSubscriptionResponse>(
-          'start-subscription',
-          {
-            body: {
-              plan_type: values.plan_type,
-              slug: org.slug,
-            },
-          },
-        );
+      const application =
+        queryClient.getQueryData<MembershipApplication | null>(
+          queryKeys.membershipApplication.byOrgUser(org.id, session?.user.id),
+        ) ?? membershipApplication;
 
-      if (error) {
-        const errorContext = error.context;
-        if (errorContext && typeof errorContext.json === 'function') {
-          const errorData = await errorContext.json();
-          throw new Error(errorData?.error || error.message);
-        }
-        throw error;
+      if (!application || application.status !== 'submitted') {
+        throw new Error('A submitted association application is required.');
       }
 
-      if (!charge) {
-        throw new Error('Invalid response from start-subscription function');
-      }
-
-      return {
-        amount: 'amount' in charge ? charge.amount : undefined,
-        paymentId: charge.paymentId,
-      };
+      return submitAssociationApplication({
+        applicationId: application.id,
+        draftVersion: application.draft_version,
+        organizationId: org.id,
+        planType: values.plan_type,
+        termsVersion: org.membership_terms_version,
+      });
     },
     onSuccess: (data) => {
+      if (!data) {
+        setErrorMessage(
+          'Não foi possível abrir a obrigação. Tente novamente mais tarde.',
+        );
+        return;
+      }
+
       router.push({
         pathname: '/payment',
-        params: getManualPaymentRouteParams({
+        params: getPaymentObligationRouteParams({
           amount: data.amount,
-          paymentId: data.paymentId,
-          paymentContext: 'new_member',
+          currency: data.currency,
+          obligationId: data.obligation_id,
           slug: org.slug,
         }),
       });
     },
     onError: (error) => {
-      console.error('Error starting subscription:', error);
+      console.error('Error submitting association application:', error);
       setErrorMessage(
         'Não foi possível iniciar a inscrição. Tente novamente mais tarde.',
       );
@@ -170,6 +164,7 @@ export function BecomeMemberForm({
         accepted_terms_at: new Date().toISOString(),
         plan_type: selectedPlan,
         slug: org.slug,
+        terms_version: org.membership_terms_version,
       },
     });
   };
@@ -284,7 +279,9 @@ export function BecomeMemberForm({
                   period="/ano"
                   selected={selectedPlan === 'annual'}
                   disabled={mutation.isPending}
-                  badge={annualDiscountPercentage ? '2 meses grátis' : undefined}
+                  badge={
+                    annualDiscountPercentage ? '2 meses grátis' : undefined
+                  }
                   onPress={() => handleSelectPlan('annual')}
                 />
               </Animated.View>

--- a/expo/lib/manual-payment.test.ts
+++ b/expo/lib/manual-payment.test.ts
@@ -1,0 +1,20 @@
+import { getPaymentObligationRouteParams } from './manual-payment';
+
+describe('payment obligation navigation', () => {
+  it('passes the authoritative obligation facts to the PIX screen', () => {
+    expect(
+      getPaymentObligationRouteParams({
+        amount: 12500,
+        currency: 'BRL',
+        obligationId: 'obligation-id',
+        slug: 'slac',
+      }),
+    ).toEqual({
+      amount: '12500',
+      currency: 'BRL',
+      obligationId: 'obligation-id',
+      paymentContext: 'new_member',
+      slug: 'slac',
+    });
+  });
+});

--- a/expo/lib/manual-payment.ts
+++ b/expo/lib/manual-payment.ts
@@ -16,3 +16,23 @@ export function getManualPaymentRouteParams({
     slug,
   };
 }
+
+export function getPaymentObligationRouteParams({
+  amount,
+  currency,
+  obligationId,
+  slug,
+}: {
+  amount: number;
+  currency: string;
+  obligationId: string;
+  slug: string;
+}) {
+  return {
+    amount: String(amount),
+    currency,
+    obligationId,
+    paymentContext: 'new_member' as const,
+    slug,
+  };
+}

--- a/expo/lib/membership-application.ts
+++ b/expo/lib/membership-application.ts
@@ -10,6 +10,18 @@ export type MembershipApplicationDraft =
   TablesInsert<'membership_applications'> &
     TablesUpdate<'membership_applications'>;
 
+export type AssociationApplicationSubmission = {
+  amount: number;
+  application_revision_id: string;
+  available_at: string;
+  currency: string;
+  obligation_id: string;
+  obligation_status: 'available' | 'settled' | 'void';
+  organization_id: string;
+  payment_method: 'manual_pix';
+  plan_type: 'monthly' | 'annual';
+};
+
 type ViaCepResponse = {
   bairro?: string;
   erro?: boolean;
@@ -56,14 +68,30 @@ export async function upsertMembershipApplicationDraft(
   return data;
 }
 
-export async function submitMembershipApplication(applicationId: string) {
-  const { data, error } = await supabase.rpc('submit_membership_application', {
+export async function submitAssociationApplication({
+  applicationId,
+  draftVersion,
+  organizationId,
+  planType,
+  termsVersion,
+}: {
+  applicationId: string;
+  draftVersion: number;
+  organizationId: string;
+  planType: 'monthly' | 'annual';
+  termsVersion: string;
+}): Promise<AssociationApplicationSubmission | null> {
+  const { data, error } = await supabase.rpc('submit_association_application', {
     p_application_id: applicationId,
+    p_draft_version: draftVersion,
+    p_organization_id: organizationId,
+    p_plan_type: planType,
+    p_terms_version: termsVersion,
   });
 
   if (error) throw error;
 
-  return data?.[0] ?? null;
+  return (data?.[0] as AssociationApplicationSubmission | undefined) ?? null;
 }
 
 export async function fetchAddressByCep(cep: string) {

--- a/packages/database/database-generated.types.ts
+++ b/packages/database/database-generated.types.ts
@@ -731,6 +731,7 @@ export type Database = {
           city: string | null
           cpf: string | null
           created_at: string
+          draft_version: number
           dietary_restrictions: string | null
           email: string | null
           emergency_contact_name: string | null
@@ -740,6 +741,8 @@ export type Database = {
             | Database["public"]["Enums"]["first_aid_course_enum"]
             | null
           full_name: string | null
+          has_allergies: boolean
+          has_dietary_restrictions: boolean
           has_rescue_course: boolean | null
           highline_experience:
             | Database["public"]["Enums"]["highline_experience_enum"]
@@ -771,6 +774,7 @@ export type Database = {
           city?: string | null
           cpf?: string | null
           created_at?: string
+          draft_version?: number
           dietary_restrictions?: string | null
           email?: string | null
           emergency_contact_name?: string | null
@@ -780,6 +784,8 @@ export type Database = {
             | Database["public"]["Enums"]["first_aid_course_enum"]
             | null
           full_name?: string | null
+          has_allergies?: boolean
+          has_dietary_restrictions?: boolean
           has_rescue_course?: boolean | null
           highline_experience?:
             | Database["public"]["Enums"]["highline_experience_enum"]
@@ -811,6 +817,7 @@ export type Database = {
           city?: string | null
           cpf?: string | null
           created_at?: string
+          draft_version?: number
           dietary_restrictions?: string | null
           email?: string | null
           emergency_contact_name?: string | null
@@ -820,6 +827,8 @@ export type Database = {
             | Database["public"]["Enums"]["first_aid_course_enum"]
             | null
           full_name?: string | null
+          has_allergies?: boolean
+          has_dietary_restrictions?: boolean
           has_rescue_course?: boolean | null
           highline_experience?:
             | Database["public"]["Enums"]["highline_experience_enum"]
@@ -858,38 +867,299 @@ export type Database = {
           },
         ]
       }
+      membership_application_revisions: {
+        Row: {
+          accepted_terms_at: string
+          address_line: string | null
+          allergies: string | null
+          application_id: string
+          birth_date: string | null
+          birthplace: string | null
+          blood_type: Database["public"]["Enums"]["blood_type_enum"] | null
+          city: string | null
+          cpf: string | null
+          created_at: string
+          currency: string
+          dietary_restrictions: string | null
+          draft_version: number
+          email: string | null
+          emergency_contact_name: string | null
+          emergency_contact_phone: string | null
+          emergency_contact_relationship: string | null
+          first_aid_course:
+            | Database["public"]["Enums"]["first_aid_course_enum"]
+            | null
+          full_name: string | null
+          has_allergies: boolean
+          has_dietary_restrictions: boolean
+          has_rescue_course: boolean | null
+          highline_experience:
+            | Database["public"]["Enums"]["highline_experience_enum"]
+            | null
+          id: string
+          id_document_issuer: string | null
+          id_document_number: string | null
+          marital_status:
+            | Database["public"]["Enums"]["marital_status_enum"]
+            | null
+          nationality: string | null
+          organization_id: string
+          phone: string | null
+          pix_copy_paste: string
+          plan_amount: number
+          plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"]
+          postal_code: string | null
+          profession: string | null
+          revision_number: number
+          state: string | null
+          submitted_at: string
+          terms_version: string
+          user_id: string
+        }
+        Insert: {
+          accepted_terms_at: string
+          address_line?: string | null
+          allergies?: string | null
+          application_id: string
+          birth_date?: string | null
+          birthplace?: string | null
+          blood_type?: Database["public"]["Enums"]["blood_type_enum"] | null
+          city?: string | null
+          cpf?: string | null
+          created_at?: string
+          currency: string
+          dietary_restrictions?: string | null
+          draft_version: number
+          email?: string | null
+          emergency_contact_name?: string | null
+          emergency_contact_phone?: string | null
+          emergency_contact_relationship?: string | null
+          first_aid_course?:
+            | Database["public"]["Enums"]["first_aid_course_enum"]
+            | null
+          full_name?: string | null
+          has_allergies: boolean
+          has_dietary_restrictions: boolean
+          has_rescue_course?: boolean | null
+          highline_experience?:
+            | Database["public"]["Enums"]["highline_experience_enum"]
+            | null
+          id?: string
+          id_document_issuer?: string | null
+          id_document_number?: string | null
+          marital_status?:
+            | Database["public"]["Enums"]["marital_status_enum"]
+            | null
+          nationality?: string | null
+          organization_id: string
+          phone?: string | null
+          pix_copy_paste: string
+          plan_amount: number
+          plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"]
+          postal_code?: string | null
+          profession?: string | null
+          revision_number: number
+          state?: string | null
+          submitted_at: string
+          terms_version: string
+          user_id: string
+        }
+        Update: {
+          accepted_terms_at?: string
+          address_line?: string | null
+          allergies?: string | null
+          application_id?: string
+          birth_date?: string | null
+          birthplace?: string | null
+          blood_type?: Database["public"]["Enums"]["blood_type_enum"] | null
+          city?: string | null
+          cpf?: string | null
+          created_at?: string
+          currency?: string
+          dietary_restrictions?: string | null
+          draft_version?: number
+          email?: string | null
+          emergency_contact_name?: string | null
+          emergency_contact_phone?: string | null
+          emergency_contact_relationship?: string | null
+          first_aid_course?:
+            | Database["public"]["Enums"]["first_aid_course_enum"]
+            | null
+          full_name?: string | null
+          has_allergies?: boolean
+          has_dietary_restrictions?: boolean
+          has_rescue_course?: boolean | null
+          highline_experience?:
+            | Database["public"]["Enums"]["highline_experience_enum"]
+            | null
+          id?: string
+          id_document_issuer?: string | null
+          id_document_number?: string | null
+          marital_status?:
+            | Database["public"]["Enums"]["marital_status_enum"]
+            | null
+          nationality?: string | null
+          organization_id?: string
+          phone?: string | null
+          pix_copy_paste?: string
+          plan_amount?: number
+          plan_type?: Database["public"]["Enums"]["subscription_plan_type_enum"]
+          postal_code?: string | null
+          profession?: string | null
+          revision_number?: number
+          state?: string | null
+          submitted_at?: string
+          terms_version?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "membership_application_revisions_application_id_fkey"
+            columns: ["application_id"]
+            isOneToOne: false
+            referencedRelation: "membership_applications"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "membership_application_revisions_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "membership_application_revisions_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       organizations: {
         Row: {
           annual_price_amount: number | null
           annual_pix_copy_paste: string | null
+          billing_currency: string
           created_at: string
           id: string
+          membership_terms_version: string
           monthly_price_amount: number | null
           monthly_pix_copy_paste: string | null
           name: string
+          organization_type: Database["public"]["Enums"]["organization_type_enum"]
           slug: string
         }
         Insert: {
           annual_price_amount?: number | null
           annual_pix_copy_paste?: string | null
+          billing_currency?: string
           created_at?: string
           id?: string
+          membership_terms_version?: string
           monthly_price_amount?: number | null
           monthly_pix_copy_paste?: string | null
           name: string
+          organization_type?: Database["public"]["Enums"]["organization_type_enum"]
           slug: string
         }
         Update: {
           annual_price_amount?: number | null
           annual_pix_copy_paste?: string | null
+          billing_currency?: string
           created_at?: string
           id?: string
+          membership_terms_version?: string
           monthly_price_amount?: number | null
           monthly_pix_copy_paste?: string | null
           name?: string
+          organization_type?: Database["public"]["Enums"]["organization_type_enum"]
           slug?: string
         }
         Relationships: []
+      }
+      payment_obligations: {
+        Row: {
+          amount: number
+          application_revision_id: string
+          available_at: string
+          created_at: string
+          currency: string
+          id: string
+          legacy_payment_id: string | null
+          organization_id: string
+          payment_method: string
+          pix_copy_paste: string
+          plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"]
+          purpose: Database["public"]["Enums"]["payment_obligation_purpose_enum"]
+          settled_at: string | null
+          status: Database["public"]["Enums"]["payment_obligation_status_enum"]
+          user_id: string
+        }
+        Insert: {
+          amount: number
+          application_revision_id: string
+          available_at: string
+          created_at?: string
+          currency: string
+          id?: string
+          legacy_payment_id?: string | null
+          organization_id: string
+          payment_method?: string
+          pix_copy_paste: string
+          plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"]
+          purpose?: Database["public"]["Enums"]["payment_obligation_purpose_enum"]
+          settled_at?: string | null
+          status?: Database["public"]["Enums"]["payment_obligation_status_enum"]
+          user_id: string
+        }
+        Update: {
+          amount?: number
+          application_revision_id?: string
+          available_at?: string
+          created_at?: string
+          currency?: string
+          id?: string
+          legacy_payment_id?: string | null
+          organization_id?: string
+          payment_method?: string
+          pix_copy_paste?: string
+          plan_type?: Database["public"]["Enums"]["subscription_plan_type_enum"]
+          purpose?: Database["public"]["Enums"]["payment_obligation_purpose_enum"]
+          settled_at?: string | null
+          status?: Database["public"]["Enums"]["payment_obligation_status_enum"]
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "payment_obligations_application_revision_id_fkey"
+            columns: ["application_revision_id"]
+            isOneToOne: false
+            referencedRelation: "membership_application_revisions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "payment_obligations_legacy_payment_id_fkey"
+            columns: ["legacy_payment_id"]
+            isOneToOne: true
+            referencedRelation: "payments"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "payment_obligations_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "payment_obligations_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       payments: {
         Row: {
@@ -1381,6 +1651,21 @@ export type Database = {
           user_marked_paid_at: string | null
         }[]
       }
+      get_payment_obligation_instructions: {
+        Args: { p_obligation_id: string }
+        Returns: {
+          amount: number
+          available_at: string
+          currency: string
+          obligation_id: string
+          payment_method: string
+          pix_copy_paste: string
+          plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"]
+          purpose: Database["public"]["Enums"]["payment_obligation_purpose_enum"]
+          status: Database["public"]["Enums"]["payment_obligation_status_enum"]
+          organization_id: string
+        }[]
+      }
       mark_payment_succeeded_manually: {
         Args: { p_paid_at?: string; p_payment_id: string }
         Returns: {
@@ -1408,6 +1693,26 @@ export type Database = {
           status: Database["public"]["Enums"]["membership_application_status_enum"]
           submitted_at: string | null
           user_id: string
+        }[]
+      }
+      submit_association_application: {
+        Args: {
+          p_application_id: string
+          p_draft_version: number
+          p_organization_id: string
+          p_plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"]
+          p_terms_version: string
+        }
+        Returns: {
+          amount: number
+          application_revision_id: string
+          available_at: string
+          currency: string
+          obligation_id: string
+          obligation_status: Database["public"]["Enums"]["payment_obligation_status_enum"]
+          organization_id: string
+          payment_method: string
+          plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"]
         }[]
       }
       get_highline: {
@@ -1562,6 +1867,9 @@ export type Database = {
       material_enum: "nylon" | "dyneema" | "polyester"
       membership_application_status_enum: "draft" | "submitted"
       organization_role_enum: "admin" | "member"
+      organization_type_enum: "group" | "association"
+      payment_obligation_purpose_enum: "initial_admission"
+      payment_obligation_status_enum: "available" | "settled" | "void"
       payment_status_enum: "pending" | "succeeded" | "failed"
       strength_class_enum: "A+" | "A" | "B" | "C"
       subscription_plan_type_enum: "monthly" | "annual"
@@ -2330,6 +2638,9 @@ export const Constants = {
       material_enum: ["nylon", "dyneema", "polyester"],
       membership_application_status_enum: ["draft", "submitted"],
       organization_role_enum: ["admin", "member"],
+      organization_type_enum: ["group", "association"],
+      payment_obligation_purpose_enum: ["initial_admission"],
+      payment_obligation_status_enum: ["available", "settled", "void"],
       payment_status_enum: ["pending", "succeeded", "failed"],
       strength_class_enum: ["A+", "A", "B", "C"],
       subscription_plan_type_enum: ["monthly", "annual"],

--- a/supabase/migrations/20260822021552_immutable_association_application_submission.sql
+++ b/supabase/migrations/20260822021552_immutable_association_application_submission.sql
@@ -1,0 +1,861 @@
+do $$
+begin
+  create type public.organization_type_enum as enum ('group', 'association');
+exception
+  when duplicate_object then null;
+end;
+$$;
+
+do $$
+begin
+  create type public.payment_obligation_purpose_enum as enum (
+    'initial_admission'
+  );
+exception
+  when duplicate_object then null;
+end;
+$$;
+
+do $$
+begin
+  create type public.payment_obligation_status_enum as enum (
+    'available',
+    'settled',
+    'void'
+  );
+exception
+  when duplicate_object then null;
+end;
+$$;
+
+alter table public.organizations
+  add column if not exists organization_type public.organization_type_enum
+    not null default 'association'::public.organization_type_enum,
+  add column if not exists billing_currency text not null default 'BRL',
+  add column if not exists membership_terms_version text not null default 'estatuto-v1';
+
+update public.organizations
+set organization_type = 'association'::public.organization_type_enum
+where organization_type is null;
+
+update public.organizations
+set billing_currency = upper(btrim(billing_currency))
+where billing_currency is not null;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'organizations_billing_currency_format_check'
+  ) then
+    alter table public.organizations
+      add constraint organizations_billing_currency_format_check
+      check (billing_currency ~ '^[A-Z]{3}$');
+  end if;
+
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'organizations_membership_terms_version_check'
+  ) then
+    alter table public.organizations
+      add constraint organizations_membership_terms_version_check
+      check (nullif(btrim(membership_terms_version), '') is not null);
+  end if;
+end;
+$$;
+
+comment on column public.organizations.organization_type is
+  'Immutable organization classification. Formal membership applications are allowed only for associations.';
+comment on column public.organizations.billing_currency is
+  'ISO 4217 currency used for new association obligations.';
+comment on column public.organizations.membership_terms_version is
+  'Exact terms version accepted by new association applicants.';
+
+alter table public.membership_applications
+  add column if not exists draft_version bigint not null default 1,
+  add column if not exists has_allergies boolean not null default false,
+  add column if not exists has_dietary_restrictions boolean not null default false;
+
+update public.membership_applications
+set has_allergies = true
+where nullif(btrim(allergies), '') is not null;
+
+update public.membership_applications
+set has_dietary_restrictions = true
+where nullif(btrim(dietary_restrictions), '') is not null;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'membership_applications_draft_version_check'
+  ) then
+    alter table public.membership_applications
+      add constraint membership_applications_draft_version_check
+      check (draft_version > 0);
+  end if;
+end;
+$$;
+
+create or replace function public.set_membership_applications_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = timezone('utc'::text, clock_timestamp());
+
+  if tg_op = 'UPDATE' then
+    -- Submitting a draft is a state transition, not a new editable draft
+    -- version. This lets a lost response retry the same command safely.
+    if old.status = 'draft'::public.membership_application_status_enum
+      and new.status = 'submitted'::public.membership_application_status_enum then
+      new.draft_version = old.draft_version;
+    else
+      new.draft_version = old.draft_version + 1;
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+create table public.membership_application_revisions (
+  id uuid primary key default gen_random_uuid(),
+  application_id uuid not null references public.membership_applications(id),
+  organization_id uuid not null references public.organizations(id),
+  user_id uuid not null references public.profiles(id),
+  revision_number integer not null,
+  draft_version bigint not null,
+  plan_type public.subscription_plan_type_enum not null,
+  terms_version text not null,
+  accepted_terms_at timestamp with time zone not null,
+  submitted_at timestamp with time zone not null,
+  full_name text,
+  birth_date date,
+  nationality text,
+  marital_status public.marital_status_enum,
+  profession text,
+  birthplace text,
+  cpf text,
+  id_document_number text,
+  id_document_issuer text,
+  postal_code text,
+  address_line text,
+  city text,
+  state text,
+  email text,
+  phone text,
+  blood_type public.blood_type_enum,
+  has_allergies boolean not null,
+  allergies text,
+  has_dietary_restrictions boolean not null,
+  dietary_restrictions text,
+  highline_experience public.highline_experience_enum,
+  has_rescue_course boolean,
+  first_aid_course public.first_aid_course_enum,
+  emergency_contact_name text,
+  emergency_contact_relationship text,
+  emergency_contact_phone text,
+  plan_amount integer not null check (plan_amount > 0),
+  currency text not null check (currency ~ '^[A-Z]{3}$'),
+  pix_copy_paste text not null check (nullif(btrim(pix_copy_paste), '') is not null),
+  created_at timestamp with time zone not null default timezone('utc'::text, now()),
+  unique (application_id, revision_number),
+  unique (application_id, draft_version),
+  check (nullif(btrim(terms_version), '') is not null),
+  check (draft_version > 0)
+);
+
+comment on table public.membership_application_revisions is
+  'Immutable, revisionable snapshots of submitted association applications. Never use live profile data for admission review.';
+comment on column public.membership_application_revisions.plan_amount is
+  'Server-snapshotted price in the smallest currency unit at submission time.';
+comment on column public.membership_application_revisions.pix_copy_paste is
+  'Server-snapshotted static manual-PIX payload for the selected association plan.';
+
+create or replace function public.reject_membership_application_revision_mutation()
+returns trigger
+language plpgsql
+as $$
+begin
+  raise exception 'Submitted application revisions are immutable.'
+    using errcode = '55000';
+end;
+$$;
+
+create trigger membership_application_revisions_immutable
+before update or delete on public.membership_application_revisions
+for each row
+execute function public.reject_membership_application_revision_mutation();
+
+alter table public.membership_application_revisions enable row level security;
+
+create policy "Application owners can read their submitted revisions"
+  on public.membership_application_revisions
+  for select
+  to authenticated
+  using ((select auth.uid()) = user_id);
+
+revoke all on table public.membership_application_revisions from public;
+revoke all on table public.membership_application_revisions from anon;
+revoke all on table public.membership_application_revisions from authenticated;
+grant select on table public.membership_application_revisions to authenticated;
+
+create table public.payment_obligations (
+  id uuid primary key default gen_random_uuid(),
+  organization_id uuid not null references public.organizations(id),
+  user_id uuid not null references public.profiles(id),
+  application_revision_id uuid not null references public.membership_application_revisions(id),
+  purpose public.payment_obligation_purpose_enum not null default 'initial_admission',
+  status public.payment_obligation_status_enum not null default 'available',
+  plan_type public.subscription_plan_type_enum not null,
+  amount integer not null check (amount > 0),
+  currency text not null check (currency ~ '^[A-Z]{3}$'),
+  payment_method text not null default 'manual_pix' check (payment_method = 'manual_pix'),
+  pix_copy_paste text not null check (nullif(btrim(pix_copy_paste), '') is not null),
+  available_at timestamp with time zone not null,
+  settled_at timestamp with time zone,
+  legacy_payment_id uuid unique references public.payments(id) on delete set null,
+  created_at timestamp with time zone not null default timezone('utc'::text, now()),
+  unique (application_revision_id, purpose)
+);
+
+comment on table public.payment_obligations is
+  'Server-authoritative, independently payable billing obligations. Claims and admission decisions are separate workflows.';
+comment on column public.payment_obligations.legacy_payment_id is
+  'Optional migration link to an existing legacy payment; new submissions never create a legacy payment row.';
+
+create index payment_obligations_user_organization_idx
+  on public.payment_obligations (user_id, organization_id, status);
+
+alter table public.payment_obligations enable row level security;
+
+create policy "Obligation owners can read their obligations"
+  on public.payment_obligations
+  for select
+  to authenticated
+  using ((select auth.uid()) = user_id);
+
+revoke all on table public.payment_obligations from public;
+revoke all on table public.payment_obligations from anon;
+revoke all on table public.payment_obligations from authenticated;
+grant select on table public.payment_obligations to authenticated;
+
+-- Preserve submitted legacy applications where the old subscription already
+-- records the selected plan. This creates no membership and no new legacy
+-- payment; existing pending/succeeded manual payments are linked below.
+insert into public.membership_application_revisions (
+  application_id,
+  organization_id,
+  user_id,
+  revision_number,
+  draft_version,
+  plan_type,
+  terms_version,
+  accepted_terms_at,
+  submitted_at,
+  full_name,
+  birth_date,
+  nationality,
+  marital_status,
+  profession,
+  birthplace,
+  cpf,
+  id_document_number,
+  id_document_issuer,
+  postal_code,
+  address_line,
+  city,
+  state,
+  email,
+  phone,
+  blood_type,
+  has_allergies,
+  allergies,
+  has_dietary_restrictions,
+  dietary_restrictions,
+  highline_experience,
+  has_rescue_course,
+  first_aid_course,
+  emergency_contact_name,
+  emergency_contact_relationship,
+  emergency_contact_phone,
+  plan_amount,
+  currency,
+  pix_copy_paste
+)
+select
+  ma.id,
+  ma.organization_id,
+  ma.user_id,
+  1,
+  ma.draft_version,
+  s.plan_type,
+  o.membership_terms_version,
+  coalesce(ma.accepted_terms_at, ma.submitted_at, timezone('utc'::text, now())),
+  coalesce(ma.submitted_at, timezone('utc'::text, now())),
+  ma.full_name,
+  ma.birth_date,
+  ma.nationality,
+  ma.marital_status,
+  ma.profession,
+  ma.birthplace,
+  ma.cpf,
+  ma.id_document_number,
+  ma.id_document_issuer,
+  ma.postal_code,
+  ma.address_line,
+  ma.city,
+  ma.state,
+  ma.email,
+  ma.phone,
+  ma.blood_type,
+  ma.has_allergies,
+  ma.allergies,
+  ma.has_dietary_restrictions,
+  ma.dietary_restrictions,
+  ma.highline_experience,
+  ma.has_rescue_course,
+  ma.first_aid_course,
+  ma.emergency_contact_name,
+  ma.emergency_contact_relationship,
+  ma.emergency_contact_phone,
+  case s.plan_type
+    when 'annual'::public.subscription_plan_type_enum then o.annual_price_amount
+    else o.monthly_price_amount
+  end,
+  o.billing_currency,
+  case s.plan_type
+    when 'annual'::public.subscription_plan_type_enum then o.annual_pix_copy_paste
+    else o.monthly_pix_copy_paste
+  end
+from public.membership_applications ma
+join public.organizations o on o.id = ma.organization_id
+join public.subscriptions s
+  on s.organization_id = ma.organization_id
+  and s.user_id = ma.user_id
+where ma.status = 'submitted'::public.membership_application_status_enum
+  and o.organization_type = 'association'::public.organization_type_enum
+  and case s.plan_type
+    when 'annual'::public.subscription_plan_type_enum then o.annual_price_amount
+    else o.monthly_price_amount
+  end > 0
+  and nullif(btrim(case s.plan_type
+    when 'annual'::public.subscription_plan_type_enum then o.annual_pix_copy_paste
+    else o.monthly_pix_copy_paste
+  end), '') is not null
+on conflict (application_id, draft_version) do nothing;
+
+insert into public.payment_obligations (
+  organization_id,
+  user_id,
+  application_revision_id,
+  purpose,
+  status,
+  plan_type,
+  amount,
+  currency,
+  payment_method,
+  pix_copy_paste,
+  available_at,
+  settled_at,
+  legacy_payment_id
+)
+select
+  mar.organization_id,
+  mar.user_id,
+  mar.id,
+  'initial_admission'::public.payment_obligation_purpose_enum,
+  case
+    when legacy_payment.status = 'succeeded'::public.payment_status_enum
+      then 'settled'::public.payment_obligation_status_enum
+    else 'available'::public.payment_obligation_status_enum
+  end,
+  mar.plan_type,
+  coalesce(legacy_payment.amount, mar.plan_amount),
+  mar.currency,
+  'manual_pix',
+  mar.pix_copy_paste,
+  coalesce(legacy_payment.created_at, mar.submitted_at),
+  case
+    when legacy_payment.status = 'succeeded'::public.payment_status_enum
+      then legacy_payment.paid_at
+    else null
+  end,
+  legacy_payment.id
+from public.membership_application_revisions mar
+left join public.subscriptions s
+  on s.organization_id = mar.organization_id
+  and s.user_id = mar.user_id
+  and s.plan_type = mar.plan_type
+left join lateral (
+  select p.id, p.amount, p.status, p.created_at, p.paid_at
+  from public.payments p
+  where p.organization_id = mar.organization_id
+    and p.user_id = mar.user_id
+    and p.subscription_id = s.id
+    and p.payment_provider is null
+    and p.provider_payment_id is null
+  order by
+    case when p.status = 'succeeded'::public.payment_status_enum then 0 else 1 end,
+    p.created_at asc
+  limit 1
+) legacy_payment on true
+where mar.plan_amount > 0
+  and nullif(btrim(mar.pix_copy_paste), '') is not null
+on conflict (application_revision_id, purpose) do nothing;
+
+create or replace function public.submit_association_application(
+  p_application_id uuid,
+  p_organization_id uuid,
+  p_plan_type public.subscription_plan_type_enum,
+  p_terms_version text,
+  p_draft_version bigint
+)
+returns table (
+  application_revision_id uuid,
+  obligation_id uuid,
+  organization_id uuid,
+  plan_type public.subscription_plan_type_enum,
+  amount integer,
+  currency text,
+  payment_method text,
+  obligation_status public.payment_obligation_status_enum,
+  available_at timestamp with time zone
+)
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  actor_id uuid := auth.uid();
+  draft_record public.membership_applications%rowtype;
+  organization_record public.organizations%rowtype;
+  revision_record public.membership_application_revisions%rowtype;
+  obligation_record public.payment_obligations%rowtype;
+  revision_number integer;
+  plan_amount integer;
+  pix_payload text;
+  submission_timestamp timestamp with time zone;
+  terms_accepted_timestamp timestamp with time zone;
+begin
+  if actor_id is null then
+    raise exception 'Authentication is required.' using errcode = '42501';
+  end if;
+
+  if p_application_id is null
+    or p_organization_id is null
+    or p_plan_type is null
+    or p_terms_version is null
+    or p_draft_version is null
+    or p_draft_version <= 0 then
+    raise exception 'The application submission request is incomplete.'
+      using errcode = '22023';
+  end if;
+
+  select ma.*
+  into draft_record
+  from public.membership_applications ma
+  where ma.id = p_application_id
+  for update;
+
+  if not found then
+    raise exception 'Application draft not found.' using errcode = 'P0002';
+  end if;
+
+  if draft_record.user_id <> actor_id then
+    raise exception 'Application draft is not owned by the current user.'
+      using errcode = '42501';
+  end if;
+
+  if draft_record.organization_id <> p_organization_id then
+    raise exception 'Application draft belongs to a different organization.'
+      using errcode = '42501';
+  end if;
+
+  -- The revision lookup comes before current billing validation so a retry
+  -- returns the original authoritative snapshot even after configuration
+  -- changes. The draft row lock serializes identical and concurrent retries.
+  select mar.*
+  into revision_record
+  from public.membership_application_revisions mar
+  where mar.application_id = p_application_id
+    and mar.draft_version = p_draft_version
+  for update;
+
+  if found then
+    if revision_record.plan_type <> p_plan_type
+      or revision_record.terms_version <> p_terms_version then
+      raise exception 'The application was already submitted with different terms or plan.'
+        using errcode = '40001';
+    end if;
+
+    select po.*
+    into obligation_record
+    from public.payment_obligations po
+    where po.application_revision_id = revision_record.id
+      and po.purpose = 'initial_admission'::public.payment_obligation_purpose_enum
+    for update;
+
+    if not found then
+      insert into public.payment_obligations (
+        organization_id,
+        user_id,
+        application_revision_id,
+        purpose,
+        status,
+        plan_type,
+        amount,
+        currency,
+        payment_method,
+        pix_copy_paste,
+        available_at
+      )
+      values (
+        revision_record.organization_id,
+        revision_record.user_id,
+        revision_record.id,
+        'initial_admission'::public.payment_obligation_purpose_enum,
+        'available'::public.payment_obligation_status_enum,
+        revision_record.plan_type,
+        revision_record.plan_amount,
+        revision_record.currency,
+        'manual_pix',
+        revision_record.pix_copy_paste,
+        revision_record.submitted_at
+      )
+      returning * into obligation_record;
+    end if;
+
+    return query
+    select
+      revision_record.id,
+      obligation_record.id,
+      obligation_record.organization_id,
+      obligation_record.plan_type,
+      obligation_record.amount,
+      obligation_record.currency,
+      obligation_record.payment_method,
+      obligation_record.status,
+      obligation_record.available_at;
+    return;
+  end if;
+
+  select o.*
+  into organization_record
+  from public.organizations o
+  where o.id = p_organization_id
+  for update;
+
+  if not found then
+    raise exception 'Association not found.' using errcode = 'P0002';
+  end if;
+
+  if organization_record.organization_type <> 'association'::public.organization_type_enum then
+    raise exception 'Applications can only be submitted to associations.'
+      using errcode = '42501';
+  end if;
+
+  if exists (
+    select 1
+    from public.organization_members om
+    where om.organization_id = organization_record.id
+      and om.user_id = actor_id
+  ) then
+    raise exception 'The current person is already associated with this organization.'
+      using errcode = '23505';
+  end if;
+
+  if p_terms_version <> organization_record.membership_terms_version then
+    raise exception 'The association terms have changed. Review and accept the current terms.'
+      using errcode = '40001';
+  end if;
+
+  if draft_record.draft_version <> p_draft_version then
+    raise exception 'The application draft changed. Refresh and try again.'
+      using errcode = '40001';
+  end if;
+
+  if draft_record.status <> 'draft'::public.membership_application_status_enum
+    and draft_record.status <> 'submitted'::public.membership_application_status_enum then
+    raise exception 'The application draft is not submittable.' using errcode = '23514';
+  end if;
+
+  if nullif(btrim(draft_record.full_name), '') is null
+    or draft_record.birth_date is null
+    or nullif(btrim(draft_record.nationality), '') is null
+    or draft_record.marital_status is null
+    or nullif(btrim(draft_record.profession), '') is null
+    or nullif(btrim(draft_record.birthplace), '') is null
+    or nullif(btrim(draft_record.cpf), '') is null
+    or btrim(draft_record.cpf) !~ '^[0-9]{11}$'
+    or nullif(btrim(draft_record.id_document_number), '') is null
+    or nullif(btrim(draft_record.id_document_issuer), '') is null
+    or nullif(btrim(draft_record.postal_code), '') is null
+    or btrim(draft_record.postal_code) !~ '^[0-9]{8}$'
+    or nullif(btrim(draft_record.address_line), '') is null
+    or nullif(btrim(draft_record.city), '') is null
+    or nullif(btrim(draft_record.state), '') is null
+    or nullif(btrim(draft_record.email), '') is null
+    or btrim(draft_record.email) !~ '^[^[:space:]@]+@[^[:space:]@]+\.[^[:space:]@]+$'
+    or nullif(btrim(draft_record.phone), '') is null
+    or btrim(draft_record.phone) !~ '^[0-9]{10,11}$'
+    or draft_record.accepted_terms_at is null
+    or draft_record.has_allergies is null
+    or (draft_record.has_allergies
+      and nullif(btrim(draft_record.allergies), '') is null)
+    or draft_record.has_dietary_restrictions is null
+    or (draft_record.has_dietary_restrictions
+      and nullif(btrim(draft_record.dietary_restrictions), '') is null)
+    or draft_record.highline_experience is null
+    or draft_record.has_rescue_course is null
+    or draft_record.first_aid_course is null
+    or nullif(btrim(draft_record.emergency_contact_name), '') is null
+    or nullif(btrim(draft_record.emergency_contact_relationship), '') is null
+    or nullif(btrim(draft_record.emergency_contact_phone), '') is null
+    or btrim(draft_record.emergency_contact_phone) !~ '^[0-9]{10,11}$' then
+    raise exception 'Complete all required application fields before submitting.'
+      using errcode = '23514';
+  end if;
+
+  plan_amount = case p_plan_type
+    when 'annual'::public.subscription_plan_type_enum then organization_record.annual_price_amount
+    else organization_record.monthly_price_amount
+  end;
+
+  pix_payload = case p_plan_type
+    when 'annual'::public.subscription_plan_type_enum then organization_record.annual_pix_copy_paste
+    else organization_record.monthly_pix_copy_paste
+  end;
+
+  if plan_amount is null or plan_amount <= 0
+    or nullif(btrim(organization_record.billing_currency), '') is null
+    or organization_record.billing_currency !~ '^[A-Z]{3}$'
+    or nullif(btrim(pix_payload), '') is null then
+    raise exception 'The association payment configuration is incomplete.'
+      using errcode = '23514';
+  end if;
+
+  terms_accepted_timestamp = timezone('utc'::text, clock_timestamp());
+  submission_timestamp = timezone('utc'::text, clock_timestamp());
+
+  select coalesce(max(mar.revision_number), 0) + 1
+  into revision_number
+  from public.membership_application_revisions mar
+  where mar.application_id = p_application_id;
+
+  insert into public.membership_application_revisions (
+    application_id,
+    organization_id,
+    user_id,
+    revision_number,
+    draft_version,
+    plan_type,
+    terms_version,
+    accepted_terms_at,
+    submitted_at,
+    full_name,
+    birth_date,
+    nationality,
+    marital_status,
+    profession,
+    birthplace,
+    cpf,
+    id_document_number,
+    id_document_issuer,
+    postal_code,
+    address_line,
+    city,
+    state,
+    email,
+    phone,
+    blood_type,
+    has_allergies,
+    allergies,
+    has_dietary_restrictions,
+    dietary_restrictions,
+    highline_experience,
+    has_rescue_course,
+    first_aid_course,
+    emergency_contact_name,
+    emergency_contact_relationship,
+    emergency_contact_phone,
+    plan_amount,
+    currency,
+    pix_copy_paste
+  )
+  values (
+    p_application_id,
+    p_organization_id,
+    actor_id,
+    revision_number,
+    p_draft_version,
+    p_plan_type,
+    p_terms_version,
+    terms_accepted_timestamp,
+    submission_timestamp,
+    draft_record.full_name,
+    draft_record.birth_date,
+    draft_record.nationality,
+    draft_record.marital_status,
+    draft_record.profession,
+    draft_record.birthplace,
+    draft_record.cpf,
+    draft_record.id_document_number,
+    draft_record.id_document_issuer,
+    draft_record.postal_code,
+    draft_record.address_line,
+    draft_record.city,
+    draft_record.state,
+    draft_record.email,
+    draft_record.phone,
+    draft_record.blood_type,
+    draft_record.has_allergies,
+    draft_record.allergies,
+    draft_record.has_dietary_restrictions,
+    draft_record.dietary_restrictions,
+    draft_record.highline_experience,
+    draft_record.has_rescue_course,
+    draft_record.first_aid_course,
+    draft_record.emergency_contact_name,
+    draft_record.emergency_contact_relationship,
+    draft_record.emergency_contact_phone,
+    plan_amount,
+    organization_record.billing_currency,
+    pix_payload
+  )
+  returning * into revision_record;
+
+  insert into public.payment_obligations (
+    organization_id,
+    user_id,
+    application_revision_id,
+    purpose,
+    status,
+    plan_type,
+    amount,
+    currency,
+    payment_method,
+    pix_copy_paste,
+    available_at
+  )
+  values (
+    p_organization_id,
+    actor_id,
+    revision_record.id,
+    'initial_admission'::public.payment_obligation_purpose_enum,
+    'available'::public.payment_obligation_status_enum,
+    p_plan_type,
+    plan_amount,
+    organization_record.billing_currency,
+    'manual_pix',
+    pix_payload,
+    submission_timestamp
+  )
+  returning * into obligation_record;
+
+  if draft_record.status = 'draft'::public.membership_application_status_enum then
+    update public.membership_applications ma
+    set
+      status = 'submitted'::public.membership_application_status_enum,
+      submitted_at = submission_timestamp
+    where ma.id = p_application_id;
+  end if;
+
+  return query
+  select
+    revision_record.id,
+    obligation_record.id,
+    obligation_record.organization_id,
+    obligation_record.plan_type,
+    obligation_record.amount,
+    obligation_record.currency,
+    obligation_record.payment_method,
+    obligation_record.status,
+    obligation_record.available_at;
+end;
+$$;
+
+comment on function public.submit_association_application(
+  uuid,
+  uuid,
+  public.subscription_plan_type_enum,
+  text,
+  bigint
+) is
+  'Atomically snapshots an authenticated association application and creates exactly one initial manual-PIX obligation. Returns no personal application fields.';
+
+revoke all on function public.reject_membership_application_revision_mutation() from public;
+revoke all on function public.reject_membership_application_revision_mutation() from anon;
+revoke all on function public.reject_membership_application_revision_mutation() from authenticated;
+
+revoke all on function public.submit_membership_application(uuid) from public;
+revoke all on function public.submit_membership_application(uuid) from anon;
+revoke all on function public.submit_membership_application(uuid) from authenticated;
+
+revoke all on function public.submit_association_application(
+  uuid,
+  uuid,
+  public.subscription_plan_type_enum,
+  text,
+  bigint
+) from public;
+revoke all on function public.submit_association_application(
+  uuid,
+  uuid,
+  public.subscription_plan_type_enum,
+  text,
+  bigint
+) from anon;
+grant execute on function public.submit_association_application(
+  uuid,
+  uuid,
+  public.subscription_plan_type_enum,
+  text,
+  bigint
+) to authenticated;
+
+create or replace function public.get_payment_obligation_instructions(
+  p_obligation_id uuid
+)
+returns table (
+  obligation_id uuid,
+  organization_id uuid,
+  purpose public.payment_obligation_purpose_enum,
+  status public.payment_obligation_status_enum,
+  plan_type public.subscription_plan_type_enum,
+  amount integer,
+  currency text,
+  payment_method text,
+  pix_copy_paste text,
+  available_at timestamp with time zone
+)
+language sql
+security definer
+set search_path = public, pg_temp
+as $$
+  select
+    po.id,
+    po.organization_id,
+    po.purpose,
+    po.status,
+    po.plan_type,
+    po.amount,
+    po.currency,
+    po.payment_method,
+    po.pix_copy_paste,
+    po.available_at
+  from public.payment_obligations po
+  where po.id = p_obligation_id
+    and po.user_id = auth.uid();
+$$;
+
+comment on function public.get_payment_obligation_instructions(uuid) is
+  'Returns authoritative PIX instructions and billing facts for an obligation owned by the signed-in user.';
+
+revoke all on function public.get_payment_obligation_instructions(uuid) from public;
+revoke all on function public.get_payment_obligation_instructions(uuid) from anon;
+grant execute on function public.get_payment_obligation_instructions(uuid) to authenticated;


### PR DESCRIPTION
Closes #205

## Summary
- replace the client-side submit-then-start-payment sequence with one idempotent authenticated database command
- snapshot submitted application data, terms evidence, billing facts, and the initial manual-PIX obligation with immutable/ownership boundaries
- repair eligible legacy submitted applications without creating membership or duplicate legacy charges
- navigate the app to authoritative obligation instructions and preserve the legacy payment flow

## Validation
- `pnpm --dir expo exec tsc --noEmit`
- focused Jest tests: 14 passed
- ESLint on changed Expo files
- rollback-only authenticated local Supabase scenario covering idempotency, conflicts, rollback, snapshot stability, isolation, group rejection, and mutation denial