### PR TITLE
feat: allow applicants to claim initial PIX payments

### DIFF
--- a/.github/workflows/check-translations.yml
+++ b/.github/workflows/check-translations.yml
@@ -32,4 +32,4 @@ jobs:
 
       - name: Run format:translations check
         working-directory: ./expo
-        run: pnpm run format:translations
+        run: pnpm exec eslint --fix --format ../node_modules/eslint-plugin-i18n-json/formatter.js ./i18n/locales

--- a/.github/workflows/check-translations.yml
+++ b/.github/workflows/check-translations.yml
@@ -13,19 +13,23 @@ jobs:
         node-version: ['24.18.0']
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.10.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
-          cache-dependency-path: expo/yarn.lock
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
-        working-directory: ./expo
-        run: yarn install --frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Run format:translations check
         working-directory: ./expo
-        run: yarn format:translations
+        run: pnpm run format:translations

--- a/expo/app/payment.tsx
+++ b/expo/app/payment.tsx
@@ -14,6 +14,7 @@ import {
   Pressable,
   ScrollView,
   Text,
+  TextInput,
   View,
 } from 'react-native';
 import Animated, { FadeIn, FadeInDown, ZoomIn } from 'react-native-reanimated';
@@ -22,6 +23,12 @@ import QRCode from 'react-qr-code';
 
 import { useAuth } from '~/context/auth';
 import { useMountEffect } from '~/hooks/use-mount-effect';
+import {
+  getPaymentClaimValidationError,
+  normalizePaymentPayerName,
+  type PaymentClaimPayerType,
+  type PaymentClaimStatus,
+} from '~/lib/payment-claim';
 import { queryKeys } from '~/lib/query-keys';
 import { supabase } from '~/lib/supabase';
 
@@ -38,8 +45,14 @@ type PaymentInstructions = {
 type ObligationInstructions = {
   amount: number;
   available_at: string;
+  claim_created_at: string | null;
+  claim_decision_reason: string | null;
+  claim_id: string | null;
+  claim_status: PaymentClaimStatus | null;
   currency: string;
   obligation_id: string;
+  payer_name: string | null;
+  payer_type: PaymentClaimPayerType | null;
   payment_method: string;
   pix_copy_paste: string;
   plan_type: 'monthly' | 'annual';
@@ -97,6 +110,10 @@ function PaymentSuccessState({
 const paymentInstructionsQueryKey = (paymentId: string | undefined) =>
   ['payment-instructions', paymentId] as const;
 
+const paymentObligationInstructionsQueryKey = (
+  obligationId: string | undefined,
+) => ['payment-obligation-instructions', obligationId] as const;
+
 export default function PaymentScreen() {
   const router = useRouter();
   const {
@@ -152,7 +169,7 @@ export default function PaymentScreen() {
     enabled: Boolean(paymentId && !obligationId),
   });
   const obligationInstructionsQuery = useQuery({
-    queryKey: ['payment-obligation-instructions', obligationId],
+    queryKey: paymentObligationInstructionsQueryKey(obligationId),
     queryFn: async (): Promise<ObligationInstructions | null> => {
       if (!obligationId) return null;
 
@@ -163,7 +180,7 @@ export default function PaymentScreen() {
 
       if (error) throw error;
 
-      return data?.[0] ?? null;
+      return (data?.[0] as ObligationInstructions | undefined) ?? null;
     },
     enabled: Boolean(obligationId),
   });
@@ -185,7 +202,16 @@ export default function PaymentScreen() {
   const manualPixCopyPaste = obligationId
     ? (obligationInstructions?.pix_copy_paste ?? '')
     : (paymentInstructions?.pix_copy_paste ?? '');
-  const hasManualPixInstructions = Boolean(manualPixCopyPaste);
+  const isSettledObligation = obligationInstructions?.status === 'settled';
+  const isVoidedObligation = obligationInstructions?.status === 'void';
+  const hasManualPixInstructions =
+    Boolean(manualPixCopyPaste) && !isSettledObligation && !isVoidedObligation;
+  const initialClaimStatus = obligationInstructions?.claim_status ?? null;
+  const canClaimInitialPayment = Boolean(
+    obligationId &&
+    obligationInstructions?.status === 'available' &&
+    (initialClaimStatus === null || initialClaimStatus === 'rejected'),
+  );
 
   const handleClose = () => {
     if (router.canGoBack()) {
@@ -195,9 +221,73 @@ export default function PaymentScreen() {
     }
   };
 
+  const handleRetryPaymentInstructions = () => {
+    if (obligationId) {
+      void obligationInstructionsQuery.refetch();
+    } else if (paymentId) {
+      void paymentInstructionsQuery.refetch();
+    }
+  };
+
+  const isFetchingPaymentInstructions = obligationId
+    ? obligationInstructionsQuery.isFetching
+    : paymentInstructionsQuery.isFetching;
+
   const userMarkedPaidAt = obligationId
     ? null
     : (paymentInstructions?.user_marked_paid_at ?? null);
+
+  const claimPaymentMutation = useMutation({
+    mutationFn: async ({
+      payerName,
+      payerType,
+    }: {
+      payerName: string;
+      payerType: PaymentClaimPayerType;
+    }) => {
+      if (!obligationId) throw new Error('obligationId is required.');
+
+      const { data, error } = await supabase.rpc('claim_initial_payment', {
+        p_obligation_id: obligationId!,
+        p_paid_by_applicant: payerType === 'applicant',
+        p_payer_name:
+          payerType === 'applicant'
+            ? undefined
+            : normalizePaymentPayerName(payerName),
+      });
+
+      if (error) throw error;
+
+      const claim = data?.[0];
+      if (!claim) throw new Error('The payment claim response was empty.');
+
+      return claim;
+    },
+    onSuccess: async (claim) => {
+      queryClient.setQueryData<ObligationInstructions | null>(
+        paymentObligationInstructionsQueryKey(obligationId),
+        (current) =>
+          current
+            ? {
+                ...current,
+                claim_created_at: claim.claim_created_at,
+                claim_decision_reason: null,
+                claim_id: claim.claim_id,
+                claim_status: claim.claim_status,
+                payer_name: claim.payer_name,
+                payer_type: claim.payer_type,
+              }
+            : current,
+      );
+      await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+      await queryClient.invalidateQueries({
+        queryKey: paymentObligationInstructionsQueryKey(obligationId),
+      });
+    },
+    onError: (error) => {
+      console.error('Failed to claim initial payment:', error);
+    },
+  });
 
   const markPaidMutation = useMutation({
     mutationFn: async () => {
@@ -261,6 +351,23 @@ export default function PaymentScreen() {
     markPaidMutation.mutate();
   };
 
+  const handleClaimPayment = ({
+    payerName,
+    payerType,
+  }: {
+    payerName: string;
+    payerType: PaymentClaimPayerType;
+  }) => {
+    const validationError = getPaymentClaimValidationError({
+      payerName,
+      payerType,
+    });
+
+    if (validationError) return;
+
+    claimPaymentMutation.mutate({ payerName, payerType });
+  };
+
   const paymentTitle =
     paymentContext === 'subscription_renewal'
       ? 'Pague sua mensalidade'
@@ -308,13 +415,26 @@ export default function PaymentScreen() {
   }
 
   if ((!paymentId && !obligationId) || !hasManualPixInstructions) {
+    const unavailableTitle = isSettledObligation
+      ? 'Pagamento já confirmado'
+      : 'Pagamento indisponível';
+    const unavailableMessage = isSettledObligation
+      ? 'Esta cobrança já foi confirmada pela associação.'
+      : isVoidedObligation
+        ? 'Esta cobrança não está mais disponível. Feche esta tela e tente novamente pelo aplicativo.'
+        : 'O PIX da associação ainda não foi configurado no aplicativo.';
+    const canRetryInstructions =
+      Boolean(paymentId || obligationId) &&
+      !isSettledObligation &&
+      !isVoidedObligation;
+
     return (
       <PaymentState onClose={handleClose}>
         <Text className="text-white text-3xl font-bold text-center leading-9">
-          Pagamento indisponível
+          {unavailableTitle}
         </Text>
         <Text className="text-white/65 text-[15px] text-center leading-6">
-          O PIX da associação ainda não foi configurado no aplicativo.
+          {unavailableMessage}
         </Text>
         {paymentInstructionsQuery.isError ||
         obligationInstructionsQuery.isError ? (
@@ -327,6 +447,23 @@ export default function PaymentScreen() {
             Valor solicitado: {formattedAmount}
           </Text>
         ) : null}
+        {canRetryInstructions ? (
+          <Pressable
+            accessibilityRole="button"
+            onPress={handleRetryPaymentInstructions}
+            disabled={isFetchingPaymentInstructions}
+            className="rounded-full bg-white px-6 py-3 mt-2"
+            style={({ pressed }) => ({
+              opacity: isFetchingPaymentInstructions ? 0.6 : pressed ? 0.85 : 1,
+            })}
+          >
+            {isFetchingPaymentInstructions ? (
+              <ActivityIndicator color="#000" />
+            ) : (
+              <Text className="text-black font-semibold">Tentar novamente</Text>
+            )}
+          </Pressable>
+        ) : null}
       </PaymentState>
     );
   }
@@ -336,10 +473,21 @@ export default function PaymentScreen() {
       formattedAmount={formattedAmount}
       insets={insets}
       manualPixCopyPaste={manualPixCopyPaste}
+      canClaimInitialPayment={canClaimInitialPayment}
+      claimDecisionReason={
+        obligationInstructions?.claim_decision_reason ?? null
+      }
+      claimPayerName={obligationInstructions?.payer_name ?? null}
+      claimPayerType={obligationInstructions?.payer_type ?? null}
+      claimStatus={initialClaimStatus}
+      claimingPayment={claimPaymentMutation.isPending}
+      claimPaymentError={claimPaymentMutation.isError}
+      obligationStatus={obligationInstructions?.status ?? null}
       markPaidError={markPaidMutation.isError}
       markingPaid={markPaidMutation.isPending}
       canReportPayment={Boolean(paymentId && !obligationId)}
       onClose={handleClose}
+      onClaimPayment={handleClaimPayment}
       onMarkPaid={handleMarkPaid}
       onPaymentFailed={() => setPaymentStatus('FAILED')}
       onPaymentSucceeded={() => setPaymentStatus('SUCCESS')}
@@ -357,17 +505,26 @@ export default function PaymentScreen() {
 }
 
 function ManualPixPayment({
+  canClaimInitialPayment,
   canReportPayment,
+  claimDecisionReason,
+  claimPayerName,
+  claimPayerType,
+  claimStatus,
+  claimingPayment,
+  claimPaymentError,
   formattedAmount,
   insets,
   manualPixCopyPaste,
   markPaidError,
   markingPaid,
   onClose,
+  onClaimPayment,
   onMarkPaid,
   onPaymentFailed,
   onPaymentSucceeded,
   obligationId,
+  obligationStatus,
   paymentContext,
   paymentId,
   profileId,
@@ -377,17 +534,29 @@ function ManualPixPayment({
   title,
   userMarkedPaidAt,
 }: {
+  canClaimInitialPayment: boolean;
   canReportPayment: boolean;
+  claimDecisionReason: string | null;
+  claimPayerName: string | null;
+  claimPayerType: PaymentClaimPayerType | null;
+  claimStatus: PaymentClaimStatus | null;
+  claimingPayment: boolean;
+  claimPaymentError: boolean;
   formattedAmount: string | null;
   insets: ReturnType<typeof useSafeAreaInsets>;
   manualPixCopyPaste: string;
   markPaidError: boolean;
   markingPaid: boolean;
   onClose: () => void;
+  onClaimPayment: (input: {
+    payerName: string;
+    payerType: PaymentClaimPayerType;
+  }) => void;
   onMarkPaid: () => void;
   onPaymentFailed: () => void;
   onPaymentSucceeded: () => void;
   obligationId?: string;
+  obligationStatus: ObligationInstructions['status'] | null;
   paymentContext?: 'new_member' | 'subscription_renewal';
   paymentId?: string;
   profileId?: string;
@@ -397,6 +566,24 @@ function ManualPixPayment({
   title: string;
   userMarkedPaidAt: string | null;
 }) {
+  const [payerType, setPayerType] =
+    React.useState<PaymentClaimPayerType>('applicant');
+  const [payerName, setPayerName] = React.useState('');
+  const [showPayerError, setShowPayerError] = React.useState(false);
+  const payerValidationError = getPaymentClaimValidationError({
+    payerName,
+    payerType,
+  });
+  const isInitialClaimUnderReview = claimStatus === 'under_review';
+  const isInitialClaimRejected = claimStatus === 'rejected';
+
+  const handleClaimPress = () => {
+    setShowPayerError(true);
+    if (payerValidationError) return;
+
+    onClaimPayment({ payerName, payerType });
+  };
+
   return (
     <BgBlob>
       <PaymentStatusSubscription
@@ -465,16 +652,137 @@ function ManualPixPayment({
               : 'Associação'}
           </Text>
           <Text className="text-white/65 text-center text-sm leading-5 mt-1">
-            {canReportPayment
-              ? 'Depois de pagar, toque em "Já paguei". A equipe confere o PIX e aprova sua assinatura manualmente.'
-              : 'Depois de pagar, a associação confere o PIX e conclui a admissão manualmente.'}
+            {obligationStatus === 'void'
+              ? 'Esta cobrança não está mais disponível.'
+              : isInitialClaimUnderReview
+                ? 'Seu aviso de pagamento está em análise. A associação conferirá o PIX manualmente.'
+                : canClaimInitialPayment
+                  ? 'Depois de pagar, confirme quem fez o PIX para enviar o aviso à associação.'
+                  : canReportPayment
+                    ? 'Depois de pagar, toque em "Já paguei". A equipe confere o PIX e aprova sua assinatura manualmente.'
+                    : claimStatus === 'approved' ||
+                        obligationStatus === 'settled'
+                      ? 'Este pagamento já foi confirmado pela associação.'
+                      : 'Depois de pagar, a associação confere o PIX e conclui a admissão manualmente.'}
           </Text>
         </Animated.View>
         <Animated.View
           entering={FadeIn.delay(900).duration(300)}
           className="mx-6 gap-3 mt-auto"
         >
-          {canReportPayment ? (
+          {canClaimInitialPayment ? (
+            <View className="rounded-2xl border border-white/15 bg-white/10 p-4 gap-3">
+              <Text className="text-white text-base font-semibold">
+                Quem fez o PIX?
+              </Text>
+              <View className="flex-row gap-2">
+                {(
+                  [
+                    ['applicant', 'Eu fiz o PIX'],
+                    ['other', 'Outra pessoa fez'],
+                  ] as const
+                ).map(([option, label]) => {
+                  const selected = payerType === option;
+
+                  return (
+                    <Pressable
+                      key={option}
+                      accessibilityRole="radio"
+                      accessibilityState={{ selected }}
+                      onPress={() => {
+                        setPayerType(option);
+                        setShowPayerError(false);
+                      }}
+                      className={`flex-1 rounded-xl border px-3 py-3 ${selected ? 'border-white bg-white' : 'border-white/20 bg-white/5'}`}
+                    >
+                      <Text
+                        className={`text-center text-sm font-semibold ${selected ? 'text-black' : 'text-white/75'}`}
+                      >
+                        {label}
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
+              {payerType === 'other' ? (
+                <TextInput
+                  accessibilityLabel="Nome de quem fez o PIX"
+                  autoCapitalize="words"
+                  onChangeText={(value) => {
+                    setPayerName(value);
+                    setShowPayerError(false);
+                  }}
+                  placeholder="Nome de quem fez o PIX"
+                  placeholderTextColor="rgba(255,255,255,0.45)"
+                  style={{
+                    borderColor: 'rgba(255,255,255,0.2)',
+                    borderRadius: 12,
+                    borderWidth: 1,
+                    color: '#FFFFFF',
+                    fontSize: 16,
+                    paddingHorizontal: 14,
+                    paddingVertical: 12,
+                  }}
+                  value={payerName}
+                />
+              ) : null}
+              {showPayerError && payerValidationError ? (
+                <Text
+                  accessibilityLiveRegion="polite"
+                  className="text-red-200 text-sm leading-5"
+                >
+                  {payerValidationError === 'payer_name_required'
+                    ? 'Informe o nome de quem fez o PIX.'
+                    : 'O nome deve ter no máximo 120 caracteres.'}
+                </Text>
+              ) : null}
+              {isInitialClaimRejected && claimDecisionReason ? (
+                <Text className="text-amber-100/80 text-sm leading-5">
+                  Motivo da última análise: {claimDecisionReason}
+                </Text>
+              ) : null}
+              <Pressable
+                accessibilityRole="button"
+                onPress={handleClaimPress}
+                disabled={claimingPayment}
+                className="rounded-full bg-white py-4 items-center justify-center"
+                style={({ pressed }) => ({
+                  opacity: claimingPayment ? 0.6 : pressed ? 0.85 : 1,
+                })}
+              >
+                {claimingPayment ? (
+                  <ActivityIndicator color="#000" />
+                ) : (
+                  <Text className="text-black text-[17px] font-bold">
+                    {isInitialClaimRejected
+                      ? 'Enviar nova confirmação'
+                      : 'Já fiz o PIX'}
+                  </Text>
+                )}
+              </Pressable>
+              {claimPaymentError ? (
+                <Text className="text-red-200 text-center text-sm leading-5">
+                  Não foi possível registrar o aviso agora. Tente novamente.
+                </Text>
+              ) : null}
+            </View>
+          ) : isInitialClaimUnderReview ? (
+            <View className="rounded-2xl border border-emerald-300/25 bg-emerald-400/10 p-4 gap-2">
+              <Text className="text-emerald-100 text-base font-semibold text-center">
+                Pagamento em análise
+              </Text>
+              <Text className="text-white/70 text-center text-sm leading-5">
+                Seu aviso foi registrado. A associação vai conferir o PIX e
+                retornar com a decisão.
+              </Text>
+              <Text className="text-white/50 text-center text-sm leading-5">
+                Pagador:{' '}
+                {claimPayerType === 'other'
+                  ? claimPayerName || 'Outra pessoa'
+                  : 'Você'}
+              </Text>
+            </View>
+          ) : canReportPayment ? (
             <Pressable
               onPress={onMarkPaid}
               disabled={markingPaid || Boolean(userMarkedPaidAt)}
@@ -503,10 +811,16 @@ function ManualPixPayment({
                 </View>
               )}
             </Pressable>
+          ) : obligationStatus === 'void' ? (
+            <Text className="text-white/65 text-center text-sm leading-5">
+              Esta cobrança não está mais disponível. Feche esta tela e tente
+              novamente pelo aplicativo.
+            </Text>
           ) : (
             <Text className="text-white/65 text-center text-sm leading-5">
-              Depois de pagar, a associação receberá sua solicitação para
-              conferir o PIX e concluir a admissão.
+              {claimStatus === 'approved' || obligationStatus === 'settled'
+                ? 'Este pagamento já foi confirmado pela associação.'
+                : 'Depois de pagar, a associação receberá sua solicitação para conferir o PIX e concluir a admissão.'}
             </Text>
           )}
           {canReportPayment && userMarkedPaidAt ? (

--- a/expo/lib/payment-claim.test.ts
+++ b/expo/lib/payment-claim.test.ts
@@ -1,0 +1,33 @@
+import {
+  getPaymentClaimValidationError,
+  normalizePaymentPayerName,
+} from './payment-claim';
+
+describe('payment claim payer details', () => {
+  it('normalizes leading, trailing, and repeated whitespace', () => {
+    expect(normalizePaymentPayerName('  Ana   Maria\nSilva  ')).toBe(
+      'Ana Maria Silva',
+    );
+  });
+
+  it('uses the applicant as the default without requiring a name', () => {
+    expect(
+      getPaymentClaimValidationError({ payerName: '', payerType: 'applicant' }),
+    ).toBeNull();
+  });
+
+  it('requires a name when another person paid', () => {
+    expect(
+      getPaymentClaimValidationError({ payerName: '   ', payerType: 'other' }),
+    ).toBe('payer_name_required');
+  });
+
+  it('enforces the server-aligned payer name limit', () => {
+    expect(
+      getPaymentClaimValidationError({
+        payerName: 'a'.repeat(121),
+        payerType: 'other',
+      }),
+    ).toBe('payer_name_too_long');
+  });
+});

--- a/expo/lib/payment-claim.ts
+++ b/expo/lib/payment-claim.ts
@@ -1,0 +1,28 @@
+export type PaymentClaimPayerType = 'applicant' | 'other';
+
+export type PaymentClaimStatus = 'under_review' | 'approved' | 'rejected';
+
+export const MAX_PAYMENT_PAYER_NAME_LENGTH = 120;
+
+export function normalizePaymentPayerName(value: string) {
+  return value.trim().replace(/\s+/g, ' ');
+}
+
+export function getPaymentClaimValidationError({
+  payerName,
+  payerType,
+}: {
+  payerName: string;
+  payerType: PaymentClaimPayerType;
+}) {
+  if (payerType === 'applicant') return null;
+
+  const normalizedName = normalizePaymentPayerName(payerName);
+
+  if (!normalizedName) return 'payer_name_required' as const;
+  if (normalizedName.length > MAX_PAYMENT_PAYER_NAME_LENGTH) {
+    return 'payer_name_too_long' as const;
+  }
+
+  return null;
+}

--- a/packages/database/database-generated.types.ts
+++ b/packages/database/database-generated.types.ts
@@ -546,6 +546,322 @@ export type Database = {
           },
         ]
       }
+      membership_application_revisions: {
+        Row: {
+          accepted_terms_at: string
+          address_line: string | null
+          allergies: string | null
+          application_id: string
+          birth_date: string | null
+          birthplace: string | null
+          blood_type: Database["public"]["Enums"]["blood_type_enum"] | null
+          city: string | null
+          cpf: string | null
+          created_at: string
+          currency: string
+          dietary_restrictions: string | null
+          draft_version: number
+          email: string | null
+          emergency_contact_name: string | null
+          emergency_contact_phone: string | null
+          emergency_contact_relationship: string | null
+          first_aid_course:
+            | Database["public"]["Enums"]["first_aid_course_enum"]
+            | null
+          full_name: string | null
+          has_allergies: boolean
+          has_dietary_restrictions: boolean
+          has_rescue_course: boolean | null
+          highline_experience:
+            | Database["public"]["Enums"]["highline_experience_enum"]
+            | null
+          id: string
+          id_document_issuer: string | null
+          id_document_number: string | null
+          marital_status:
+            | Database["public"]["Enums"]["marital_status_enum"]
+            | null
+          nationality: string | null
+          organization_id: string
+          phone: string | null
+          pix_copy_paste: string
+          plan_amount: number
+          plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"]
+          postal_code: string | null
+          profession: string | null
+          revision_number: number
+          state: string | null
+          submitted_at: string
+          terms_version: string
+          user_id: string
+        }
+        Insert: {
+          accepted_terms_at: string
+          address_line?: string | null
+          allergies?: string | null
+          application_id: string
+          birth_date?: string | null
+          birthplace?: string | null
+          blood_type?: Database["public"]["Enums"]["blood_type_enum"] | null
+          city?: string | null
+          cpf?: string | null
+          created_at?: string
+          currency: string
+          dietary_restrictions?: string | null
+          draft_version: number
+          email?: string | null
+          emergency_contact_name?: string | null
+          emergency_contact_phone?: string | null
+          emergency_contact_relationship?: string | null
+          first_aid_course?:
+            | Database["public"]["Enums"]["first_aid_course_enum"]
+            | null
+          full_name?: string | null
+          has_allergies: boolean
+          has_dietary_restrictions: boolean
+          has_rescue_course?: boolean | null
+          highline_experience?:
+            | Database["public"]["Enums"]["highline_experience_enum"]
+            | null
+          id?: string
+          id_document_issuer?: string | null
+          id_document_number?: string | null
+          marital_status?:
+            | Database["public"]["Enums"]["marital_status_enum"]
+            | null
+          nationality?: string | null
+          organization_id: string
+          phone?: string | null
+          pix_copy_paste: string
+          plan_amount: number
+          plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"]
+          postal_code?: string | null
+          profession?: string | null
+          revision_number: number
+          state?: string | null
+          submitted_at: string
+          terms_version: string
+          user_id: string
+        }
+        Update: {
+          accepted_terms_at?: string
+          address_line?: string | null
+          allergies?: string | null
+          application_id?: string
+          birth_date?: string | null
+          birthplace?: string | null
+          blood_type?: Database["public"]["Enums"]["blood_type_enum"] | null
+          city?: string | null
+          cpf?: string | null
+          created_at?: string
+          currency?: string
+          dietary_restrictions?: string | null
+          draft_version?: number
+          email?: string | null
+          emergency_contact_name?: string | null
+          emergency_contact_phone?: string | null
+          emergency_contact_relationship?: string | null
+          first_aid_course?:
+            | Database["public"]["Enums"]["first_aid_course_enum"]
+            | null
+          full_name?: string | null
+          has_allergies?: boolean
+          has_dietary_restrictions?: boolean
+          has_rescue_course?: boolean | null
+          highline_experience?:
+            | Database["public"]["Enums"]["highline_experience_enum"]
+            | null
+          id?: string
+          id_document_issuer?: string | null
+          id_document_number?: string | null
+          marital_status?:
+            | Database["public"]["Enums"]["marital_status_enum"]
+            | null
+          nationality?: string | null
+          organization_id?: string
+          phone?: string | null
+          pix_copy_paste?: string
+          plan_amount?: number
+          plan_type?: Database["public"]["Enums"]["subscription_plan_type_enum"]
+          postal_code?: string | null
+          profession?: string | null
+          revision_number?: number
+          state?: string | null
+          submitted_at?: string
+          terms_version?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "membership_application_revisions_application_id_fkey"
+            columns: ["application_id"]
+            isOneToOne: false
+            referencedRelation: "membership_applications"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "membership_application_revisions_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "membership_application_revisions_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      membership_applications: {
+        Row: {
+          accepted_terms_at: string | null
+          address_line: string | null
+          allergies: string | null
+          birth_date: string | null
+          birthplace: string | null
+          blood_type: Database["public"]["Enums"]["blood_type_enum"] | null
+          city: string | null
+          cpf: string | null
+          created_at: string
+          dietary_restrictions: string | null
+          draft_version: number
+          email: string | null
+          emergency_contact_name: string | null
+          emergency_contact_phone: string | null
+          emergency_contact_relationship: string | null
+          first_aid_course:
+            | Database["public"]["Enums"]["first_aid_course_enum"]
+            | null
+          full_name: string | null
+          has_allergies: boolean
+          has_dietary_restrictions: boolean
+          has_rescue_course: boolean | null
+          highline_experience:
+            | Database["public"]["Enums"]["highline_experience_enum"]
+            | null
+          id: string
+          id_document_issuer: string | null
+          id_document_number: string | null
+          marital_status:
+            | Database["public"]["Enums"]["marital_status_enum"]
+            | null
+          nationality: string | null
+          organization_id: string
+          phone: string | null
+          postal_code: string | null
+          profession: string | null
+          state: string | null
+          status: Database["public"]["Enums"]["membership_application_status_enum"]
+          submitted_at: string | null
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          accepted_terms_at?: string | null
+          address_line?: string | null
+          allergies?: string | null
+          birth_date?: string | null
+          birthplace?: string | null
+          blood_type?: Database["public"]["Enums"]["blood_type_enum"] | null
+          city?: string | null
+          cpf?: string | null
+          created_at?: string
+          dietary_restrictions?: string | null
+          draft_version?: number
+          email?: string | null
+          emergency_contact_name?: string | null
+          emergency_contact_phone?: string | null
+          emergency_contact_relationship?: string | null
+          first_aid_course?:
+            | Database["public"]["Enums"]["first_aid_course_enum"]
+            | null
+          full_name?: string | null
+          has_allergies?: boolean
+          has_dietary_restrictions?: boolean
+          has_rescue_course?: boolean | null
+          highline_experience?:
+            | Database["public"]["Enums"]["highline_experience_enum"]
+            | null
+          id?: string
+          id_document_issuer?: string | null
+          id_document_number?: string | null
+          marital_status?:
+            | Database["public"]["Enums"]["marital_status_enum"]
+            | null
+          nationality?: string | null
+          organization_id: string
+          phone?: string | null
+          postal_code?: string | null
+          profession?: string | null
+          state?: string | null
+          status?: Database["public"]["Enums"]["membership_application_status_enum"]
+          submitted_at?: string | null
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          accepted_terms_at?: string | null
+          address_line?: string | null
+          allergies?: string | null
+          birth_date?: string | null
+          birthplace?: string | null
+          blood_type?: Database["public"]["Enums"]["blood_type_enum"] | null
+          city?: string | null
+          cpf?: string | null
+          created_at?: string
+          dietary_restrictions?: string | null
+          draft_version?: number
+          email?: string | null
+          emergency_contact_name?: string | null
+          emergency_contact_phone?: string | null
+          emergency_contact_relationship?: string | null
+          first_aid_course?:
+            | Database["public"]["Enums"]["first_aid_course_enum"]
+            | null
+          full_name?: string | null
+          has_allergies?: boolean
+          has_dietary_restrictions?: boolean
+          has_rescue_course?: boolean | null
+          highline_experience?:
+            | Database["public"]["Enums"]["highline_experience_enum"]
+            | null
+          id?: string
+          id_document_issuer?: string | null
+          id_document_number?: string | null
+          marital_status?:
+            | Database["public"]["Enums"]["marital_status_enum"]
+            | null
+          nationality?: string | null
+          organization_id?: string
+          phone?: string | null
+          postal_code?: string | null
+          profession?: string | null
+          state?: string | null
+          status?: Database["public"]["Enums"]["membership_application_status_enum"]
+          submitted_at?: string | null
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "membership_applications_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "membership_applications_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       news: {
         Row: {
           content: string
@@ -720,363 +1036,173 @@ export type Database = {
           },
         ]
       }
-      membership_applications: {
-        Row: {
-          accepted_terms_at: string | null
-          address_line: string | null
-          allergies: string | null
-          birth_date: string | null
-          birthplace: string | null
-          blood_type: Database["public"]["Enums"]["blood_type_enum"] | null
-          city: string | null
-          cpf: string | null
-          created_at: string
-          draft_version: number
-          dietary_restrictions: string | null
-          email: string | null
-          emergency_contact_name: string | null
-          emergency_contact_phone: string | null
-          emergency_contact_relationship: string | null
-          first_aid_course:
-            | Database["public"]["Enums"]["first_aid_course_enum"]
-            | null
-          full_name: string | null
-          has_allergies: boolean
-          has_dietary_restrictions: boolean
-          has_rescue_course: boolean | null
-          highline_experience:
-            | Database["public"]["Enums"]["highline_experience_enum"]
-            | null
-          id: string
-          id_document_issuer: string | null
-          id_document_number: string | null
-          marital_status:
-            | Database["public"]["Enums"]["marital_status_enum"]
-            | null
-          nationality: string | null
-          organization_id: string
-          phone: string | null
-          postal_code: string | null
-          profession: string | null
-          state: string | null
-          status: Database["public"]["Enums"]["membership_application_status_enum"]
-          submitted_at: string | null
-          updated_at: string
-          user_id: string
-        }
-        Insert: {
-          accepted_terms_at?: string | null
-          address_line?: string | null
-          allergies?: string | null
-          birth_date?: string | null
-          birthplace?: string | null
-          blood_type?: Database["public"]["Enums"]["blood_type_enum"] | null
-          city?: string | null
-          cpf?: string | null
-          created_at?: string
-          draft_version?: number
-          dietary_restrictions?: string | null
-          email?: string | null
-          emergency_contact_name?: string | null
-          emergency_contact_phone?: string | null
-          emergency_contact_relationship?: string | null
-          first_aid_course?:
-            | Database["public"]["Enums"]["first_aid_course_enum"]
-            | null
-          full_name?: string | null
-          has_allergies?: boolean
-          has_dietary_restrictions?: boolean
-          has_rescue_course?: boolean | null
-          highline_experience?:
-            | Database["public"]["Enums"]["highline_experience_enum"]
-            | null
-          id?: string
-          id_document_issuer?: string | null
-          id_document_number?: string | null
-          marital_status?:
-            | Database["public"]["Enums"]["marital_status_enum"]
-            | null
-          nationality?: string | null
-          organization_id: string
-          phone?: string | null
-          postal_code?: string | null
-          profession?: string | null
-          state?: string | null
-          status?: Database["public"]["Enums"]["membership_application_status_enum"]
-          submitted_at?: string | null
-          updated_at?: string
-          user_id: string
-        }
-        Update: {
-          accepted_terms_at?: string | null
-          address_line?: string | null
-          allergies?: string | null
-          birth_date?: string | null
-          birthplace?: string | null
-          blood_type?: Database["public"]["Enums"]["blood_type_enum"] | null
-          city?: string | null
-          cpf?: string | null
-          created_at?: string
-          draft_version?: number
-          dietary_restrictions?: string | null
-          email?: string | null
-          emergency_contact_name?: string | null
-          emergency_contact_phone?: string | null
-          emergency_contact_relationship?: string | null
-          first_aid_course?:
-            | Database["public"]["Enums"]["first_aid_course_enum"]
-            | null
-          full_name?: string | null
-          has_allergies?: boolean
-          has_dietary_restrictions?: boolean
-          has_rescue_course?: boolean | null
-          highline_experience?:
-            | Database["public"]["Enums"]["highline_experience_enum"]
-            | null
-          id?: string
-          id_document_issuer?: string | null
-          id_document_number?: string | null
-          marital_status?:
-            | Database["public"]["Enums"]["marital_status_enum"]
-            | null
-          nationality?: string | null
-          organization_id?: string
-          phone?: string | null
-          postal_code?: string | null
-          profession?: string | null
-          state?: string | null
-          status?: Database["public"]["Enums"]["membership_application_status_enum"]
-          submitted_at?: string | null
-          updated_at?: string
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "membership_applications_organization_id_fkey"
-            columns: ["organization_id"]
-            isOneToOne: false
-            referencedRelation: "organizations"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "membership_applications_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      membership_application_revisions: {
-        Row: {
-          accepted_terms_at: string
-          address_line: string | null
-          allergies: string | null
-          application_id: string
-          birth_date: string | null
-          birthplace: string | null
-          blood_type: Database["public"]["Enums"]["blood_type_enum"] | null
-          city: string | null
-          cpf: string | null
-          created_at: string
-          currency: string
-          dietary_restrictions: string | null
-          draft_version: number
-          email: string | null
-          emergency_contact_name: string | null
-          emergency_contact_phone: string | null
-          emergency_contact_relationship: string | null
-          first_aid_course:
-            | Database["public"]["Enums"]["first_aid_course_enum"]
-            | null
-          full_name: string | null
-          has_allergies: boolean
-          has_dietary_restrictions: boolean
-          has_rescue_course: boolean | null
-          highline_experience:
-            | Database["public"]["Enums"]["highline_experience_enum"]
-            | null
-          id: string
-          id_document_issuer: string | null
-          id_document_number: string | null
-          marital_status:
-            | Database["public"]["Enums"]["marital_status_enum"]
-            | null
-          nationality: string | null
-          organization_id: string
-          phone: string | null
-          pix_copy_paste: string
-          plan_amount: number
-          plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"]
-          postal_code: string | null
-          profession: string | null
-          revision_number: number
-          state: string | null
-          submitted_at: string
-          terms_version: string
-          user_id: string
-        }
-        Insert: {
-          accepted_terms_at: string
-          address_line?: string | null
-          allergies?: string | null
-          application_id: string
-          birth_date?: string | null
-          birthplace?: string | null
-          blood_type?: Database["public"]["Enums"]["blood_type_enum"] | null
-          city?: string | null
-          cpf?: string | null
-          created_at?: string
-          currency: string
-          dietary_restrictions?: string | null
-          draft_version: number
-          email?: string | null
-          emergency_contact_name?: string | null
-          emergency_contact_phone?: string | null
-          emergency_contact_relationship?: string | null
-          first_aid_course?:
-            | Database["public"]["Enums"]["first_aid_course_enum"]
-            | null
-          full_name?: string | null
-          has_allergies: boolean
-          has_dietary_restrictions: boolean
-          has_rescue_course?: boolean | null
-          highline_experience?:
-            | Database["public"]["Enums"]["highline_experience_enum"]
-            | null
-          id?: string
-          id_document_issuer?: string | null
-          id_document_number?: string | null
-          marital_status?:
-            | Database["public"]["Enums"]["marital_status_enum"]
-            | null
-          nationality?: string | null
-          organization_id: string
-          phone?: string | null
-          pix_copy_paste: string
-          plan_amount: number
-          plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"]
-          postal_code?: string | null
-          profession?: string | null
-          revision_number: number
-          state?: string | null
-          submitted_at: string
-          terms_version: string
-          user_id: string
-        }
-        Update: {
-          accepted_terms_at?: string
-          address_line?: string | null
-          allergies?: string | null
-          application_id?: string
-          birth_date?: string | null
-          birthplace?: string | null
-          blood_type?: Database["public"]["Enums"]["blood_type_enum"] | null
-          city?: string | null
-          cpf?: string | null
-          created_at?: string
-          currency?: string
-          dietary_restrictions?: string | null
-          draft_version?: number
-          email?: string | null
-          emergency_contact_name?: string | null
-          emergency_contact_phone?: string | null
-          emergency_contact_relationship?: string | null
-          first_aid_course?:
-            | Database["public"]["Enums"]["first_aid_course_enum"]
-            | null
-          full_name?: string | null
-          has_allergies?: boolean
-          has_dietary_restrictions?: boolean
-          has_rescue_course?: boolean | null
-          highline_experience?:
-            | Database["public"]["Enums"]["highline_experience_enum"]
-            | null
-          id?: string
-          id_document_issuer?: string | null
-          id_document_number?: string | null
-          marital_status?:
-            | Database["public"]["Enums"]["marital_status_enum"]
-            | null
-          nationality?: string | null
-          organization_id?: string
-          phone?: string | null
-          pix_copy_paste?: string
-          plan_amount?: number
-          plan_type?: Database["public"]["Enums"]["subscription_plan_type_enum"]
-          postal_code?: string | null
-          profession?: string | null
-          revision_number?: number
-          state?: string | null
-          submitted_at?: string
-          terms_version?: string
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "membership_application_revisions_application_id_fkey"
-            columns: ["application_id"]
-            isOneToOne: false
-            referencedRelation: "membership_applications"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "membership_application_revisions_organization_id_fkey"
-            columns: ["organization_id"]
-            isOneToOne: false
-            referencedRelation: "organizations"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "membership_application_revisions_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
       organizations: {
         Row: {
-          annual_price_amount: number | null
           annual_pix_copy_paste: string | null
+          annual_price_amount: number | null
           billing_currency: string
           created_at: string
           id: string
           membership_terms_version: string
-          monthly_price_amount: number | null
           monthly_pix_copy_paste: string | null
+          monthly_price_amount: number | null
           name: string
           organization_type: Database["public"]["Enums"]["organization_type_enum"]
           slug: string
         }
         Insert: {
-          annual_price_amount?: number | null
           annual_pix_copy_paste?: string | null
+          annual_price_amount?: number | null
           billing_currency?: string
           created_at?: string
           id?: string
           membership_terms_version?: string
-          monthly_price_amount?: number | null
           monthly_pix_copy_paste?: string | null
+          monthly_price_amount?: number | null
           name: string
           organization_type?: Database["public"]["Enums"]["organization_type_enum"]
           slug: string
         }
         Update: {
-          annual_price_amount?: number | null
           annual_pix_copy_paste?: string | null
+          annual_price_amount?: number | null
           billing_currency?: string
           created_at?: string
           id?: string
           membership_terms_version?: string
-          monthly_price_amount?: number | null
           monthly_pix_copy_paste?: string | null
+          monthly_price_amount?: number | null
           name?: string
           organization_type?: Database["public"]["Enums"]["organization_type_enum"]
           slug?: string
         }
         Relationships: []
+      }
+      payment_claim_audit_events: {
+        Row: {
+          actor_user_id: string
+          claim_id: string
+          created_at: string
+          id: string
+          next_state: string
+          obligation_id: string
+          organization_id: string
+          previous_state: string
+          reason: string | null
+        }
+        Insert: {
+          actor_user_id: string
+          claim_id: string
+          created_at?: string
+          id?: string
+          next_state: string
+          obligation_id: string
+          organization_id: string
+          previous_state: string
+          reason?: string | null
+        }
+        Update: {
+          actor_user_id?: string
+          claim_id?: string
+          created_at?: string
+          id?: string
+          next_state?: string
+          obligation_id?: string
+          organization_id?: string
+          previous_state?: string
+          reason?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "payment_claim_audit_events_actor_user_id_fkey"
+            columns: ["actor_user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "payment_claim_audit_events_claim_id_fkey"
+            columns: ["claim_id"]
+            isOneToOne: false
+            referencedRelation: "payment_claims"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "payment_claim_audit_events_obligation_id_fkey"
+            columns: ["obligation_id"]
+            isOneToOne: false
+            referencedRelation: "payment_obligations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "payment_claim_audit_events_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      payment_claims: {
+        Row: {
+          claimant_user_id: string
+          created_at: string
+          decided_at: string | null
+          decision_reason: string | null
+          id: string
+          obligation_id: string
+          organization_id: string
+          payer_name: string | null
+          payer_type: Database["public"]["Enums"]["payment_claim_payer_type_enum"]
+          status: Database["public"]["Enums"]["payment_claim_status_enum"]
+        }
+        Insert: {
+          claimant_user_id: string
+          created_at?: string
+          decided_at?: string | null
+          decision_reason?: string | null
+          id?: string
+          obligation_id: string
+          organization_id: string
+          payer_name?: string | null
+          payer_type: Database["public"]["Enums"]["payment_claim_payer_type_enum"]
+          status?: Database["public"]["Enums"]["payment_claim_status_enum"]
+        }
+        Update: {
+          claimant_user_id?: string
+          created_at?: string
+          decided_at?: string | null
+          decision_reason?: string | null
+          id?: string
+          obligation_id?: string
+          organization_id?: string
+          payer_name?: string | null
+          payer_type?: Database["public"]["Enums"]["payment_claim_payer_type_enum"]
+          status?: Database["public"]["Enums"]["payment_claim_status_enum"]
+        }
+        Relationships: [
+          {
+            foreignKeyName: "payment_claims_claimant_user_id_fkey"
+            columns: ["claimant_user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "payment_claims_obligation_id_fkey"
+            columns: ["obligation_id"]
+            isOneToOne: false
+            referencedRelation: "payment_obligations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "payment_claims_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       payment_obligations: {
         Row: {
@@ -1174,8 +1300,8 @@ export type Database = {
           settlement_applied_at: string | null
           status: Database["public"]["Enums"]["payment_status_enum"]
           subscription_id: string
-          user_marked_paid_at: string | null
           user_id: string
+          user_marked_paid_at: string | null
         }
         Insert: {
           abacate_pay_charge_id?: string | null
@@ -1189,8 +1315,8 @@ export type Database = {
           settlement_applied_at?: string | null
           status?: Database["public"]["Enums"]["payment_status_enum"]
           subscription_id: string
-          user_marked_paid_at?: string | null
           user_id: string
+          user_marked_paid_at?: string | null
         }
         Update: {
           abacate_pay_charge_id?: string | null
@@ -1204,8 +1330,8 @@ export type Database = {
           settlement_applied_at?: string | null
           status?: Database["public"]["Enums"]["payment_status_enum"]
           subscription_id?: string
-          user_marked_paid_at?: string | null
           user_id?: string
+          user_marked_paid_at?: string | null
         }
         Relationships: [
           {
@@ -1602,6 +1728,22 @@ export type Database = {
           isSetofReturn: false
         }
       }
+      claim_initial_payment: {
+        Args: {
+          p_obligation_id: string
+          p_paid_by_applicant: boolean
+          p_payer_name?: string
+        }
+        Returns: {
+          audit_event_id: string
+          claim_created_at: string
+          claim_id: string
+          claim_status: Database["public"]["Enums"]["payment_claim_status_enum"]
+          obligation_id: string
+          payer_name: string
+          payer_type: Database["public"]["Enums"]["payment_claim_payer_type_enum"]
+        }[]
+      }
       enqueue_festival_schedule_open_notifications: {
         Args: never
         Returns: number
@@ -1614,6 +1756,15 @@ export type Database = {
           profile_picture: string
         }[]
       }
+      get_festival_schedule_booking_cooldown_ends_at: {
+        Args: { target_festival_id: string }
+        Returns: string
+      }
+      get_festival_schedule_booking_cooldown_seconds: {
+        Args: never
+        Returns: number
+      }
+      get_festival_schedule_booking_limit: { Args: never; Returns: number }
       get_festival_schedule_bookings: {
         Args: { target_festival_id: string }
         Returns: {
@@ -1627,92 +1778,6 @@ export type Database = {
           participant_secondary_text: string
           slot_id: string
           status: Database["public"]["Enums"]["festival_schedule_booking_status_enum"]
-        }[]
-      }
-      get_festival_schedule_booking_cooldown_ends_at: {
-        Args: { target_festival_id: string }
-        Returns: string | null
-      }
-      get_festival_schedule_booking_cooldown_seconds: {
-        Args: never
-        Returns: number
-      }
-      get_festival_schedule_booking_limit: {
-        Args: never
-        Returns: number
-      }
-      get_manual_payment_instructions: {
-        Args: { p_payment_id: string }
-        Returns: {
-          amount: number
-          payment_id: string
-          pix_copy_paste: string | null
-          status: Database["public"]["Enums"]["payment_status_enum"]
-          user_marked_paid_at: string | null
-        }[]
-      }
-      get_payment_obligation_instructions: {
-        Args: { p_obligation_id: string }
-        Returns: {
-          amount: number
-          available_at: string
-          currency: string
-          obligation_id: string
-          payment_method: string
-          pix_copy_paste: string
-          plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"]
-          purpose: Database["public"]["Enums"]["payment_obligation_purpose_enum"]
-          status: Database["public"]["Enums"]["payment_obligation_status_enum"]
-          organization_id: string
-        }[]
-      }
-      mark_payment_succeeded_manually: {
-        Args: { p_paid_at?: string; p_payment_id: string }
-        Returns: {
-          applied_effects_now: boolean
-          paid_at: string
-          payment_id: string
-          previous_status: Database["public"]["Enums"]["payment_status_enum"]
-          settlement_applied_at: string | null
-          status: Database["public"]["Enums"]["payment_status_enum"]
-        }[]
-      }
-      mark_manual_payment_paid_by_user: {
-        Args: { p_payment_id: string }
-        Returns: {
-          payment_id: string
-          status: Database["public"]["Enums"]["payment_status_enum"]
-          user_marked_paid_at: string | null
-        }[]
-      }
-      submit_membership_application: {
-        Args: { p_application_id: string }
-        Returns: {
-          id: string
-          organization_id: string
-          status: Database["public"]["Enums"]["membership_application_status_enum"]
-          submitted_at: string | null
-          user_id: string
-        }[]
-      }
-      submit_association_application: {
-        Args: {
-          p_application_id: string
-          p_draft_version: number
-          p_organization_id: string
-          p_plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"]
-          p_terms_version: string
-        }
-        Returns: {
-          amount: number
-          application_revision_id: string
-          available_at: string
-          currency: string
-          obligation_id: string
-          obligation_status: Database["public"]["Enums"]["payment_obligation_status_enum"]
-          organization_id: string
-          payment_method: string
-          plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"]
         }[]
       }
       get_highline: {
@@ -1738,6 +1803,37 @@ export type Database = {
           name: string
           sector_id: number
           status: string
+        }[]
+      }
+      get_manual_payment_instructions: {
+        Args: { p_payment_id: string }
+        Returns: {
+          amount: number
+          payment_id: string
+          pix_copy_paste: string
+          status: Database["public"]["Enums"]["payment_status_enum"]
+          user_marked_paid_at: string
+        }[]
+      }
+      get_payment_obligation_instructions: {
+        Args: { p_obligation_id: string }
+        Returns: {
+          amount: number
+          available_at: string
+          claim_created_at: string
+          claim_decision_reason: string
+          claim_id: string
+          claim_status: Database["public"]["Enums"]["payment_claim_status_enum"]
+          currency: string
+          obligation_id: string
+          organization_id: string
+          payer_name: string
+          payer_type: Database["public"]["Enums"]["payment_claim_payer_type_enum"]
+          payment_method: string
+          pix_copy_paste: string
+          plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"]
+          purpose: Database["public"]["Enums"]["payment_obligation_purpose_enum"]
+          status: Database["public"]["Enums"]["payment_obligation_status_enum"]
         }[]
       }
       get_total_cadenas: {
@@ -1809,10 +1905,30 @@ export type Database = {
         Args: { target_festival_id: string; target_profile_id: string }
         Returns: boolean
       }
+      mark_manual_payment_paid_by_user: {
+        Args: { p_payment_id: string }
+        Returns: {
+          payment_id: string
+          status: Database["public"]["Enums"]["payment_status_enum"]
+          user_marked_paid_at: string
+        }[]
+      }
+      mark_payment_succeeded_manually: {
+        Args: { p_paid_at?: string; p_payment_id: string }
+        Returns: {
+          applied_effects_now: boolean
+          paid_at: string
+          payment_id: string
+          previous_status: Database["public"]["Enums"]["payment_status_enum"]
+          settlement_applied_at: string
+          status: Database["public"]["Enums"]["payment_status_enum"]
+        }[]
+      }
       normalize_festival_instagram_username: {
         Args: { value: string }
         Returns: string
       }
+      normalize_profile_username: { Args: { value: string }; Returns: string }
       profile_stats: {
         Args: { username: string }
         Returns: {
@@ -1820,6 +1936,10 @@ export type Database = {
           total_distance_walked: number
           total_full_lines: number
         }[]
+      }
+      profile_username_disambiguated: {
+        Args: { normalized_username: string; profile_id: string }
+        Returns: string
       }
       reconcile_festival_schedule: {
         Args: { festival_slug?: string }
@@ -1832,6 +1952,36 @@ export type Database = {
       regenerate_festival_schedule_window: {
         Args: { target_window_id: string }
         Returns: number
+      }
+      submit_association_application: {
+        Args: {
+          p_application_id: string
+          p_draft_version: number
+          p_organization_id: string
+          p_plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"]
+          p_terms_version: string
+        }
+        Returns: {
+          amount: number
+          application_revision_id: string
+          available_at: string
+          currency: string
+          obligation_id: string
+          obligation_status: Database["public"]["Enums"]["payment_obligation_status_enum"]
+          organization_id: string
+          payment_method: string
+          plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"]
+        }[]
+      }
+      submit_membership_application: {
+        Args: { p_application_id: string }
+        Returns: {
+          id: string
+          organization_id: string
+          status: Database["public"]["Enums"]["membership_application_status_enum"]
+          submitted_at: string
+          user_id: string
+        }[]
       }
       validate_locale_keys: { Args: { json_data: Json }; Returns: boolean }
     }
@@ -1868,6 +2018,8 @@ export type Database = {
       membership_application_status_enum: "draft" | "submitted"
       organization_role_enum: "admin" | "member"
       organization_type_enum: "group" | "association"
+      payment_claim_payer_type_enum: "applicant" | "other"
+      payment_claim_status_enum: "under_review" | "approved" | "rejected"
       payment_obligation_purpose_enum: "initial_admission"
       payment_obligation_status_enum: "available" | "settled" | "void"
       payment_status_enum: "pending" | "succeeded" | "failed"
@@ -2098,7 +2250,6 @@ export type Database = {
           created_at: string | null
           id: string
           last_accessed_at: string | null
-          level: number | null
           metadata: Json | null
           name: string | null
           owner: string | null
@@ -2113,7 +2264,6 @@ export type Database = {
           created_at?: string | null
           id?: string
           last_accessed_at?: string | null
-          level?: number | null
           metadata?: Json | null
           name?: string | null
           owner?: string | null
@@ -2128,7 +2278,6 @@ export type Database = {
           created_at?: string | null
           id?: string
           last_accessed_at?: string | null
-          level?: number | null
           metadata?: Json | null
           name?: string | null
           owner?: string | null
@@ -2148,38 +2297,6 @@ export type Database = {
           },
         ]
       }
-      prefixes: {
-        Row: {
-          bucket_id: string
-          created_at: string | null
-          level: number
-          name: string
-          updated_at: string | null
-        }
-        Insert: {
-          bucket_id: string
-          created_at?: string | null
-          level?: number
-          name: string
-          updated_at?: string | null
-        }
-        Update: {
-          bucket_id?: string
-          created_at?: string | null
-          level?: number
-          name?: string
-          updated_at?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "prefixes_bucketId_fkey"
-            columns: ["bucket_id"]
-            isOneToOne: false
-            referencedRelation: "buckets"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
       s3_multipart_uploads: {
         Row: {
           bucket_id: string
@@ -2187,6 +2304,7 @@ export type Database = {
           id: string
           in_progress_size: number
           key: string
+          metadata: Json | null
           owner_id: string | null
           upload_signature: string
           user_metadata: Json | null
@@ -2198,6 +2316,7 @@ export type Database = {
           id: string
           in_progress_size?: number
           key: string
+          metadata?: Json | null
           owner_id?: string | null
           upload_signature: string
           user_metadata?: Json | null
@@ -2209,6 +2328,7 @@ export type Database = {
           id?: string
           in_progress_size?: number
           key?: string
+          metadata?: Json | null
           owner_id?: string | null
           upload_signature?: string
           user_metadata?: Json | null
@@ -2327,28 +2447,25 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
-      add_prefixes: {
-        Args: { _bucket_id: string; _name: string }
-        Returns: undefined
+      allow_any_operation: {
+        Args: { expected_operations: string[] }
+        Returns: boolean
+      }
+      allow_only_operation: {
+        Args: { expected_operation: string }
+        Returns: boolean
       }
       can_insert_object: {
         Args: { bucketid: string; metadata: Json; name: string; owner: string }
         Returns: undefined
       }
-      delete_leaf_prefixes: {
-        Args: { bucket_ids: string[]; names: string[] }
-        Returns: undefined
-      }
-      delete_prefix: {
-        Args: { _bucket_id: string; _name: string }
-        Returns: boolean
-      }
       extension: { Args: { name: string }; Returns: string }
       filename: { Args: { name: string }; Returns: string }
       foldername: { Args: { name: string }; Returns: string[] }
-      get_level: { Args: { name: string }; Returns: number }
-      get_prefix: { Args: { name: string }; Returns: string }
-      get_prefixes: { Args: { name: string }; Returns: string[] }
+      get_common_prefix: {
+        Args: { p_delimiter: string; p_key: string; p_prefix: string }
+        Returns: string
+      }
       get_size_by_bucket: {
         Args: never
         Returns: {
@@ -2373,23 +2490,22 @@ export type Database = {
       }
       list_objects_with_delimiter: {
         Args: {
-          bucket_id: string
+          _bucket_id: string
           delimiter_param: string
           max_keys?: number
           next_token?: string
           prefix_param: string
+          sort_order?: string
           start_after?: string
         }
         Returns: {
+          created_at: string
           id: string
+          last_accessed_at: string
           metadata: Json
           name: string
           updated_at: string
         }[]
-      }
-      lock_top_prefixes: {
-        Args: { bucket_ids: string[]; names: string[] }
-        Returns: undefined
       }
       operation: { Args: never; Returns: string }
       search: {
@@ -2412,40 +2528,21 @@ export type Database = {
           updated_at: string
         }[]
       }
-      search_legacy_v1: {
+      search_by_timestamp: {
         Args: {
-          bucketname: string
-          levels?: number
-          limits?: number
-          offsets?: number
-          prefix: string
-          search?: string
-          sortcolumn?: string
-          sortorder?: string
+          p_bucket_id: string
+          p_level: number
+          p_limit: number
+          p_prefix: string
+          p_sort_column: string
+          p_sort_column_after: string
+          p_sort_order: string
+          p_start_after: string
         }
         Returns: {
           created_at: string
           id: string
-          last_accessed_at: string
-          metadata: Json
-          name: string
-          updated_at: string
-        }[]
-      }
-      search_v1_optimised: {
-        Args: {
-          bucketname: string
-          levels?: number
-          limits?: number
-          offsets?: number
-          prefix: string
-          search?: string
-          sortcolumn?: string
-          sortorder?: string
-        }
-        Returns: {
-          created_at: string
-          id: string
+          key: string
           last_accessed_at: string
           metadata: Json
           name: string
@@ -2639,6 +2736,8 @@ export const Constants = {
       membership_application_status_enum: ["draft", "submitted"],
       organization_role_enum: ["admin", "member"],
       organization_type_enum: ["group", "association"],
+      payment_claim_payer_type_enum: ["applicant", "other"],
+      payment_claim_status_enum: ["under_review", "approved", "rejected"],
       payment_obligation_purpose_enum: ["initial_admission"],
       payment_obligation_status_enum: ["available", "settled", "void"],
       payment_status_enum: ["pending", "succeeded", "failed"],

--- a/supabase/migrations/20260822230811_claim_initial_pix_payment.sql
+++ b/supabase/migrations/20260822230811_claim_initial_pix_payment.sql
@@ -1,0 +1,465 @@
+do $$
+begin
+  create type public.payment_claim_payer_type_enum as enum (
+    'applicant',
+    'other'
+  );
+exception
+  when duplicate_object then null;
+end;
+$$;
+
+do $$
+begin
+  create type public.payment_claim_status_enum as enum (
+    'under_review',
+    'approved',
+    'rejected'
+  );
+exception
+  when duplicate_object then null;
+end;
+$$;
+
+create table public.payment_claims (
+  id uuid primary key default gen_random_uuid(),
+  obligation_id uuid not null references public.payment_obligations(id),
+  organization_id uuid not null references public.organizations(id),
+  claimant_user_id uuid not null references public.profiles(id),
+  payer_type public.payment_claim_payer_type_enum not null,
+  payer_name text,
+  status public.payment_claim_status_enum not null default 'under_review',
+  created_at timestamp with time zone not null default timezone('utc'::text, now()),
+  decided_at timestamp with time zone,
+  decision_reason text,
+  check (
+    (payer_type = 'applicant'::public.payment_claim_payer_type_enum
+      and payer_name is null)
+    or (
+      payer_type = 'other'::public.payment_claim_payer_type_enum
+      and nullif(btrim(payer_name), '') is not null
+      and char_length(payer_name) <= 120
+    )
+  ),
+  check (decision_reason is null or char_length(decision_reason) <= 500),
+  check (
+    status <> 'under_review'::public.payment_claim_status_enum
+    or (decided_at is null and decision_reason is null)
+  )
+);
+
+comment on table public.payment_claims is
+  'Immutable payment-claim submissions. Claim decisions are server-controlled and never settle the obligation by themselves.';
+comment on column public.payment_claims.payer_name is
+  'Normalized payer name when another person made the deposit. No receipt or banking metadata is stored.';
+comment on column public.payment_claims.status is
+  'Current server-controlled decision state. Submission evidence remains immutable; transitions are appended to payment_claim_audit_events.';
+
+create or replace function public.reject_payment_claim_evidence_mutation()
+returns trigger
+language plpgsql
+as $$
+begin
+  if tg_op = 'DELETE' then
+    raise exception 'Payment claim evidence is immutable.'
+      using errcode = '55000';
+  end if;
+
+  if old.id is distinct from new.id
+    or old.obligation_id is distinct from new.obligation_id
+    or old.organization_id is distinct from new.organization_id
+    or old.claimant_user_id is distinct from new.claimant_user_id
+    or old.payer_type is distinct from new.payer_type
+    or old.payer_name is distinct from new.payer_name
+    or old.created_at is distinct from new.created_at then
+    raise exception 'Payment claim evidence is immutable.'
+      using errcode = '55000';
+  end if;
+
+  return new;
+end;
+$$;
+
+create trigger payment_claims_evidence_immutable
+before update or delete on public.payment_claims
+for each row
+execute function public.reject_payment_claim_evidence_mutation();
+
+revoke all on function public.reject_payment_claim_evidence_mutation() from public;
+revoke all on function public.reject_payment_claim_evidence_mutation() from anon;
+revoke all on function public.reject_payment_claim_evidence_mutation() from authenticated;
+
+create unique index payment_claims_one_under_review_per_obligation_idx
+  on public.payment_claims (obligation_id)
+  where status = 'under_review'::public.payment_claim_status_enum;
+
+create index payment_claims_claimant_created_at_idx
+  on public.payment_claims (claimant_user_id, created_at desc);
+
+create index payment_claims_organization_status_idx
+  on public.payment_claims (organization_id, status, created_at desc);
+
+alter table public.payment_claims enable row level security;
+
+create policy "Claimants can read their own payment claims"
+  on public.payment_claims
+  for select
+  to authenticated
+  using ((select auth.uid()) = claimant_user_id);
+
+create policy "Organization admins can read payment claims"
+  on public.payment_claims
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.organization_members om
+      where om.organization_id = payment_claims.organization_id
+        and om.user_id = (select auth.uid())
+        and om.role = 'admin'::public.organization_role_enum
+    )
+  );
+
+revoke all on table public.payment_claims from public;
+revoke all on table public.payment_claims from anon;
+revoke all on table public.payment_claims from authenticated;
+grant select on table public.payment_claims to authenticated;
+
+create table public.payment_claim_audit_events (
+  id uuid primary key default gen_random_uuid(),
+  organization_id uuid not null references public.organizations(id),
+  obligation_id uuid not null references public.payment_obligations(id),
+  claim_id uuid not null references public.payment_claims(id),
+  actor_user_id uuid not null references public.profiles(id),
+  previous_state text not null check (
+    previous_state in ('payment_available', 'under_review', 'payment_settled')
+  ),
+  next_state text not null check (
+    next_state in ('payment_available', 'under_review', 'payment_settled')
+  ),
+  reason text check (reason is null or char_length(reason) <= 500),
+  created_at timestamp with time zone not null default timezone('utc'::text, now()),
+  unique (claim_id, next_state)
+);
+
+comment on table public.payment_claim_audit_events is
+  'Append-only claim transition evidence containing server-derived actor, obligation, claim, state change, time, and optional reason.';
+
+alter table public.payment_claim_audit_events enable row level security;
+
+create policy "Claimants can read their own payment claim audit events"
+  on public.payment_claim_audit_events
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.payment_claims pc
+      where pc.id = payment_claim_audit_events.claim_id
+        and pc.claimant_user_id = (select auth.uid())
+    )
+  );
+
+create policy "Organization admins can read payment claim audit events"
+  on public.payment_claim_audit_events
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.organization_members om
+      where om.organization_id = payment_claim_audit_events.organization_id
+        and om.user_id = (select auth.uid())
+        and om.role = 'admin'::public.organization_role_enum
+    )
+  );
+
+revoke all on table public.payment_claim_audit_events from public;
+revoke all on table public.payment_claim_audit_events from anon;
+revoke all on table public.payment_claim_audit_events from authenticated;
+grant select on table public.payment_claim_audit_events to authenticated;
+
+create or replace function public.reject_payment_claim_audit_mutation()
+returns trigger
+language plpgsql
+as $$
+begin
+  raise exception 'Payment claim audit events are immutable.'
+    using errcode = '55000';
+end;
+$$;
+
+create trigger payment_claim_audit_events_immutable
+before update or delete on public.payment_claim_audit_events
+for each row
+execute function public.reject_payment_claim_audit_mutation();
+
+revoke all on function public.reject_payment_claim_audit_mutation() from public;
+revoke all on function public.reject_payment_claim_audit_mutation() from anon;
+revoke all on function public.reject_payment_claim_audit_mutation() from authenticated;
+
+drop function if exists public.get_payment_obligation_instructions(uuid);
+
+create function public.get_payment_obligation_instructions(
+  p_obligation_id uuid
+)
+returns table (
+  obligation_id uuid,
+  organization_id uuid,
+  purpose public.payment_obligation_purpose_enum,
+  status public.payment_obligation_status_enum,
+  plan_type public.subscription_plan_type_enum,
+  amount integer,
+  currency text,
+  payment_method text,
+  pix_copy_paste text,
+  available_at timestamp with time zone,
+  claim_id uuid,
+  claim_status public.payment_claim_status_enum,
+  payer_type public.payment_claim_payer_type_enum,
+  payer_name text,
+  claim_created_at timestamp with time zone,
+  claim_decision_reason text
+)
+language sql
+security definer
+set search_path = public, pg_temp
+as $$
+  select
+    po.id,
+    po.organization_id,
+    po.purpose,
+    po.status,
+    po.plan_type,
+    po.amount,
+    po.currency,
+    po.payment_method,
+    po.pix_copy_paste,
+    po.available_at,
+    claim.id,
+    claim.status,
+    claim.payer_type,
+    claim.payer_name,
+    claim.created_at,
+    claim.decision_reason
+  from public.payment_obligations po
+  left join lateral (
+    select
+      pc.id,
+      pc.status,
+      pc.payer_type,
+      pc.payer_name,
+      pc.created_at,
+      pc.decision_reason
+    from public.payment_claims pc
+    where pc.obligation_id = po.id
+      and pc.claimant_user_id = auth.uid()
+    order by pc.created_at desc, pc.id desc
+    limit 1
+  ) claim on true
+  where po.id = p_obligation_id
+    and po.user_id = auth.uid();
+$$;
+
+comment on function public.get_payment_obligation_instructions(uuid) is
+  'Returns authoritative PIX instructions and the signed-in owner''s latest claim for an obligation.';
+
+revoke all on function public.get_payment_obligation_instructions(uuid) from public;
+revoke all on function public.get_payment_obligation_instructions(uuid) from anon;
+grant execute on function public.get_payment_obligation_instructions(uuid) to authenticated;
+
+create or replace function public.claim_initial_payment(
+  p_obligation_id uuid,
+  p_paid_by_applicant boolean,
+  p_payer_name text default null
+)
+returns table (
+  claim_id uuid,
+  obligation_id uuid,
+  payer_type public.payment_claim_payer_type_enum,
+  payer_name text,
+  claim_status public.payment_claim_status_enum,
+  claim_created_at timestamp with time zone,
+  audit_event_id uuid
+)
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  actor_id uuid := auth.uid();
+  obligation_record public.payment_obligations%rowtype;
+  existing_claim public.payment_claims%rowtype;
+  existing_audit_event public.payment_claim_audit_events%rowtype;
+  inserted_claim public.payment_claims%rowtype;
+  normalized_payer_name text;
+  inserted_audit_event public.payment_claim_audit_events%rowtype;
+begin
+  if actor_id is null then
+    raise exception 'Authentication is required.' using errcode = '42501';
+  end if;
+
+  if p_obligation_id is null or p_paid_by_applicant is null then
+    raise exception 'The payment claim request is incomplete.'
+      using errcode = '22023';
+  end if;
+
+  normalized_payer_name = nullif(
+    btrim(regexp_replace(coalesce(p_payer_name, ''), '\s+', ' ', 'g')),
+    ''
+  );
+
+  if p_paid_by_applicant and normalized_payer_name is not null then
+    raise exception 'Payer name is only allowed when another person paid.'
+      using errcode = '22023';
+  end if;
+
+  if not p_paid_by_applicant and normalized_payer_name is null then
+    raise exception 'Enter the name of the person who made the payment.'
+      using errcode = '22023';
+  end if;
+
+  if normalized_payer_name is not null
+    and char_length(normalized_payer_name) > 120 then
+    raise exception 'Payer name must be 120 characters or fewer.'
+      using errcode = '22023';
+  end if;
+
+  select po.*
+  into obligation_record
+  from public.payment_obligations po
+  where po.id = p_obligation_id
+    and po.user_id = actor_id
+  for update;
+
+  if not found then
+    raise exception 'Payment obligation is unavailable.' using errcode = '42501';
+  end if;
+
+  if obligation_record.purpose <> 'initial_admission'::public.payment_obligation_purpose_enum
+    or obligation_record.status <> 'available'::public.payment_obligation_status_enum
+    or obligation_record.payment_method <> 'manual_pix'
+    or nullif(btrim(obligation_record.pix_copy_paste), '') is null then
+    raise exception 'This payment obligation cannot be claimed.'
+      using errcode = '23514';
+  end if;
+
+  if not exists (
+    select 1
+    from public.membership_application_revisions mar
+    join public.membership_applications ma on ma.id = mar.application_id
+    where mar.id = obligation_record.application_revision_id
+      and mar.user_id = actor_id
+      and ma.status = 'submitted'::public.membership_application_status_enum
+  ) then
+    raise exception 'This payment obligation is not attached to a submitted application.'
+      using errcode = '23514';
+  end if;
+
+  select pc.*
+  into existing_claim
+  from public.payment_claims pc
+  where pc.obligation_id = obligation_record.id
+    and pc.status = 'under_review'::public.payment_claim_status_enum
+  for update;
+
+  if found then
+    if existing_claim.payer_type <> (
+      case
+        when p_paid_by_applicant then 'applicant'::public.payment_claim_payer_type_enum
+        else 'other'::public.payment_claim_payer_type_enum
+      end
+    )
+    or existing_claim.payer_name is distinct from normalized_payer_name then
+      raise exception 'A payment claim is already under review with different payer details.'
+        using errcode = '40001';
+    end if;
+
+    select pcae.*
+    into existing_audit_event
+    from public.payment_claim_audit_events pcae
+    where pcae.claim_id = existing_claim.id
+      and pcae.next_state = 'under_review'
+    order by pcae.created_at asc
+    limit 1;
+
+    return query
+    select
+      existing_claim.id,
+      existing_claim.obligation_id,
+      existing_claim.payer_type,
+      existing_claim.payer_name,
+      existing_claim.status,
+      existing_claim.created_at,
+      existing_audit_event.id;
+    return;
+  end if;
+
+  if exists (
+    select 1
+    from public.payment_claims pc
+    where pc.obligation_id = obligation_record.id
+      and pc.status = 'approved'::public.payment_claim_status_enum
+  ) then
+    raise exception 'This payment obligation has already been approved.'
+      using errcode = '23514';
+  end if;
+
+  insert into public.payment_claims (
+    obligation_id,
+    organization_id,
+    claimant_user_id,
+    payer_type,
+    payer_name,
+    status
+  )
+  values (
+    obligation_record.id,
+    obligation_record.organization_id,
+    actor_id,
+    case
+      when p_paid_by_applicant then 'applicant'::public.payment_claim_payer_type_enum
+      else 'other'::public.payment_claim_payer_type_enum
+    end,
+    case when p_paid_by_applicant then null else normalized_payer_name end,
+    'under_review'::public.payment_claim_status_enum
+  )
+  returning * into inserted_claim;
+
+  insert into public.payment_claim_audit_events (
+    organization_id,
+    obligation_id,
+    claim_id,
+    actor_user_id,
+    previous_state,
+    next_state
+  )
+  values (
+    obligation_record.organization_id,
+    obligation_record.id,
+    inserted_claim.id,
+    actor_id,
+    'payment_available',
+    'under_review'
+  )
+  returning * into inserted_audit_event;
+
+  return query
+  select
+    inserted_claim.id,
+    inserted_claim.obligation_id,
+    inserted_claim.payer_type,
+    inserted_claim.payer_name,
+    inserted_claim.status,
+    inserted_claim.created_at,
+    inserted_audit_event.id;
+end;
+$$;
+
+comment on function public.claim_initial_payment(uuid, boolean, text) is
+  'Atomically records one authenticated applicant claim for an available initial manual-PIX obligation without settling it or creating membership.';
+
+revoke all on function public.claim_initial_payment(uuid, boolean, text) from public;
+revoke all on function public.claim_initial_payment(uuid, boolean, text) from anon;
+grant execute on function public.claim_initial_payment(uuid, boolean, text) to authenticated;

--- a/supabase/migrations/20260822235839_harden_initial_pix_claim.sql
+++ b/supabase/migrations/20260822235839_harden_initial_pix_claim.sql
@@ -1,0 +1,55 @@
+-- Harden the initial PIX claim schema and its security-definer entry points.
+
+create index payment_claims_obligation_claimant_created_at_idx
+  on public.payment_claims (obligation_id, claimant_user_id, created_at desc, id desc);
+
+create index payment_claim_audit_events_organization_created_at_idx
+  on public.payment_claim_audit_events (organization_id, created_at desc);
+
+create index payment_claim_audit_events_obligation_created_at_idx
+  on public.payment_claim_audit_events (obligation_id, created_at desc);
+
+create index payment_claim_audit_events_actor_created_at_idx
+  on public.payment_claim_audit_events (actor_user_id, created_at desc);
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'payment_claims_terminal_decided_at_check'
+      and conrelid = 'public.payment_claims'::regclass
+  ) then
+    alter table public.payment_claims
+      add constraint payment_claims_terminal_decided_at_check
+      check (
+        status = 'under_review'::public.payment_claim_status_enum
+        or decided_at is not null
+      );
+  end if;
+
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'payment_claim_audit_events_transition_check'
+      and conrelid = 'public.payment_claim_audit_events'::regclass
+  ) then
+    alter table public.payment_claim_audit_events
+      add constraint payment_claim_audit_events_transition_check
+      check (
+        (previous_state = 'payment_available'
+          and next_state = 'under_review')
+        or (
+          previous_state = 'under_review'
+          and next_state in ('payment_available', 'payment_settled')
+        )
+      );
+  end if;
+end;
+$$;
+
+alter function public.get_payment_obligation_instructions(uuid)
+  set search_path = '';
+
+alter function public.claim_initial_payment(uuid, boolean, text)
+  set search_path = '';

--- a/supabase/tests/claim_initial_pix_payment_test.sql
+++ b/supabase/tests/claim_initial_pix_payment_test.sql
@@ -1,0 +1,578 @@
+BEGIN;
+
+select plan(30);
+
+-- These fixtures model the same server-owned rows created by application
+-- submission. The public command below is the seam under test.
+insert into public.organizations (
+  id,
+  name,
+  slug,
+  organization_type,
+  billing_currency,
+  membership_terms_version,
+  monthly_price_amount,
+  monthly_pix_copy_paste
+)
+values (
+  '2c9c5c8a-4e4d-4322-bb48-adf6231d2bb1'::uuid,
+  'SL.A.C',
+  'slac',
+  'association',
+  'BRL',
+  'estatuto-v1',
+  12500,
+  '000201claim-test-pix'
+)
+on conflict (id) do update
+set
+  organization_type = excluded.organization_type,
+  billing_currency = excluded.billing_currency,
+  membership_terms_version = excluded.membership_terms_version,
+  monthly_price_amount = excluded.monthly_price_amount,
+  monthly_pix_copy_paste = excluded.monthly_pix_copy_paste;
+
+insert into auth.users (
+  id,
+  aud,
+  role,
+  email,
+  email_confirmed_at,
+  raw_user_meta_data,
+  created_at,
+  updated_at
+)
+values
+  (
+    '11111111-1111-4111-8111-111111111111'::uuid,
+    'authenticated',
+    'authenticated',
+    'claim-applicant@example.com',
+    timezone('utc'::text, now()),
+    '{"full_name":"Claim Applicant"}'::jsonb,
+    timezone('utc'::text, now()),
+    timezone('utc'::text, now())
+  ),
+  (
+    '22222222-2222-4222-8222-222222222222'::uuid,
+    'authenticated',
+    'authenticated',
+    'claim-other-user@example.com',
+    timezone('utc'::text, now()),
+    '{"full_name":"Other User"}'::jsonb,
+    timezone('utc'::text, now()),
+    timezone('utc'::text, now())
+  );
+
+insert into public.membership_applications (
+  id,
+  organization_id,
+  user_id,
+  status,
+  accepted_terms_at,
+  submitted_at
+)
+values
+  (
+    'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'::uuid,
+    '2c9c5c8a-4e4d-4322-bb48-adf6231d2bb1'::uuid,
+    '11111111-1111-4111-8111-111111111111'::uuid,
+    'submitted',
+    timezone('utc'::text, now()),
+    timezone('utc'::text, now())
+  ),
+  (
+    'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'::uuid,
+    '2c9c5c8a-4e4d-4322-bb48-adf6231d2bb1'::uuid,
+    '22222222-2222-4222-8222-222222222222'::uuid,
+    'submitted',
+    timezone('utc'::text, now()),
+    timezone('utc'::text, now())
+  );
+
+insert into public.membership_application_revisions (
+  id,
+  application_id,
+  organization_id,
+  user_id,
+  revision_number,
+  draft_version,
+  plan_type,
+  terms_version,
+  accepted_terms_at,
+  submitted_at,
+  has_allergies,
+  has_dietary_restrictions,
+  plan_amount,
+  currency,
+  pix_copy_paste
+)
+values
+  (
+    'aaaaaaa1-aaaa-4aaa-8aaa-aaaaaaaaaaa1'::uuid,
+    'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'::uuid,
+    '2c9c5c8a-4e4d-4322-bb48-adf6231d2bb1'::uuid,
+    '11111111-1111-4111-8111-111111111111'::uuid,
+    1,
+    1,
+    'monthly',
+    'estatuto-v1',
+    timezone('utc'::text, now()),
+    timezone('utc'::text, now()),
+    false,
+    false,
+    12500,
+    'BRL',
+    '000201claim-test-pix'
+  ),
+  (
+    'bbbbbbb1-bbbb-4bbb-8bbb-bbbbbbbbbbb1'::uuid,
+    'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'::uuid,
+    '2c9c5c8a-4e4d-4322-bb48-adf6231d2bb1'::uuid,
+    '22222222-2222-4222-8222-222222222222'::uuid,
+    1,
+    1,
+    'monthly',
+    'estatuto-v1',
+    timezone('utc'::text, now()),
+    timezone('utc'::text, now()),
+    false,
+    false,
+    12500,
+    'BRL',
+    '000201claim-test-pix'
+  );
+
+insert into public.organization_members (organization_id, user_id, role)
+values (
+  '2c9c5c8a-4e4d-4322-bb48-adf6231d2bb1'::uuid,
+  '22222222-2222-4222-8222-222222222222'::uuid,
+  'admin'
+);
+
+insert into public.payment_obligations (
+  id,
+  organization_id,
+  user_id,
+  application_revision_id,
+  purpose,
+  status,
+  plan_type,
+  amount,
+  currency,
+  payment_method,
+  pix_copy_paste,
+  available_at
+)
+values
+  (
+    'ccccccc1-cccc-4ccc-8ccc-ccccccccccc1'::uuid,
+    '2c9c5c8a-4e4d-4322-bb48-adf6231d2bb1'::uuid,
+    '11111111-1111-4111-8111-111111111111'::uuid,
+    'aaaaaaa1-aaaa-4aaa-8aaa-aaaaaaaaaaa1'::uuid,
+    'initial_admission',
+    'available',
+    'monthly',
+    12500,
+    'BRL',
+    'manual_pix',
+    '000201claim-test-pix',
+    timezone('utc'::text, now())
+  ),
+  (
+    'ccccccc2-cccc-4ccc-8ccc-ccccccccccc2'::uuid,
+    '2c9c5c8a-4e4d-4322-bb48-adf6231d2bb1'::uuid,
+    '22222222-2222-4222-8222-222222222222'::uuid,
+    'bbbbbbb1-bbbb-4bbb-8bbb-bbbbbbbbbbb1'::uuid,
+    'initial_admission',
+    'available',
+    'monthly',
+    12500,
+    'BRL',
+    'manual_pix',
+    '000201claim-test-pix',
+    timezone('utc'::text, now())
+  )
+on conflict (id) do nothing;
+
+insert into public.payment_claims (
+  id,
+  obligation_id,
+  organization_id,
+  claimant_user_id,
+  payer_type,
+  payer_name,
+  status,
+  created_at,
+  decided_at,
+  decision_reason
+)
+values (
+    'ddddddd1-dddd-4ddd-8ddd-ddddddddddd1'::uuid,
+    'ccccccc2-cccc-4ccc-8ccc-ccccccccccc2'::uuid,
+    '2c9c5c8a-4e4d-4322-bb48-adf6231d2bb1'::uuid,
+    '22222222-2222-4222-8222-222222222222'::uuid,
+  'other',
+  'Former Payer',
+  'rejected',
+  timezone('utc'::text, now()) - interval '2 hours',
+  timezone('utc'::text, now()) - interval '1 hour',
+  'The first claim needs correction.'
+);
+
+insert into public.payment_claim_audit_events (
+  id,
+  organization_id,
+  obligation_id,
+  claim_id,
+  actor_user_id,
+  previous_state,
+  next_state,
+  created_at
+)
+values
+  (
+    'eeeeeee1-eeee-4eee-8eee-eeeeeeeeeee1'::uuid,
+    '2c9c5c8a-4e4d-4322-bb48-adf6231d2bb1'::uuid,
+    'ccccccc2-cccc-4ccc-8ccc-ccccccccccc2'::uuid,
+    'ddddddd1-dddd-4ddd-8ddd-ddddddddddd1'::uuid,
+    '22222222-2222-4222-8222-222222222222'::uuid,
+    'payment_available',
+    'under_review',
+    timezone('utc'::text, now()) - interval '2 hours'
+  ),
+  (
+    'eeeeeee2-eeee-4eee-8eee-eeeeeeeeeee2'::uuid,
+    '2c9c5c8a-4e4d-4322-bb48-adf6231d2bb1'::uuid,
+    'ccccccc2-cccc-4ccc-8ccc-ccccccccccc2'::uuid,
+    'ddddddd1-dddd-4ddd-8ddd-ddddddddddd1'::uuid,
+    '22222222-2222-4222-8222-222222222222'::uuid,
+    'under_review',
+    'payment_available',
+    timezone('utc'::text, now()) - interval '1 hour'
+  );
+
+set local role authenticated;
+select set_config('request.jwt.claim.role', 'authenticated', true);
+select set_config(
+  'request.jwt.claim.sub',
+  '11111111-1111-4111-8111-111111111111',
+  true
+);
+
+select is(
+  (select amount from public.get_payment_obligation_instructions(
+    'ccccccc1-cccc-4ccc-8ccc-ccccccccccc1'::uuid
+  )),
+  12500,
+  'the owner sees the snapshotted amount from the obligation'
+);
+
+select is(
+  (select pix_copy_paste from public.get_payment_obligation_instructions(
+    'ccccccc1-cccc-4ccc-8ccc-ccccccccccc1'::uuid
+  )),
+  '000201claim-test-pix',
+  'the owner sees the snapshotted PIX payload'
+);
+
+select is(
+  (select status::text from public.get_payment_obligation_instructions(
+    'ccccccc1-cccc-4ccc-8ccc-ccccccccccc1'::uuid
+  )),
+  'available',
+  'an unclaimed initial obligation is payment_available'
+);
+
+set local role postgres;
+
+update public.payment_obligations
+set status = 'settled'
+where id = 'ccccccc1-cccc-4ccc-8ccc-ccccccccccc1'::uuid;
+
+set local role authenticated;
+
+select throws_ok(
+  $$select * from public.claim_initial_payment(
+    'ccccccc1-cccc-4ccc-8ccc-ccccccccccc1'::uuid,
+    true,
+    null
+  )$$,
+  '23514',
+  'This payment obligation cannot be claimed.',
+  'a settled obligation cannot be claimed'
+);
+
+set local role postgres;
+
+update public.payment_obligations
+set status = 'void'
+where id = 'ccccccc1-cccc-4ccc-8ccc-ccccccccccc1'::uuid;
+
+set local role authenticated;
+
+select throws_ok(
+  $$select * from public.claim_initial_payment(
+    'ccccccc1-cccc-4ccc-8ccc-ccccccccccc1'::uuid,
+    true,
+    null
+  )$$,
+  '23514',
+  'This payment obligation cannot be claimed.',
+  'a void obligation cannot be claimed'
+);
+
+set local role postgres;
+
+update public.payment_obligations
+set status = 'available'
+where id = 'ccccccc1-cccc-4ccc-8ccc-ccccccccccc1'::uuid;
+
+set local role authenticated;
+
+create temp table first_claim as
+select *
+from public.claim_initial_payment(
+  'ccccccc1-cccc-4ccc-8ccc-ccccccccccc1'::uuid,
+  true,
+  null
+);
+
+select is(
+  (select count(*)::integer from first_claim),
+  1,
+  'a valid claim returns one authoritative result'
+);
+
+select is(
+  (select payer_type::text from first_claim),
+  'applicant',
+  'the default payer choice records the applicant'
+);
+
+select is(
+  (select claim_status::text from first_claim),
+  'under_review',
+  'a valid claim enters under_review'
+);
+
+select is(
+  (select claim_status::text from public.get_payment_obligation_instructions(
+    'ccccccc1-cccc-4ccc-8ccc-ccccccccccc1'::uuid
+  )),
+  'under_review',
+  'reopening the obligation returns the persisted under_review claim'
+);
+
+select is(
+  (select count(*)::integer
+   from public.payment_claim_audit_events
+   where claim_id = (select claim_id from first_claim)),
+  1,
+  'the claim and its first audit event are created together'
+);
+
+select is(
+  (select previous_state || ' -> ' || next_state
+   from public.payment_claim_audit_events
+   where claim_id = (select claim_id from first_claim)),
+  'payment_available -> under_review',
+  'the audit event records the applicant-facing transition'
+);
+
+select is(
+  (select count(*)::integer
+   from public.claim_initial_payment(
+     'ccccccc1-cccc-4ccc-8ccc-ccccccccccc1'::uuid,
+     true,
+     null
+   )),
+  1,
+  'an identical retry returns the existing claim'
+);
+
+select is(
+  (select count(*)::integer
+   from public.payment_claims
+   where obligation_id = 'ccccccc1-cccc-4ccc-8ccc-ccccccccccc1'::uuid),
+  1,
+  'an identical retry does not create a second claim'
+);
+
+select is(
+  (select count(*)::integer
+   from public.payment_claim_audit_events
+   where claim_id = (select claim_id from first_claim)),
+  1,
+  'an identical retry does not create a second audit event'
+);
+
+select throws_ok(
+  $$select * from public.claim_initial_payment(
+    'ccccccc1-cccc-4ccc-8ccc-ccccccccccc1'::uuid,
+    false,
+    'Another Payer'
+  )$$,
+  '40001',
+  'A payment claim is already under review with different payer details.',
+  'a conflicting retry cannot overwrite payer details'
+);
+
+select set_config(
+  'request.jwt.claim.sub',
+  '22222222-2222-4222-8222-222222222222',
+  true
+);
+
+select throws_ok(
+  $$select * from public.claim_initial_payment(
+    'ccccccc2-cccc-4ccc-8ccc-ccccccccccc2'::uuid,
+    false,
+    '   '
+  )$$,
+  '22023',
+  'Enter the name of the person who made the payment.',
+  'another payer requires a nonblank name'
+);
+
+create temp table retried_claim as
+select *
+from public.claim_initial_payment(
+  'ccccccc2-cccc-4ccc-8ccc-ccccccccccc2'::uuid,
+  false,
+  '  Ana   Maria  '
+);
+
+select is(
+  (select payer_name from retried_claim),
+  'Ana Maria',
+  'the server normalizes another payer name'
+);
+
+select is(
+  (select count(*)::integer
+   from public.payment_claims
+   where obligation_id = 'ccccccc2-cccc-4ccc-8ccc-ccccccccccc2'::uuid),
+  2,
+  'a retry after rejection creates a new claim'
+);
+
+select is(
+  (select decision_reason
+   from public.payment_claims
+   where id = 'ddddddd1-dddd-4ddd-8ddd-ddddddddddd1'::uuid),
+  'The first claim needs correction.',
+  'the rejected claim and its decision reason remain preserved'
+);
+
+select set_config(
+  'request.jwt.claim.sub',
+  '11111111-1111-4111-8111-111111111111',
+  true
+);
+
+select is(
+  (select status::text from public.payment_obligations
+   where id = 'ccccccc1-cccc-4ccc-8ccc-ccccccccccc1'::uuid),
+  'available',
+  'claiming does not settle the obligation'
+);
+
+select is(
+  (select count(*)::integer from public.organization_members
+   where organization_id = '2c9c5c8a-4e4d-4322-bb48-adf6231d2bb1'::uuid
+     and user_id = '11111111-1111-4111-8111-111111111111'::uuid),
+  0,
+  'claiming does not create membership'
+);
+
+select is(
+  (select count(*)::integer from public.payments
+   where organization_id = '2c9c5c8a-4e4d-4322-bb48-adf6231d2bb1'::uuid
+     and user_id = '11111111-1111-4111-8111-111111111111'::uuid),
+  0,
+  'claiming does not create or settle a legacy payment'
+);
+
+select is(
+  (select count(*)::integer from public.get_payment_obligation_instructions(
+    'ccccccc1-cccc-4ccc-8ccc-ccccccccccc1'::uuid
+  )),
+  1,
+  'the owner can read exactly their obligation'
+);
+
+select set_config(
+  'request.jwt.claim.sub',
+  '22222222-2222-4222-8222-222222222222',
+  true
+);
+
+select is(
+  (select count(*)::integer from public.get_payment_obligation_instructions(
+    'ccccccc1-cccc-4ccc-8ccc-ccccccccccc1'::uuid
+  )),
+  0,
+  'another authenticated person cannot read the obligation'
+);
+
+select is(
+  (select count(*)::integer
+   from public.payment_claims
+   where obligation_id = 'ccccccc1-cccc-4ccc-8ccc-ccccccccccc1'::uuid),
+  1,
+  'an organization admin can read the applicant claim'
+);
+
+select is(
+  (select count(*)::integer
+   from public.payment_claim_audit_events
+   where obligation_id = 'ccccccc1-cccc-4ccc-8ccc-ccccccccccc1'::uuid),
+  1,
+  'an organization admin can read the claim audit event'
+);
+
+set local role service_role;
+
+select throws_ok(
+  $$update public.payment_claims
+    set payer_name = 'Tampered Payer'
+    where id = (
+      select id
+      from public.payment_claims
+      where obligation_id = 'ccccccc1-cccc-4ccc-8ccc-ccccccccccc1'::uuid
+    )$$,
+  '55000',
+  'Payment claim evidence is immutable.',
+  'claim evidence cannot be mutated even with server-side table access'
+);
+
+set local role authenticated;
+
+select throws_ok(
+  $$select * from public.claim_initial_payment(
+    'ccccccc1-cccc-4ccc-8ccc-ccccccccccc1'::uuid,
+    true,
+    null
+  )$$,
+  '42501',
+  'Payment obligation is unavailable.',
+  'another authenticated person cannot claim the obligation'
+);
+
+select ok(
+  not has_table_privilege('authenticated', 'public.payment_claims', 'INSERT'),
+  'authenticated clients cannot insert payment claims directly'
+);
+
+select ok(
+  not has_function_privilege(
+    'anon',
+    'public.claim_initial_payment(uuid,boolean,text)',
+    'EXECUTE'
+  ),
+  'anonymous callers cannot execute the claim command'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/claim_initial_pix_payment_test.sql
+++ b/supabase/tests/claim_initial_pix_payment_test.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-select plan(30);
+select plan(32);
 
 -- These fixtures model the same server-owned rows created by application
 -- submission. The public command below is the seam under test.
@@ -545,6 +545,45 @@ select throws_ok(
   '55000',
   'Payment claim evidence is immutable.',
   'claim evidence cannot be mutated even with server-side table access'
+);
+
+select throws_ok(
+  $$update public.payment_claims
+    set status = 'rejected', decided_at = null
+    where id = (
+      select id
+      from public.payment_claims
+      where obligation_id = 'ccccccc1-cccc-4ccc-8ccc-ccccccccccc1'::uuid
+    )$$,
+  '23514',
+  null,
+  'terminal claims require a decision timestamp'
+);
+
+select throws_ok(
+  $$insert into public.payment_claim_audit_events (
+    organization_id,
+    obligation_id,
+    claim_id,
+    actor_user_id,
+    previous_state,
+    next_state
+  )
+  values (
+    '2c9c5c8a-4e4d-4322-bb48-adf6231d2bb1'::uuid,
+    'ccccccc1-cccc-4ccc-8ccc-ccccccccccc1'::uuid,
+    (
+      select id
+      from public.payment_claims
+      where obligation_id = 'ccccccc1-cccc-4ccc-8ccc-ccccccccccc1'::uuid
+    ),
+    '11111111-1111-4111-8111-111111111111'::uuid,
+    'payment_available',
+    'payment_available'
+  )$$,
+  '23514',
+  null,
+  'audit events reject invalid state transitions'
 );
 
 set local role authenticated;


### PR DESCRIPTION
Closes #206

## Summary

- Add the authenticated, idempotent initial-PIX claim command with normalized payer details and append-only audit evidence.
- Keep settlement, membership, and admission effects separate from the applicant claim.
- Surface authoritative PIX instructions and persisted claim status in the mobile payment screen, including retry and rejected-claim resubmission states.
- Restrict claim data to applicants and organization admins, and protect submitted evidence from mutation.
- Harden the claim schema with FK/query indexes, valid state-transition constraints, terminal decision timestamps, and empty search paths for security-definer functions.

## Verification

- `pnpm --dir expo exec jest --runInBand --watchman=false` — 89 tests passed
- `pnpm --dir expo exec tsc --noEmit`
- Focused ESLint on changed mobile files
- `supabase test db supabase/tests/claim_initial_pix_payment_test.sql --local` — 32 tests passed
- `supabase db lint --local --schema public --fail-on error`
- Read-only local EXPLAIN checks confirmed the new claim and audit indexes are used
