### PR TITLE
feat: verify initial payment and admit member

### DIFF
--- a/next/app/[locale]/admin/claims/_components/initial-payment-claim-formatters.ts
+++ b/next/app/[locale]/admin/claims/_components/initial-payment-claim-formatters.ts
@@ -1,0 +1,30 @@
+const DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  dateStyle: "medium",
+  timeStyle: "short",
+  timeZone: "UTC",
+});
+
+const CURRENCY_FORMATTERS = new Map([
+  [
+    "BRL",
+    new Intl.NumberFormat("pt-BR", {
+      currency: "BRL",
+      maximumFractionDigits: 2,
+      minimumFractionDigits: 2,
+      style: "currency",
+    }),
+  ],
+]);
+
+export function formatAmount(amount: number, currency: string) {
+  return (
+    CURRENCY_FORMATTERS.get(currency) ?? CURRENCY_FORMATTERS.get("BRL")!
+  ).format(amount / 100);
+}
+
+export function formatDate(value: string | null | undefined) {
+  if (!value) return "—";
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? "—" : DATE_FORMATTER.format(date);
+}

--- a/next/app/[locale]/admin/claims/_components/initial-payment-claim-review.tsx
+++ b/next/app/[locale]/admin/claims/_components/initial-payment-claim-review.tsx
@@ -1,0 +1,594 @@
+import Image from "next/image";
+import {
+  AlertTriangle,
+  CalendarDays,
+  Check,
+  CheckCircle2,
+  Clock3,
+  FileText,
+  Loader2,
+  UserRound,
+  X,
+  XCircle,
+} from "lucide-react";
+import type { ReactNode } from "react";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import type {
+  InitialPaymentClaimDetail,
+  InitialPaymentClaimQueueRow,
+} from "@/lib/initial-payment-claims";
+
+const DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  dateStyle: "medium",
+  timeStyle: "short",
+  timeZone: "UTC",
+});
+const CURRENCY_FORMATTERS = new Map([
+  [
+    "BRL",
+    new Intl.NumberFormat("pt-BR", {
+      currency: "BRL",
+      maximumFractionDigits: 2,
+      minimumFractionDigits: 2,
+      style: "currency",
+    }),
+  ],
+]);
+
+export function formatAmount(amount: number, currency: string) {
+  return (
+    CURRENCY_FORMATTERS.get(currency) ?? CURRENCY_FORMATTERS.get("BRL")!
+  ).format(amount / 100);
+}
+
+export function formatDate(value: string | null | undefined) {
+  if (!value) return "—";
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? "—" : DATE_FORMATTER.format(date);
+}
+
+export function getInitials(name: string | null, handle: string | null) {
+  const source = name?.trim() || handle?.replace(/^@/, "") || "Applicant";
+  const initials = source
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((part) => part[0])
+    .join("")
+    .toUpperCase();
+
+  return initials || "A";
+}
+
+export function getHistory(value: unknown) {
+  return Array.isArray(value)
+    ? value.filter(
+        (entry): entry is Record<string, unknown> =>
+          typeof entry === "object" && entry !== null,
+      )
+    : [];
+}
+
+export function QueueStatusBadge({
+  status,
+}: {
+  status: InitialPaymentClaimQueueRow["claim_status"];
+}) {
+  return (
+    <Badge
+      variant="outline"
+      className="border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+    >
+      <Clock3 className="mr-1.5 size-3.5" aria-hidden="true" />
+      {status === "under_review" ? "Awaiting review" : status}
+    </Badge>
+  );
+}
+
+export function ApplicantAvatar({
+  name,
+  handle,
+  picture,
+  size = "md",
+}: {
+  name: string | null;
+  handle: string | null;
+  picture: string | null;
+  size?: "sm" | "md";
+}) {
+  const sizeClass = size === "sm" ? "size-10 text-sm" : "size-14 text-base";
+
+  return (
+    <div
+      className={`relative flex ${sizeClass} shrink-0 items-center justify-center overflow-hidden rounded-full bg-muted font-semibold text-muted-foreground outline outline-1 outline-black/10 dark:outline-white/10`}
+    >
+      {picture ? (
+        <Image
+          src={picture}
+          alt=""
+          fill
+          sizes={size === "sm" ? "40px" : "56px"}
+          className="object-cover"
+          loading="lazy"
+        />
+      ) : (
+        getInitials(name, handle)
+      )}
+    </div>
+  );
+}
+
+export type ReviewAction = "approve" | "reject" | null;
+
+export function InitialPaymentClaimReview({
+  action,
+  actionError,
+  detail,
+  detailLoading,
+  onApprove,
+  onClose,
+  onReject,
+  rejectionReason,
+  onRejectionReasonChange,
+}: {
+  action: ReviewAction;
+  actionError: string | null;
+  detail: InitialPaymentClaimDetail | null;
+  detailLoading: boolean;
+  onApprove: () => Promise<void>;
+  onClose: () => void;
+  onReject: () => Promise<void>;
+  rejectionReason: string;
+  onRejectionReasonChange: (value: string) => void;
+}) {
+  return (
+    <div className="flex max-h-[90vh] flex-col bg-background">
+      <ReviewHeader action={action} detail={detail} onClose={onClose} />
+      <ReviewDetails
+        actionError={actionError}
+        detail={detail}
+        detailLoading={detailLoading}
+      />
+      <ReviewActions
+        action={action}
+        detail={detail}
+        onApprove={onApprove}
+        onReject={onReject}
+        rejectionReason={rejectionReason}
+        onRejectionReasonChange={onRejectionReasonChange}
+      />
+    </div>
+  );
+}
+
+function ReviewHeader({
+  action,
+  detail,
+  onClose,
+}: {
+  action: ReviewAction;
+  detail: InitialPaymentClaimDetail | null;
+  onClose: () => void;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-4 border-b px-5 py-5 md:px-7">
+      <div className="flex min-w-0 items-center gap-3">
+        {detail ? (
+          <ApplicantAvatar
+            name={detail.applicant_name}
+            handle={detail.applicant_handle}
+            picture={detail.applicant_profile_picture}
+          />
+        ) : (
+          <span className="flex size-14 shrink-0 items-center justify-center rounded-full bg-muted">
+            <UserRound
+              className="size-6 text-muted-foreground"
+              aria-hidden="true"
+            />
+          </span>
+        )}
+        <div className="min-w-0">
+          <p className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
+            Initial claim review
+          </p>
+          <h2 className="mt-1 truncate text-xl font-semibold">
+            {detail?.applicant_name || "Loading applicant"}
+          </h2>
+          <p className="truncate text-sm text-muted-foreground">
+            {detail?.applicant_handle || detail?.organization_name || ""}
+          </p>
+        </div>
+      </div>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        onClick={onClose}
+        disabled={action !== null}
+        aria-label="Close review"
+        className="shrink-0 rounded-xl"
+      >
+        <X className="size-5" aria-hidden="true" />
+      </Button>
+    </div>
+  );
+}
+
+function ReviewDetails({
+  actionError,
+  detail,
+  detailLoading,
+}: {
+  actionError: string | null;
+  detail: InitialPaymentClaimDetail | null;
+  detailLoading: boolean;
+}) {
+  const claimHistory = getHistory(detail?.claim_history);
+  const auditHistory = getHistory(detail?.audit_history);
+
+  return (
+    <div className="scrollbar overflow-y-auto px-5 py-5 md:px-7 md:py-6">
+      {detailLoading ? (
+        <div className="flex min-h-72 items-center justify-center">
+          <Loader2
+            className="size-7 animate-spin text-muted-foreground"
+            aria-label="Loading claim details"
+          />
+        </div>
+      ) : !detail ? (
+        <div className="flex min-h-72 items-center justify-center">
+          <Alert variant="destructive" className="max-w-lg">
+            <AlertTriangle className="size-4" aria-hidden="true" />
+            <AlertTitle>Review unavailable</AlertTitle>
+            <AlertDescription>
+              {actionError || "Refresh the queue and try again."}
+            </AlertDescription>
+          </Alert>
+        </div>
+      ) : (
+        <div className="space-y-6">
+          <div className="flex flex-wrap items-center gap-2">
+            <QueueStatusBadge status={detail.claim_status} />
+            <Badge variant="secondary">Revision {detail.revision_number}</Badge>
+            <Badge variant="secondary">{detail.organization_name}</Badge>
+          </div>
+
+          {actionError ? (
+            <Alert variant="destructive" aria-live="assertive">
+              <AlertTriangle className="size-4" aria-hidden="true" />
+              <AlertTitle>Decision not completed</AlertTitle>
+              <AlertDescription>{actionError}</AlertDescription>
+            </Alert>
+          ) : null}
+
+          <div className="grid gap-3 sm:grid-cols-3">
+            <SummaryCard
+              label="Claim amount"
+              value={formatAmount(detail.amount, detail.currency)}
+            />
+            <SummaryCard
+              label="Plan"
+              value={detail.plan_type === "annual" ? "Annual" : "Monthly"}
+            />
+            <SummaryCard
+              label="Submitted"
+              value={formatDate(detail.claim_created_at)}
+            />
+          </div>
+
+          <section aria-labelledby="payment-evidence-title">
+            <SectionHeading
+              id="payment-evidence-title"
+              icon={<CheckCircle2 className="size-4" aria-hidden="true" />}
+              title="Payment evidence"
+            />
+            <div className="mt-3 grid gap-x-6 gap-y-4 rounded-2xl border bg-muted/20 p-4 sm:grid-cols-2">
+              <DetailField label="Payer">
+                {detail.payer_type === "applicant"
+                  ? "Applicant"
+                  : detail.payer_name || "Other payer"}
+              </DetailField>
+              <DetailField label="Claim attempts">
+                {detail.attempt_count}
+              </DetailField>
+              <DetailField label="Claim created">
+                {formatDate(detail.claim_created_at)}
+              </DetailField>
+              <DetailField label="Terms version">
+                {detail.terms_version}
+              </DetailField>
+            </div>
+          </section>
+
+          <ApplicationRevision detail={detail} />
+
+          {claimHistory.length > 0 || auditHistory.length > 0 ? (
+            <ClaimHistory
+              claimHistory={claimHistory}
+              auditHistory={auditHistory}
+            />
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ApplicationRevision({
+  detail,
+}: {
+  detail: InitialPaymentClaimDetail;
+}) {
+  return (
+    <section aria-labelledby="application-title">
+      <SectionHeading
+        id="application-title"
+        icon={<FileText className="size-4" aria-hidden="true" />}
+        title="Submitted application revision"
+      />
+      <div className="mt-3 grid gap-x-6 gap-y-4 rounded-2xl border bg-muted/20 p-4 sm:grid-cols-2">
+        <DetailField label="Full name">{detail.full_name}</DetailField>
+        <DetailField label="Handle">{detail.applicant_handle}</DetailField>
+        <DetailField label="Birth date">{detail.birth_date}</DetailField>
+        <DetailField label="Nationality">{detail.nationality}</DetailField>
+        <DetailField label="Marital status">
+          {detail.marital_status}
+        </DetailField>
+        <DetailField label="Profession">{detail.profession}</DetailField>
+        <DetailField label="Birthplace">{detail.birthplace}</DetailField>
+        <DetailField label="Email">{detail.email}</DetailField>
+        <DetailField label="Phone">{detail.phone}</DetailField>
+        <DetailField label="CPF">{detail.cpf}</DetailField>
+        <DetailField label="ID document">
+          {detail.id_document_number}
+        </DetailField>
+        <DetailField label="Issuing authority">
+          {detail.id_document_issuer}
+        </DetailField>
+        <DetailField label="Postal code">{detail.postal_code}</DetailField>
+        <DetailField label="Address">{detail.address_line}</DetailField>
+        <DetailField label="City / state">
+          {[detail.city, detail.state].filter(Boolean).join(" / ")}
+        </DetailField>
+        <DetailField label="Blood type">{detail.blood_type}</DetailField>
+        <DetailField label="Allergies">
+          {detail.has_allergies ? detail.allergies : "None reported"}
+        </DetailField>
+        <DetailField label="Dietary restrictions">
+          {detail.has_dietary_restrictions
+            ? detail.dietary_restrictions
+            : "None reported"}
+        </DetailField>
+        <DetailField label="Highline experience">
+          {detail.highline_experience}
+        </DetailField>
+        <DetailField label="Rescue course">
+          {detail.has_rescue_course ? "Yes" : "No"}
+        </DetailField>
+        <DetailField label="First-aid course">
+          {detail.first_aid_course}
+        </DetailField>
+        <DetailField label="Emergency contact">
+          {[
+            detail.emergency_contact_name,
+            detail.emergency_contact_relationship,
+            detail.emergency_contact_phone,
+          ]
+            .filter(Boolean)
+            .join(" · ")}
+        </DetailField>
+      </div>
+    </section>
+  );
+}
+
+function ClaimHistory({
+  auditHistory,
+  claimHistory,
+}: {
+  auditHistory: Record<string, unknown>[];
+  claimHistory: Record<string, unknown>[];
+}) {
+  return (
+    <section aria-labelledby="history-title">
+      <SectionHeading
+        id="history-title"
+        icon={<CalendarDays className="size-4" aria-hidden="true" />}
+        title="Immutable history"
+      />
+      <div className="mt-3 grid gap-3 rounded-2xl border bg-muted/20 p-4 lg:grid-cols-2">
+        <HistoryColumn title="Claim states">
+          {claimHistory.map((history) => (
+            <div
+              key={String(history.claim_id)}
+              className="flex flex-wrap items-center justify-between gap-2 text-sm"
+            >
+              <span className="font-medium">{String(history.status)}</span>
+              <span className="text-muted-foreground">
+                {formatDate(String(history.created_at))}
+                {history.decision_reason
+                  ? ` · ${String(history.decision_reason)}`
+                  : ""}
+              </span>
+            </div>
+          ))}
+        </HistoryColumn>
+        <HistoryColumn title="Audit events">
+          {auditHistory.map((history) => (
+            <div
+              key={String(history.id)}
+              className="flex flex-wrap items-center justify-between gap-2 text-sm"
+            >
+              <span className="font-medium">
+                {String(history.previous_state)} → {String(history.next_state)}
+              </span>
+              <span className="text-muted-foreground">
+                {formatDate(String(history.created_at))}
+                {history.reason ? ` · ${String(history.reason)}` : ""}
+              </span>
+            </div>
+          ))}
+        </HistoryColumn>
+      </div>
+    </section>
+  );
+}
+
+function ReviewActions({
+  action,
+  detail,
+  onApprove,
+  onReject,
+  rejectionReason,
+  onRejectionReasonChange,
+}: {
+  action: ReviewAction;
+  detail: InitialPaymentClaimDetail | null;
+  onApprove: () => Promise<void>;
+  onReject: () => Promise<void>;
+  rejectionReason: string;
+  onRejectionReasonChange: (value: string) => void;
+}) {
+  if (!detail) return null;
+
+  if (detail.claim_status !== "under_review") {
+    return (
+      <div className="border-t bg-muted/20 px-5 py-4 md:px-7">
+        <div className="flex items-start gap-3 text-sm text-muted-foreground">
+          {detail.claim_status === "approved" ? (
+            <CheckCircle2
+              className="mt-0.5 size-5 shrink-0 text-emerald-600"
+              aria-hidden="true"
+            />
+          ) : (
+            <XCircle
+              className="mt-0.5 size-5 shrink-0 text-destructive"
+              aria-hidden="true"
+            />
+          )}
+          <p>
+            This claim is {detail.claim_status}. The authoritative state has
+            been preserved; close this review and refresh the queue.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-t bg-card px-5 py-4 md:px-7">
+      <label htmlFor="rejection-reason" className="text-sm font-medium">
+        Rejection reason
+        <span className="ml-1 text-destructive" aria-hidden="true">
+          *
+        </span>
+      </label>
+      <Textarea
+        id="rejection-reason"
+        value={rejectionReason}
+        onChange={(event) => onRejectionReasonChange(event.target.value)}
+        maxLength={500}
+        placeholder="Explain what the applicant needs to correct."
+        className="mt-2 min-h-20 rounded-xl"
+        disabled={action !== null}
+      />
+      <div className="mt-3 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+        <Button
+          type="button"
+          variant="destructive"
+          onClick={() => void onReject()}
+          disabled={action !== null}
+          className="h-11 rounded-xl px-5 active:scale-[0.96]"
+        >
+          {action === "reject" ? (
+            <Loader2 className="mr-2 size-4 animate-spin" aria-hidden="true" />
+          ) : (
+            <XCircle className="mr-2 size-4" aria-hidden="true" />
+          )}
+          Reject claim
+        </Button>
+        <Button
+          type="button"
+          onClick={() => void onApprove()}
+          disabled={action !== null}
+          className="h-11 rounded-xl px-5 active:scale-[0.96]"
+        >
+          {action === "approve" ? (
+            <Loader2 className="mr-2 size-4 animate-spin" aria-hidden="true" />
+          ) : (
+            <Check className="mr-2 size-4" aria-hidden="true" />
+          )}
+          Verify payment and admit member.
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function SummaryCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-2xl border bg-card p-4 shadow-sm">
+      <p className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
+        {label}
+      </p>
+      <p className="mt-2 truncate font-semibold tabular-nums">{value}</p>
+    </div>
+  );
+}
+
+function SectionHeading({
+  icon,
+  id,
+  title,
+}: {
+  icon: ReactNode;
+  id: string;
+  title: string;
+}) {
+  return (
+    <h3 id={id} className="flex items-center gap-2 text-sm font-semibold">
+      <span className="text-muted-foreground">{icon}</span>
+      {title}
+    </h3>
+  );
+}
+
+function DetailField({
+  children,
+  label,
+}: {
+  children: ReactNode;
+  label: string;
+}) {
+  return (
+    <div className="min-w-0">
+      <dt className="text-xs font-medium uppercase tracking-[0.08em] text-muted-foreground">
+        {label}
+      </dt>
+      <dd className="mt-1 break-words text-sm font-medium">
+        {children || "—"}
+      </dd>
+    </div>
+  );
+}
+
+function HistoryColumn({
+  children,
+  title,
+}: {
+  children: ReactNode;
+  title: string;
+}) {
+  return (
+    <div>
+      <p className="text-xs font-medium uppercase tracking-[0.08em] text-muted-foreground">
+        {title}
+      </p>
+      <div className="mt-2 space-y-2">{children}</div>
+    </div>
+  );
+}

--- a/next/app/[locale]/admin/claims/_components/initial-payment-claim-review.tsx
+++ b/next/app/[locale]/admin/claims/_components/initial-payment-claim-review.tsx
@@ -22,37 +22,9 @@ import type {
   InitialPaymentClaimQueueRow,
 } from "@/lib/initial-payment-claims";
 
-const DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
-  dateStyle: "medium",
-  timeStyle: "short",
-  timeZone: "UTC",
-});
-const CURRENCY_FORMATTERS = new Map([
-  [
-    "BRL",
-    new Intl.NumberFormat("pt-BR", {
-      currency: "BRL",
-      maximumFractionDigits: 2,
-      minimumFractionDigits: 2,
-      style: "currency",
-    }),
-  ],
-]);
+import { formatAmount, formatDate } from "./initial-payment-claim-formatters";
 
-export function formatAmount(amount: number, currency: string) {
-  return (
-    CURRENCY_FORMATTERS.get(currency) ?? CURRENCY_FORMATTERS.get("BRL")!
-  ).format(amount / 100);
-}
-
-export function formatDate(value: string | null | undefined) {
-  if (!value) return "—";
-
-  const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? "—" : DATE_FORMATTER.format(date);
-}
-
-export function getInitials(name: string | null, handle: string | null) {
+function getInitials(name: string | null, handle: string | null) {
   const source = name?.trim() || handle?.replace(/^@/, "") || "Applicant";
   const initials = source
     .split(/\s+/)
@@ -64,7 +36,7 @@ export function getInitials(name: string | null, handle: string | null) {
   return initials || "A";
 }
 
-export function getHistory(value: unknown) {
+function getHistory(value: unknown) {
   return Array.isArray(value)
     ? value.filter(
         (entry): entry is Record<string, unknown> =>

--- a/next/app/[locale]/admin/claims/_components/initial-payment-claims-list.tsx
+++ b/next/app/[locale]/admin/claims/_components/initial-payment-claims-list.tsx
@@ -1,0 +1,189 @@
+import { CheckCircle2, ChevronRight, FileText, Search } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import type { InitialPaymentClaimQueueRow } from "@/lib/initial-payment-claims";
+import {
+  ApplicantAvatar,
+  formatAmount,
+  formatDate,
+  QueueStatusBadge,
+} from "./initial-payment-claim-review";
+
+export type QueueStatusFilter = "all" | "under_review";
+export type QueueSort = "oldest" | "newest" | "amount" | "applicant";
+
+function statusLabel(status: QueueStatusFilter) {
+  return status === "all" ? "All current claims" : "Awaiting review";
+}
+
+export function InitialPaymentClaimsList({
+  claims,
+  initialClaimsCount,
+  onOpenClaim,
+  onSearchChange,
+  onSortChange,
+  onStatusFilterChange,
+  search,
+  sort,
+  statusFilter,
+}: {
+  claims: InitialPaymentClaimQueueRow[];
+  initialClaimsCount: number;
+  onOpenClaim: (claimId: string) => void;
+  onSearchChange: (value: string) => void;
+  onSortChange: (value: QueueSort) => void;
+  onStatusFilterChange: (value: QueueStatusFilter) => void;
+  search: string;
+  sort: QueueSort;
+  statusFilter: QueueStatusFilter;
+}) {
+  return (
+    <Card className="mt-8 overflow-hidden rounded-3xl border-0 shadow-[0_20px_70px_-40px_hsl(var(--foreground)/0.45)]">
+      <CardHeader className="border-b bg-card/80 pb-5">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <CardTitle>Queue</CardTitle>
+            <CardDescription className="mt-1">
+              Current initial claims from the associations you administer.
+            </CardDescription>
+          </div>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <label className="relative block min-w-0 sm:w-72">
+              <span className="sr-only">Search claims</span>
+              <Search
+                className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+                aria-hidden="true"
+              />
+              <Input
+                type="search"
+                value={search}
+                onChange={(event) => onSearchChange(event.target.value)}
+                placeholder="Search applicant or payer"
+                className="h-11 rounded-xl pl-9"
+              />
+            </label>
+            <label>
+              <span className="sr-only">Filter payment state</span>
+              <select
+                value={statusFilter}
+                onChange={(event) =>
+                  onStatusFilterChange(event.target.value as QueueStatusFilter)
+                }
+                className="h-11 min-w-44 rounded-xl border border-input bg-background px-3 text-sm shadow-sm outline-none focus:ring-1 focus:ring-ring"
+              >
+                <option value="all">{statusLabel("all")}</option>
+                <option value="under_review">
+                  {statusLabel("under_review")}
+                </option>
+              </select>
+            </label>
+            <label>
+              <span className="sr-only">Sort claims</span>
+              <select
+                value={sort}
+                onChange={(event) =>
+                  onSortChange(event.target.value as QueueSort)
+                }
+                className="h-11 min-w-40 rounded-xl border border-input bg-background px-3 text-sm shadow-sm outline-none focus:ring-1 focus:ring-ring"
+              >
+                <option value="oldest">Oldest first</option>
+                <option value="newest">Newest first</option>
+                <option value="amount">Highest amount</option>
+                <option value="applicant">Applicant name</option>
+              </select>
+            </label>
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent className="p-0">
+        {claims.length === 0 ? (
+          <div className="flex min-h-72 flex-col items-center justify-center px-6 py-16 text-center">
+            <span className="flex size-14 items-center justify-center rounded-full bg-emerald-500/10 text-emerald-600 dark:text-emerald-400">
+              <CheckCircle2 className="size-7" aria-hidden="true" />
+            </span>
+            <h2 className="mt-5 text-xl font-semibold">
+              {initialClaimsCount === 0
+                ? "The queue is clear"
+                : "No claims match these filters"}
+            </h2>
+            <p className="mt-2 max-w-md text-sm text-muted-foreground">
+              {initialClaimsCount === 0
+                ? "New initial payment claims will appear here when an applicant submits one."
+                : "Try clearing the search or changing the sort and payment-state filters."}
+            </p>
+          </div>
+        ) : (
+          <ul aria-label="Initial payment claims" className="list-none p-0">
+            {claims.map((claim) => (
+              <li key={claim.claim_id}>
+                <button
+                  type="button"
+                  onClick={() => onOpenClaim(claim.claim_id)}
+                  className="group grid w-full grid-cols-[auto_1fr_auto] items-center gap-4 px-5 py-4 text-left transition-[background-color,transform] duration-200 hover:bg-muted/40 focus-visible:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring active:scale-[0.996] md:grid-cols-[minmax(14rem,1.7fr)_minmax(8rem,0.8fr)_minmax(8rem,0.7fr)_minmax(8rem,0.7fr)_auto] md:px-6"
+                >
+                  <div className="flex min-w-0 items-center gap-3">
+                    <ApplicantAvatar
+                      name={claim.applicant_name}
+                      handle={claim.applicant_handle}
+                      picture={claim.applicant_profile_picture}
+                      size="sm"
+                    />
+                    <div className="min-w-0">
+                      <p className="truncate font-semibold">
+                        {claim.applicant_name || "Unnamed applicant"}
+                      </p>
+                      <p className="truncate text-sm text-muted-foreground">
+                        {claim.applicant_handle || "No handle"}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="hidden min-w-0 md:block">
+                    <p className="truncate text-sm font-medium">
+                      {claim.payer_type === "applicant"
+                        ? "Applicant"
+                        : claim.payer_name || "Other payer"}
+                    </p>
+                    <p className="text-xs text-muted-foreground">Payer</p>
+                  </div>
+                  <div className="hidden md:block">
+                    <p className="font-semibold">
+                      {claim.plan_type === "annual" ? "Annual" : "Monthly"}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {claim.attempt_count} attempt
+                      {claim.attempt_count === 1 ? "" : "s"}
+                    </p>
+                  </div>
+                  <div className="hidden md:block">
+                    <p className="font-semibold tabular-nums">
+                      {formatAmount(claim.amount, claim.currency)}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {formatDate(claim.claim_created_at)}
+                    </p>
+                  </div>
+                  <div className="flex items-center justify-end gap-3">
+                    <QueueStatusBadge status={claim.claim_status} />
+                    <ChevronRight
+                      className="size-5 text-muted-foreground transition-transform duration-200 group-hover:translate-x-0.5"
+                      aria-hidden="true"
+                    />
+                  </div>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/next/app/[locale]/admin/claims/_components/initial-payment-claims-list.tsx
+++ b/next/app/[locale]/admin/claims/_components/initial-payment-claims-list.tsx
@@ -10,10 +10,10 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import type { InitialPaymentClaimQueueRow } from "@/lib/initial-payment-claims";
+
+import { formatAmount, formatDate } from "./initial-payment-claim-formatters";
 import {
   ApplicantAvatar,
-  formatAmount,
-  formatDate,
   QueueStatusBadge,
 } from "./initial-payment-claim-review";
 

--- a/next/app/[locale]/admin/claims/_components/initial-payment-claims-queue.tsx
+++ b/next/app/[locale]/admin/claims/_components/initial-payment-claims-queue.tsx
@@ -1,34 +1,8 @@
 "use client";
 
-/* eslint-disable @next/next/no-img-element */
+import { ShieldCheck } from "lucide-react";
+import { useMemo, useReducer } from "react";
 
-import {
-  AlertTriangle,
-  CalendarDays,
-  Check,
-  CheckCircle2,
-  ChevronRight,
-  Clock3,
-  FileText,
-  Loader2,
-  Search,
-  ShieldCheck,
-  UserRound,
-  X,
-  XCircle,
-} from "lucide-react";
-import { useMemo, useState, type ReactNode } from "react";
-
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import {
   Dialog,
   DialogContent,
@@ -43,49 +17,139 @@ import {
   DrawerHeader,
   DrawerTitle,
 } from "@/components/ui/drawer";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
 import { useRouter } from "@/i18n/navigation";
-import {
-  type InitialPaymentClaimDetail,
-  type InitialPaymentClaimQueueRow,
+import type {
+  InitialPaymentClaimDetail,
+  InitialPaymentClaimQueueRow,
 } from "@/lib/initial-payment-claims";
 import { supabaseBrowser } from "@/utils/supabase/client";
 
-type QueueStatusFilter = "all" | "under_review";
-type QueueSort = "oldest" | "newest" | "amount" | "applicant";
-type Action = "approve" | "reject" | null;
+import {
+  InitialPaymentClaimReview,
+  type ReviewAction,
+} from "./initial-payment-claim-review";
+import {
+  InitialPaymentClaimsList,
+  type QueueSort,
+  type QueueStatusFilter,
+} from "./initial-payment-claims-list";
+
+type QueueState = {
+  search: string;
+  statusFilter: QueueStatusFilter;
+  sort: QueueSort;
+  selectedClaimId: string | null;
+  selectedDetail: InitialPaymentClaimDetail | null;
+  detailLoading: boolean;
+  action: ReviewAction;
+  actionError: string | null;
+  rejectionReason: string;
+  resolvedClaimIds: Set<string>;
+};
+
+type QueueAction =
+  | { type: "search_changed"; value: string }
+  | { type: "status_filter_changed"; value: QueueStatusFilter }
+  | { type: "sort_changed"; value: QueueSort }
+  | { type: "claim_selected"; claimId: string }
+  | {
+      type: "detail_loaded";
+      claimId: string;
+      detail: InitialPaymentClaimDetail | null;
+      message?: string;
+    }
+  | { type: "detail_failed"; claimId: string; message: string }
+  | { type: "detail_finished"; claimId: string }
+  | { type: "action_started"; action: Exclude<ReviewAction, null> }
+  | { type: "action_failed"; message: string }
+  | { type: "rejection_reason_changed"; value: string }
+  | { type: "claim_resolved"; claimId: string }
+  | { type: "review_closed" };
+
+const INITIAL_QUEUE_STATE: QueueState = {
+  search: "",
+  statusFilter: "all",
+  sort: "oldest",
+  selectedClaimId: null,
+  selectedDetail: null,
+  detailLoading: false,
+  action: null,
+  actionError: null,
+  rejectionReason: "",
+  resolvedClaimIds: new Set(),
+};
 
 const supabase = supabaseBrowser();
 
-function formatAmount(amount: number, currency: string) {
-  return new Intl.NumberFormat("pt-BR", {
-    currency,
-    maximumFractionDigits: 2,
-    minimumFractionDigits: 2,
-    style: "currency",
-  }).format(amount / 100);
-}
+function queueReducer(state: QueueState, action: QueueAction): QueueState {
+  switch (action.type) {
+    case "search_changed":
+      return { ...state, search: action.value };
+    case "status_filter_changed":
+      return { ...state, statusFilter: action.value };
+    case "sort_changed":
+      return { ...state, sort: action.value };
+    case "claim_selected":
+      return {
+        ...state,
+        selectedClaimId: action.claimId,
+        selectedDetail: null,
+        detailLoading: true,
+        action: null,
+        actionError: null,
+        rejectionReason: "",
+      };
+    case "detail_loaded":
+      if (state.selectedClaimId !== action.claimId) return state;
 
-function formatDate(value: string | null | undefined) {
-  if (!value) return "—";
+      return {
+        ...state,
+        selectedDetail: action.detail,
+        actionError: action.message ?? null,
+      };
+    case "detail_failed":
+      if (state.selectedClaimId !== action.claimId) return state;
 
-  return new Intl.DateTimeFormat("en", {
-    dateStyle: "medium",
-    timeStyle: "short",
-  }).format(new Date(value));
-}
+      return {
+        ...state,
+        selectedDetail: null,
+        actionError: action.message,
+      };
+    case "detail_finished":
+      if (state.selectedClaimId !== action.claimId) return state;
 
-function getInitials(name: string | null, handle: string | null) {
-  const source = name?.trim() || handle?.replace(/^@/, "") || "Applicant";
-  const initials = source
-    .split(/\s+/)
-    .slice(0, 2)
-    .map((part) => part[0])
-    .join("")
-    .toUpperCase();
+      return { ...state, detailLoading: false };
+    case "action_started":
+      return { ...state, action: action.action, actionError: null };
+    case "action_failed":
+      return { ...state, action: null, actionError: action.message };
+    case "rejection_reason_changed":
+      return { ...state, rejectionReason: action.value };
+    case "claim_resolved": {
+      const resolvedClaimIds = new Set(state.resolvedClaimIds);
+      resolvedClaimIds.add(action.claimId);
 
-  return initials || "A";
+      return {
+        ...state,
+        selectedClaimId: null,
+        selectedDetail: null,
+        detailLoading: false,
+        action: null,
+        actionError: null,
+        rejectionReason: "",
+        resolvedClaimIds,
+      };
+    }
+    case "review_closed":
+      return {
+        ...state,
+        selectedClaimId: null,
+        selectedDetail: null,
+        detailLoading: false,
+        actionError: null,
+        rejectionReason: "",
+      };
+  }
 }
 
 function getRpcErrorMessage(error: { code?: string; message?: string }) {
@@ -104,91 +168,22 @@ function getRpcErrorMessage(error: { code?: string; message?: string }) {
   return "The decision could not be completed. Nothing was changed; try again.";
 }
 
-function getHistory(value: unknown) {
-  return Array.isArray(value)
-    ? value.filter(
-        (entry): entry is Record<string, unknown> =>
-          typeof entry === "object" && entry !== null,
-      )
-    : [];
-}
-
-function statusLabel(status: QueueStatusFilter) {
-  return status === "all" ? "All current claims" : "Awaiting review";
-}
-
-function QueueStatusBadge({
-  status,
-}: {
-  status: InitialPaymentClaimQueueRow["claim_status"];
-}) {
-  return (
-    <Badge
-      variant="outline"
-      className="border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300"
-    >
-      <Clock3 className="mr-1.5 size-3.5" aria-hidden="true" />
-      {status === "under_review" ? "Awaiting review" : status}
-    </Badge>
-  );
-}
-
-function ApplicantAvatar({
-  name,
-  handle,
-  picture,
-  size = "md",
-}: {
-  name: string | null;
-  handle: string | null;
-  picture: string | null;
-  size?: "sm" | "md";
-}) {
-  const sizeClass = size === "sm" ? "size-10 text-sm" : "size-14 text-base";
-
-  return (
-    <div
-      className={`relative flex ${sizeClass} shrink-0 items-center justify-center overflow-hidden rounded-full bg-muted font-semibold text-muted-foreground outline outline-1 outline-black/10 dark:outline-white/10`}
-    >
-      {picture ? (
-        <img
-          src={picture}
-          alt=""
-          className="size-full object-cover"
-          loading="lazy"
-        />
-      ) : (
-        getInitials(name, handle)
-      )}
-    </div>
-  );
-}
-
 export default function InitialPaymentClaimsQueue({
   initialClaims,
 }: {
   initialClaims: InitialPaymentClaimQueueRow[];
 }) {
   const router = useRouter();
-  const [search, setSearch] = useState("");
-  const [statusFilter, setStatusFilter] = useState<QueueStatusFilter>("all");
-  const [sort, setSort] = useState<QueueSort>("oldest");
-  const [selectedClaimId, setSelectedClaimId] = useState<string | null>(null);
-  const [selectedDetail, setSelectedDetail] =
-    useState<InitialPaymentClaimDetail | null>(null);
-  const [detailLoading, setDetailLoading] = useState(false);
-  const [action, setAction] = useState<Action>(null);
-  const [actionError, setActionError] = useState<string | null>(null);
-  const [rejectionReason, setRejectionReason] = useState("");
-  const [resolvedClaimIds, setResolvedClaimIds] = useState<Set<string>>(
-    () => new Set(),
-  );
+  const [state, dispatch] = useReducer(queueReducer, INITIAL_QUEUE_STATE);
 
   const visibleClaims = useMemo(() => {
-    const normalizedSearch = search.trim().toLowerCase();
+    const normalizedSearch = state.search.trim().toLowerCase();
     const filteredClaims = initialClaims.filter((claim) => {
-      if (resolvedClaimIds.has(claim.claim_id)) return false;
-      if (statusFilter !== "all" && claim.claim_status !== statusFilter) {
+      if (state.resolvedClaimIds.has(claim.claim_id)) return false;
+      if (
+        state.statusFilter !== "all" &&
+        claim.claim_status !== state.statusFilter
+      ) {
         return false;
       }
 
@@ -205,8 +200,8 @@ export default function InitialPaymentClaimsQueue({
     });
 
     return [...filteredClaims].sort((left, right) => {
-      if (sort === "amount") return right.amount - left.amount;
-      if (sort === "applicant") {
+      if (state.sort === "amount") return right.amount - left.amount;
+      if (state.sort === "applicant") {
         return (
           left.applicant_name ||
           left.applicant_handle ||
@@ -216,129 +211,155 @@ export default function InitialPaymentClaimsQueue({
 
       const leftDate = new Date(left.claim_created_at).getTime();
       const rightDate = new Date(right.claim_created_at).getTime();
-      return sort === "newest" ? rightDate - leftDate : leftDate - rightDate;
+      return state.sort === "newest"
+        ? rightDate - leftDate
+        : leftDate - rightDate;
     });
-  }, [initialClaims, resolvedClaimIds, search, sort, statusFilter]);
+  }, [initialClaims, state]);
 
   const loadDetail = async (claimId: string, showLoading = true) => {
-    if (showLoading) setDetailLoading(true);
-    setActionError(null);
-
-    const { data, error } = await supabase.rpc(
-      "get_initial_payment_claim_detail",
-      { p_claim_id: claimId },
-    );
-
-    if (error) {
-      setSelectedDetail(null);
-      setActionError(getRpcErrorMessage(error));
-    } else if (data?.[0]) {
-      setSelectedDetail(data[0]);
-    } else {
-      setSelectedDetail(null);
-      setActionError(
-        "This claim is no longer available to your reviewer scope. Refresh the queue.",
-      );
+    if (showLoading) {
+      dispatch({ type: "claim_selected", claimId });
     }
 
-    if (showLoading) setDetailLoading(false);
+    try {
+      const { data, error } = await supabase.rpc(
+        "get_initial_payment_claim_detail",
+        { p_claim_id: claimId },
+      );
+
+      if (error) {
+        dispatch({
+          type: "detail_failed",
+          claimId,
+          message: getRpcErrorMessage(error),
+        });
+      } else if (data?.[0]) {
+        dispatch({
+          type: "detail_loaded",
+          claimId,
+          detail: data[0],
+        });
+      } else {
+        dispatch({
+          type: "detail_loaded",
+          claimId,
+          detail: null,
+          message:
+            "This claim is no longer available to your reviewer scope. Refresh the queue.",
+        });
+      }
+    } catch {
+      dispatch({
+        type: "detail_failed",
+        claimId,
+        message: "The claim details could not be loaded. Try again.",
+      });
+    } finally {
+      if (showLoading) {
+        dispatch({ type: "detail_finished", claimId });
+      }
+    }
   };
 
   const openClaim = async (claimId: string) => {
-    setSelectedClaimId(claimId);
-    setSelectedDetail(null);
-    setRejectionReason("");
-    setActionError(null);
     await loadDetail(claimId);
   };
 
   const closeClaim = () => {
-    if (action) return;
-    setSelectedClaimId(null);
-    setSelectedDetail(null);
-    setActionError(null);
-    setRejectionReason("");
-  };
-
-  const removeResolvedClaim = (claimId: string) => {
-    setResolvedClaimIds((current) => {
-      const next = new Set(current);
-      next.add(claimId);
-      return next;
-    });
-    setSelectedClaimId(null);
-    setSelectedDetail(null);
-    setActionError(null);
-    setRejectionReason("");
-    router.refresh();
+    if (state.action) return;
+    dispatch({ type: "review_closed" });
   };
 
   const handleApprove = async () => {
-    if (!selectedClaimId) return;
+    const claimId = state.selectedClaimId;
+    if (!claimId || state.action) return;
 
-    setAction("approve");
-    setActionError(null);
+    dispatch({ type: "action_started", action: "approve" });
 
-    const { error } = await supabase.rpc("approve_initial_claim", {
-      p_claim_id: selectedClaimId,
-    });
+    try {
+      const { error } = await supabase.rpc("approve_initial_claim", {
+        p_claim_id: claimId,
+      });
 
-    if (error) {
-      setActionError(getRpcErrorMessage(error));
-      if (error.code === "40001") {
-        await loadDetail(selectedClaimId, false);
-        router.refresh();
+      if (error) {
+        dispatch({
+          type: "action_failed",
+          message: getRpcErrorMessage(error),
+        });
+        if (error.code === "40001") {
+          await loadDetail(claimId, false);
+          router.refresh();
+        }
+        return;
       }
-      setAction(null);
-      return;
-    }
 
-    removeResolvedClaim(selectedClaimId);
-    setAction(null);
+      dispatch({ type: "claim_resolved", claimId });
+      router.refresh();
+    } catch {
+      dispatch({
+        type: "action_failed",
+        message: "The decision could not be completed. Try again.",
+      });
+    }
   };
 
   const handleReject = async () => {
-    if (!selectedClaimId) return;
+    const claimId = state.selectedClaimId;
+    if (!claimId || state.action) return;
 
-    const normalizedReason = rejectionReason.trim().replace(/\s+/g, " ");
+    const normalizedReason = state.rejectionReason.trim().replace(/\s+/g, " ");
     if (!normalizedReason) {
-      setActionError("A rejection reason is required.");
+      dispatch({
+        type: "action_failed",
+        message: "A rejection reason is required.",
+      });
       return;
     }
 
-    setAction("reject");
-    setActionError(null);
+    dispatch({ type: "action_started", action: "reject" });
 
-    const { error } = await supabase.rpc("reject_initial_claim", {
-      p_claim_id: selectedClaimId,
-      p_reason: normalizedReason,
-    });
+    try {
+      const { error } = await supabase.rpc("reject_initial_claim", {
+        p_claim_id: claimId,
+        p_reason: normalizedReason,
+      });
 
-    if (error) {
-      setActionError(getRpcErrorMessage(error));
-      if (error.code === "40001") {
-        await loadDetail(selectedClaimId, false);
-        router.refresh();
+      if (error) {
+        dispatch({
+          type: "action_failed",
+          message: getRpcErrorMessage(error),
+        });
+        if (error.code === "40001") {
+          await loadDetail(claimId, false);
+          router.refresh();
+        }
+        return;
       }
-      setAction(null);
-      return;
-    }
 
-    removeResolvedClaim(selectedClaimId);
-    setAction(null);
+      dispatch({ type: "claim_resolved", claimId });
+      router.refresh();
+    } catch {
+      dispatch({
+        type: "action_failed",
+        message: "The decision could not be completed. Try again.",
+      });
+    }
   };
 
   const reviewSurface = (
-    <ReviewContent
-      action={action}
-      actionError={actionError}
-      detail={selectedDetail}
-      detailLoading={detailLoading}
+    <InitialPaymentClaimReview
+      action={state.action}
+      actionError={state.actionError}
+      detail={state.selectedDetail}
+      detailLoading={state.detailLoading}
       onApprove={handleApprove}
       onClose={closeClaim}
       onReject={handleReject}
-      rejectionReason={rejectionReason}
-      setRejectionReason={setRejectionReason}
+      rejectionReason={state.rejectionReason}
+      onRejectionReasonChange={(value) =>
+        dispatch({ type: "rejection_reason_changed", value })
+      }
     />
   );
 
@@ -361,161 +382,34 @@ export default function InitialPaymentClaimsQueue({
           </div>
           <div className="flex items-center gap-2 rounded-2xl border bg-card px-4 py-3 text-sm shadow-sm">
             <span className="flex size-8 items-center justify-center rounded-full bg-primary/10 text-primary">
-              <FileText className="size-4" aria-hidden="true" />
-            </span>
-            <span>
-              <span className="block font-semibold tabular-nums">
+              <span className="text-sm font-semibold tabular-nums">
                 {visibleClaims.length}
               </span>
-              <span className="text-muted-foreground">visible claims</span>
             </span>
+            <span className="text-muted-foreground">visible claims</span>
           </div>
         </div>
 
-        <Card className="mt-8 overflow-hidden rounded-3xl border-0 shadow-[0_20px_70px_-40px_hsl(var(--foreground)/0.45)]">
-          <CardHeader className="border-b bg-card/80 pb-5">
-            <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-              <div>
-                <CardTitle>Queue</CardTitle>
-                <CardDescription className="mt-1">
-                  Current initial claims from the associations you administer.
-                </CardDescription>
-              </div>
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-                <label className="relative block min-w-0 sm:w-72">
-                  <span className="sr-only">Search claims</span>
-                  <Search
-                    className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
-                    aria-hidden="true"
-                  />
-                  <Input
-                    type="search"
-                    value={search}
-                    onChange={(event) => setSearch(event.target.value)}
-                    placeholder="Search applicant or payer"
-                    className="h-11 rounded-xl pl-9"
-                  />
-                </label>
-                <label>
-                  <span className="sr-only">Filter payment state</span>
-                  <select
-                    value={statusFilter}
-                    onChange={(event) =>
-                      setStatusFilter(event.target.value as QueueStatusFilter)
-                    }
-                    className="h-11 min-w-44 rounded-xl border border-input bg-background px-3 text-sm shadow-sm outline-none focus:ring-1 focus:ring-ring"
-                  >
-                    <option value="all">{statusLabel("all")}</option>
-                    <option value="under_review">
-                      {statusLabel("under_review")}
-                    </option>
-                  </select>
-                </label>
-                <label>
-                  <span className="sr-only">Sort claims</span>
-                  <select
-                    value={sort}
-                    onChange={(event) =>
-                      setSort(event.target.value as QueueSort)
-                    }
-                    className="h-11 min-w-40 rounded-xl border border-input bg-background px-3 text-sm shadow-sm outline-none focus:ring-1 focus:ring-ring"
-                  >
-                    <option value="oldest">Oldest first</option>
-                    <option value="newest">Newest first</option>
-                    <option value="amount">Highest amount</option>
-                    <option value="applicant">Applicant name</option>
-                  </select>
-                </label>
-              </div>
-            </div>
-          </CardHeader>
-
-          <CardContent className="p-0">
-            {visibleClaims.length === 0 ? (
-              <div className="flex min-h-72 flex-col items-center justify-center px-6 py-16 text-center">
-                <span className="flex size-14 items-center justify-center rounded-full bg-emerald-500/10 text-emerald-600 dark:text-emerald-400">
-                  <CheckCircle2 className="size-7" aria-hidden="true" />
-                </span>
-                <h2 className="mt-5 text-xl font-semibold">
-                  {initialClaims.length === 0
-                    ? "The queue is clear"
-                    : "No claims match these filters"}
-                </h2>
-                <p className="mt-2 max-w-md text-sm text-muted-foreground">
-                  {initialClaims.length === 0
-                    ? "New initial payment claims will appear here when an applicant submits one."
-                    : "Try clearing the search or changing the sort and payment-state filters."}
-                </p>
-              </div>
-            ) : (
-              <div role="list" aria-label="Initial payment claims">
-                {visibleClaims.map((claim) => (
-                  <div key={claim.claim_id} role="listitem">
-                    <button
-                      type="button"
-                      onClick={() => void openClaim(claim.claim_id)}
-                      className="group grid w-full grid-cols-[auto_1fr_auto] items-center gap-4 px-5 py-4 text-left transition-[background-color,transform] duration-200 hover:bg-muted/40 focus-visible:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring active:scale-[0.996] md:grid-cols-[minmax(14rem,1.7fr)_minmax(8rem,0.8fr)_minmax(8rem,0.7fr)_minmax(8rem,0.7fr)_auto] md:px-6"
-                    >
-                      <div className="flex min-w-0 items-center gap-3">
-                        <ApplicantAvatar
-                          name={claim.applicant_name}
-                          handle={claim.applicant_handle}
-                          picture={claim.applicant_profile_picture}
-                          size="sm"
-                        />
-                        <div className="min-w-0">
-                          <p className="truncate font-semibold">
-                            {claim.applicant_name || "Unnamed applicant"}
-                          </p>
-                          <p className="truncate text-sm text-muted-foreground">
-                            {claim.applicant_handle || "No handle"}
-                          </p>
-                        </div>
-                      </div>
-                      <div className="hidden min-w-0 md:block">
-                        <p className="truncate text-sm font-medium">
-                          {claim.payer_type === "applicant"
-                            ? "Applicant"
-                            : claim.payer_name || "Other payer"}
-                        </p>
-                        <p className="text-xs text-muted-foreground">Payer</p>
-                      </div>
-                      <div className="hidden md:block">
-                        <p className="font-semibold">
-                          {claim.plan_type === "annual" ? "Annual" : "Monthly"}
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                          {claim.attempt_count} attempt
-                          {claim.attempt_count === 1 ? "" : "s"}
-                        </p>
-                      </div>
-                      <div className="hidden md:block">
-                        <p className="font-semibold tabular-nums">
-                          {formatAmount(claim.amount, claim.currency)}
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                          {formatDate(claim.claim_created_at)}
-                        </p>
-                      </div>
-                      <div className="flex items-center justify-end gap-3">
-                        <QueueStatusBadge status={claim.claim_status} />
-                        <ChevronRight
-                          className="size-5 text-muted-foreground transition-transform duration-200 group-hover:translate-x-0.5"
-                          aria-hidden="true"
-                        />
-                      </div>
-                    </button>
-                  </div>
-                ))}
-              </div>
-            )}
-          </CardContent>
-        </Card>
+        <InitialPaymentClaimsList
+          claims={visibleClaims}
+          initialClaimsCount={initialClaims.length}
+          onOpenClaim={(claimId) => void openClaim(claimId)}
+          onSearchChange={(value) =>
+            dispatch({ type: "search_changed", value })
+          }
+          onSortChange={(value) => dispatch({ type: "sort_changed", value })}
+          onStatusFilterChange={(value) =>
+            dispatch({ type: "status_filter_changed", value })
+          }
+          search={state.search}
+          sort={state.sort}
+          statusFilter={state.statusFilter}
+        />
       </div>
 
       <div className="hidden md:block">
         <Dialog
-          open={selectedClaimId !== null}
+          open={state.selectedClaimId !== null}
           onOpenChange={(open) => {
             if (!open) closeClaim();
           }}
@@ -535,7 +429,7 @@ export default function InitialPaymentClaimsQueue({
 
       <div className="md:hidden">
         <Drawer
-          open={selectedClaimId !== null}
+          open={state.selectedClaimId !== null}
           onOpenChange={(open) => {
             if (!open) closeClaim();
           }}
@@ -553,409 +447,5 @@ export default function InitialPaymentClaimsQueue({
         </Drawer>
       </div>
     </section>
-  );
-}
-
-function ReviewContent({
-  action,
-  actionError,
-  detail,
-  detailLoading,
-  onApprove,
-  onClose,
-  onReject,
-  rejectionReason,
-  setRejectionReason,
-}: {
-  action: Action;
-  actionError: string | null;
-  detail: InitialPaymentClaimDetail | null;
-  detailLoading: boolean;
-  onApprove: () => Promise<void>;
-  onClose: () => void;
-  onReject: () => Promise<void>;
-  rejectionReason: string;
-  setRejectionReason: (value: string) => void;
-}) {
-  const claimHistory = getHistory(detail?.claim_history);
-  const auditHistory = getHistory(detail?.audit_history);
-  const isActionable = detail?.claim_status === "under_review";
-
-  return (
-    <div className="flex max-h-[90vh] flex-col bg-background">
-      <div className="flex items-start justify-between gap-4 border-b px-5 py-5 md:px-7">
-        <div className="flex min-w-0 items-center gap-3">
-          {detail ? (
-            <ApplicantAvatar
-              name={detail.applicant_name}
-              handle={detail.applicant_handle}
-              picture={detail.applicant_profile_picture}
-            />
-          ) : (
-            <span className="flex size-14 shrink-0 items-center justify-center rounded-full bg-muted">
-              <UserRound
-                className="size-6 text-muted-foreground"
-                aria-hidden="true"
-              />
-            </span>
-          )}
-          <div className="min-w-0">
-            <p className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
-              Initial claim review
-            </p>
-            <h2 className="mt-1 truncate text-xl font-semibold">
-              {detail?.applicant_name || "Loading applicant"}
-            </h2>
-            <p className="truncate text-sm text-muted-foreground">
-              {detail?.applicant_handle || detail?.organization_name || ""}
-            </p>
-          </div>
-        </div>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          onClick={onClose}
-          disabled={action !== null}
-          aria-label="Close review"
-          className="shrink-0 rounded-xl"
-        >
-          <X className="size-5" aria-hidden="true" />
-        </Button>
-      </div>
-
-      <div className="scrollbar overflow-y-auto px-5 py-5 md:px-7 md:py-6">
-        {detailLoading ? (
-          <div className="flex min-h-72 items-center justify-center">
-            <Loader2
-              className="size-7 animate-spin text-muted-foreground"
-              aria-label="Loading claim details"
-            />
-          </div>
-        ) : !detail ? (
-          <div className="flex min-h-72 items-center justify-center">
-            <Alert variant="destructive" className="max-w-lg">
-              <AlertTriangle className="size-4" aria-hidden="true" />
-              <AlertTitle>Review unavailable</AlertTitle>
-              <AlertDescription>
-                {actionError || "Refresh the queue and try again."}
-              </AlertDescription>
-            </Alert>
-          </div>
-        ) : (
-          <div className="space-y-6">
-            <div className="flex flex-wrap items-center gap-2">
-              <QueueStatusBadge status={detail.claim_status} />
-              <Badge variant="secondary">
-                Revision {detail.revision_number}
-              </Badge>
-              <Badge variant="secondary">{detail.organization_name}</Badge>
-            </div>
-
-            {actionError ? (
-              <Alert variant="destructive" aria-live="assertive">
-                <AlertTriangle className="size-4" aria-hidden="true" />
-                <AlertTitle>Decision not completed</AlertTitle>
-                <AlertDescription>{actionError}</AlertDescription>
-              </Alert>
-            ) : null}
-
-            <div className="grid gap-3 sm:grid-cols-3">
-              <SummaryCard
-                label="Claim amount"
-                value={formatAmount(detail.amount, detail.currency)}
-              />
-              <SummaryCard
-                label="Plan"
-                value={detail.plan_type === "annual" ? "Annual" : "Monthly"}
-              />
-              <SummaryCard
-                label="Submitted"
-                value={formatDate(detail.claim_created_at)}
-              />
-            </div>
-
-            <section aria-labelledby="payment-evidence-title">
-              <SectionHeading
-                id="payment-evidence-title"
-                icon={<CheckCircle2 className="size-4" aria-hidden="true" />}
-                title="Payment evidence"
-              />
-              <div className="mt-3 grid gap-x-6 gap-y-4 rounded-2xl border bg-muted/20 p-4 sm:grid-cols-2">
-                <DetailField label="Payer">
-                  {detail.payer_type === "applicant"
-                    ? "Applicant"
-                    : detail.payer_name || "Other payer"}
-                </DetailField>
-                <DetailField label="Claim attempts">
-                  {detail.attempt_count}
-                </DetailField>
-                <DetailField label="Claim created">
-                  {formatDate(detail.claim_created_at)}
-                </DetailField>
-                <DetailField label="Terms version">
-                  {detail.terms_version}
-                </DetailField>
-              </div>
-            </section>
-
-            <section aria-labelledby="application-title">
-              <SectionHeading
-                id="application-title"
-                icon={<FileText className="size-4" aria-hidden="true" />}
-                title="Submitted application revision"
-              />
-              <div className="mt-3 grid gap-x-6 gap-y-4 rounded-2xl border bg-muted/20 p-4 sm:grid-cols-2">
-                <DetailField label="Full name">{detail.full_name}</DetailField>
-                <DetailField label="Handle">
-                  {detail.applicant_handle}
-                </DetailField>
-                <DetailField label="Birth date">
-                  {detail.birth_date}
-                </DetailField>
-                <DetailField label="Nationality">
-                  {detail.nationality}
-                </DetailField>
-                <DetailField label="Marital status">
-                  {detail.marital_status}
-                </DetailField>
-                <DetailField label="Profession">
-                  {detail.profession}
-                </DetailField>
-                <DetailField label="Birthplace">
-                  {detail.birthplace}
-                </DetailField>
-                <DetailField label="Email">{detail.email}</DetailField>
-                <DetailField label="Phone">{detail.phone}</DetailField>
-                <DetailField label="CPF">{detail.cpf}</DetailField>
-                <DetailField label="ID document">
-                  {detail.id_document_number}
-                </DetailField>
-                <DetailField label="Issuing authority">
-                  {detail.id_document_issuer}
-                </DetailField>
-                <DetailField label="Postal code">
-                  {detail.postal_code}
-                </DetailField>
-                <DetailField label="Address">{detail.address_line}</DetailField>
-                <DetailField label="City / state">
-                  {[detail.city, detail.state].filter(Boolean).join(" / ")}
-                </DetailField>
-                <DetailField label="Blood type">
-                  {detail.blood_type}
-                </DetailField>
-                <DetailField label="Allergies">
-                  {detail.has_allergies ? detail.allergies : "None reported"}
-                </DetailField>
-                <DetailField label="Dietary restrictions">
-                  {detail.has_dietary_restrictions
-                    ? detail.dietary_restrictions
-                    : "None reported"}
-                </DetailField>
-                <DetailField label="Highline experience">
-                  {detail.highline_experience}
-                </DetailField>
-                <DetailField label="Rescue course">
-                  {detail.has_rescue_course ? "Yes" : "No"}
-                </DetailField>
-                <DetailField label="First-aid course">
-                  {detail.first_aid_course}
-                </DetailField>
-                <DetailField label="Emergency contact">
-                  {[
-                    detail.emergency_contact_name,
-                    detail.emergency_contact_relationship,
-                    detail.emergency_contact_phone,
-                  ]
-                    .filter(Boolean)
-                    .join(" · ")}
-                </DetailField>
-              </div>
-            </section>
-
-            {claimHistory.length > 0 || auditHistory.length > 0 ? (
-              <section aria-labelledby="history-title">
-                <SectionHeading
-                  id="history-title"
-                  icon={<CalendarDays className="size-4" aria-hidden="true" />}
-                  title="Immutable history"
-                />
-                <div className="mt-3 grid gap-3 rounded-2xl border bg-muted/20 p-4 lg:grid-cols-2">
-                  <div>
-                    <p className="text-xs font-medium uppercase tracking-[0.08em] text-muted-foreground">
-                      Claim states
-                    </p>
-                    <div className="mt-2 space-y-2">
-                      {claimHistory.map((history) => (
-                        <div
-                          key={String(history.claim_id)}
-                          className="flex flex-wrap items-center justify-between gap-2 text-sm"
-                        >
-                          <span className="font-medium">
-                            {String(history.status)}
-                          </span>
-                          <span className="text-muted-foreground">
-                            {formatDate(String(history.created_at))}
-                            {history.decision_reason
-                              ? ` · ${String(history.decision_reason)}`
-                              : ""}
-                          </span>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                  <div>
-                    <p className="text-xs font-medium uppercase tracking-[0.08em] text-muted-foreground">
-                      Audit events
-                    </p>
-                    <div className="mt-2 space-y-2">
-                      {auditHistory.map((history) => (
-                        <div
-                          key={String(history.id)}
-                          className="flex flex-wrap items-center justify-between gap-2 text-sm"
-                        >
-                          <span className="font-medium">
-                            {String(history.previous_state)} →{" "}
-                            {String(history.next_state)}
-                          </span>
-                          <span className="text-muted-foreground">
-                            {formatDate(String(history.created_at))}
-                            {history.reason
-                              ? ` · ${String(history.reason)}`
-                              : ""}
-                          </span>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                </div>
-              </section>
-            ) : null}
-          </div>
-        )}
-      </div>
-
-      {detail && isActionable ? (
-        <div className="border-t bg-card px-5 py-4 md:px-7">
-          <label htmlFor="rejection-reason" className="text-sm font-medium">
-            Rejection reason
-            <span className="ml-1 text-destructive" aria-hidden="true">
-              *
-            </span>
-          </label>
-          <Textarea
-            id="rejection-reason"
-            value={rejectionReason}
-            onChange={(event) => setRejectionReason(event.target.value)}
-            maxLength={500}
-            placeholder="Explain what the applicant needs to correct."
-            className="mt-2 min-h-20 rounded-xl"
-            disabled={action !== null}
-          />
-          <div className="mt-3 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-            <Button
-              type="button"
-              variant="destructive"
-              onClick={() => void onReject()}
-              disabled={action !== null}
-              className="h-11 rounded-xl px-5 active:scale-[0.96]"
-            >
-              {action === "reject" ? (
-                <Loader2
-                  className="mr-2 size-4 animate-spin"
-                  aria-hidden="true"
-                />
-              ) : (
-                <XCircle className="mr-2 size-4" aria-hidden="true" />
-              )}
-              Reject claim
-            </Button>
-            <Button
-              type="button"
-              onClick={() => void onApprove()}
-              disabled={action !== null}
-              className="h-11 rounded-xl px-5 active:scale-[0.96]"
-            >
-              {action === "approve" ? (
-                <Loader2
-                  className="mr-2 size-4 animate-spin"
-                  aria-hidden="true"
-                />
-              ) : (
-                <Check className="mr-2 size-4" aria-hidden="true" />
-              )}
-              Verify payment and admit member.
-            </Button>
-          </div>
-        </div>
-      ) : detail ? (
-        <div className="border-t bg-muted/20 px-5 py-4 md:px-7">
-          <div className="flex items-start gap-3 text-sm text-muted-foreground">
-            {detail.claim_status === "approved" ? (
-              <CheckCircle2
-                className="mt-0.5 size-5 shrink-0 text-emerald-600"
-                aria-hidden="true"
-              />
-            ) : (
-              <XCircle
-                className="mt-0.5 size-5 shrink-0 text-destructive"
-                aria-hidden="true"
-              />
-            )}
-            <p>
-              This claim is {detail.claim_status}. The authoritative state has
-              been preserved; close this review and refresh the queue.
-            </p>
-          </div>
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-function SummaryCard({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-2xl border bg-card p-4 shadow-sm">
-      <p className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
-        {label}
-      </p>
-      <p className="mt-2 truncate font-semibold tabular-nums">{value}</p>
-    </div>
-  );
-}
-
-function SectionHeading({
-  icon,
-  id,
-  title,
-}: {
-  icon: ReactNode;
-  id: string;
-  title: string;
-}) {
-  return (
-    <h3 id={id} className="flex items-center gap-2 text-sm font-semibold">
-      <span className="text-muted-foreground">{icon}</span>
-      {title}
-    </h3>
-  );
-}
-
-function DetailField({
-  children,
-  label,
-}: {
-  children: ReactNode;
-  label: string;
-}) {
-  return (
-    <div className="min-w-0">
-      <dt className="text-xs font-medium uppercase tracking-[0.08em] text-muted-foreground">
-        {label}
-      </dt>
-      <dd className="mt-1 break-words text-sm font-medium">
-        {children || "—"}
-      </dd>
-    </div>
   );
 }

--- a/next/app/[locale]/admin/claims/_components/initial-payment-claims-queue.tsx
+++ b/next/app/[locale]/admin/claims/_components/initial-payment-claims-queue.tsx
@@ -1,0 +1,961 @@
+"use client";
+
+/* eslint-disable @next/next/no-img-element */
+
+import {
+  AlertTriangle,
+  CalendarDays,
+  Check,
+  CheckCircle2,
+  ChevronRight,
+  Clock3,
+  FileText,
+  Loader2,
+  Search,
+  ShieldCheck,
+  UserRound,
+  X,
+  XCircle,
+} from "lucide-react";
+import { useMemo, useState, type ReactNode } from "react";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { useRouter } from "@/i18n/navigation";
+import {
+  type InitialPaymentClaimDetail,
+  type InitialPaymentClaimQueueRow,
+} from "@/lib/initial-payment-claims";
+import { supabaseBrowser } from "@/utils/supabase/client";
+
+type QueueStatusFilter = "all" | "under_review";
+type QueueSort = "oldest" | "newest" | "amount" | "applicant";
+type Action = "approve" | "reject" | null;
+
+const supabase = supabaseBrowser();
+
+function formatAmount(amount: number, currency: string) {
+  return new Intl.NumberFormat("pt-BR", {
+    currency,
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2,
+    style: "currency",
+  }).format(amount / 100);
+}
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return "—";
+
+  return new Intl.DateTimeFormat("en", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function getInitials(name: string | null, handle: string | null) {
+  const source = name?.trim() || handle?.replace(/^@/, "") || "Applicant";
+  const initials = source
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((part) => part[0])
+    .join("")
+    .toUpperCase();
+
+  return initials || "A";
+}
+
+function getRpcErrorMessage(error: { code?: string; message?: string }) {
+  if (error.code === "40001") {
+    return "Another reviewer may have acted on this claim. The review stays open while we refresh the authoritative state.";
+  }
+
+  if (error.code === "42501") {
+    return "You are not authorized to inspect or decide this claim.";
+  }
+
+  if (error.code === "22023") {
+    return error.message || "Check the information and try again.";
+  }
+
+  return "The decision could not be completed. Nothing was changed; try again.";
+}
+
+function getHistory(value: unknown) {
+  return Array.isArray(value)
+    ? value.filter(
+        (entry): entry is Record<string, unknown> =>
+          typeof entry === "object" && entry !== null,
+      )
+    : [];
+}
+
+function statusLabel(status: QueueStatusFilter) {
+  return status === "all" ? "All current claims" : "Awaiting review";
+}
+
+function QueueStatusBadge({
+  status,
+}: {
+  status: InitialPaymentClaimQueueRow["claim_status"];
+}) {
+  return (
+    <Badge
+      variant="outline"
+      className="border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+    >
+      <Clock3 className="mr-1.5 size-3.5" aria-hidden="true" />
+      {status === "under_review" ? "Awaiting review" : status}
+    </Badge>
+  );
+}
+
+function ApplicantAvatar({
+  name,
+  handle,
+  picture,
+  size = "md",
+}: {
+  name: string | null;
+  handle: string | null;
+  picture: string | null;
+  size?: "sm" | "md";
+}) {
+  const sizeClass = size === "sm" ? "size-10 text-sm" : "size-14 text-base";
+
+  return (
+    <div
+      className={`relative flex ${sizeClass} shrink-0 items-center justify-center overflow-hidden rounded-full bg-muted font-semibold text-muted-foreground outline outline-1 outline-black/10 dark:outline-white/10`}
+    >
+      {picture ? (
+        <img
+          src={picture}
+          alt=""
+          className="size-full object-cover"
+          loading="lazy"
+        />
+      ) : (
+        getInitials(name, handle)
+      )}
+    </div>
+  );
+}
+
+export default function InitialPaymentClaimsQueue({
+  initialClaims,
+}: {
+  initialClaims: InitialPaymentClaimQueueRow[];
+}) {
+  const router = useRouter();
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState<QueueStatusFilter>("all");
+  const [sort, setSort] = useState<QueueSort>("oldest");
+  const [selectedClaimId, setSelectedClaimId] = useState<string | null>(null);
+  const [selectedDetail, setSelectedDetail] =
+    useState<InitialPaymentClaimDetail | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [action, setAction] = useState<Action>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [rejectionReason, setRejectionReason] = useState("");
+  const [resolvedClaimIds, setResolvedClaimIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+
+  const visibleClaims = useMemo(() => {
+    const normalizedSearch = search.trim().toLowerCase();
+    const filteredClaims = initialClaims.filter((claim) => {
+      if (resolvedClaimIds.has(claim.claim_id)) return false;
+      if (statusFilter !== "all" && claim.claim_status !== statusFilter) {
+        return false;
+      }
+
+      if (!normalizedSearch) return true;
+
+      return [
+        claim.applicant_name,
+        claim.applicant_handle,
+        claim.payer_name,
+        claim.organization_name,
+      ]
+        .filter(Boolean)
+        .some((value) => value!.toLowerCase().includes(normalizedSearch));
+    });
+
+    return [...filteredClaims].sort((left, right) => {
+      if (sort === "amount") return right.amount - left.amount;
+      if (sort === "applicant") {
+        return (
+          left.applicant_name ||
+          left.applicant_handle ||
+          ""
+        ).localeCompare(right.applicant_name || right.applicant_handle || "");
+      }
+
+      const leftDate = new Date(left.claim_created_at).getTime();
+      const rightDate = new Date(right.claim_created_at).getTime();
+      return sort === "newest" ? rightDate - leftDate : leftDate - rightDate;
+    });
+  }, [initialClaims, resolvedClaimIds, search, sort, statusFilter]);
+
+  const loadDetail = async (claimId: string, showLoading = true) => {
+    if (showLoading) setDetailLoading(true);
+    setActionError(null);
+
+    const { data, error } = await supabase.rpc(
+      "get_initial_payment_claim_detail",
+      { p_claim_id: claimId },
+    );
+
+    if (error) {
+      setSelectedDetail(null);
+      setActionError(getRpcErrorMessage(error));
+    } else if (data?.[0]) {
+      setSelectedDetail(data[0]);
+    } else {
+      setSelectedDetail(null);
+      setActionError(
+        "This claim is no longer available to your reviewer scope. Refresh the queue.",
+      );
+    }
+
+    if (showLoading) setDetailLoading(false);
+  };
+
+  const openClaim = async (claimId: string) => {
+    setSelectedClaimId(claimId);
+    setSelectedDetail(null);
+    setRejectionReason("");
+    setActionError(null);
+    await loadDetail(claimId);
+  };
+
+  const closeClaim = () => {
+    if (action) return;
+    setSelectedClaimId(null);
+    setSelectedDetail(null);
+    setActionError(null);
+    setRejectionReason("");
+  };
+
+  const removeResolvedClaim = (claimId: string) => {
+    setResolvedClaimIds((current) => {
+      const next = new Set(current);
+      next.add(claimId);
+      return next;
+    });
+    setSelectedClaimId(null);
+    setSelectedDetail(null);
+    setActionError(null);
+    setRejectionReason("");
+    router.refresh();
+  };
+
+  const handleApprove = async () => {
+    if (!selectedClaimId) return;
+
+    setAction("approve");
+    setActionError(null);
+
+    const { error } = await supabase.rpc("approve_initial_claim", {
+      p_claim_id: selectedClaimId,
+    });
+
+    if (error) {
+      setActionError(getRpcErrorMessage(error));
+      if (error.code === "40001") {
+        await loadDetail(selectedClaimId, false);
+        router.refresh();
+      }
+      setAction(null);
+      return;
+    }
+
+    removeResolvedClaim(selectedClaimId);
+    setAction(null);
+  };
+
+  const handleReject = async () => {
+    if (!selectedClaimId) return;
+
+    const normalizedReason = rejectionReason.trim().replace(/\s+/g, " ");
+    if (!normalizedReason) {
+      setActionError("A rejection reason is required.");
+      return;
+    }
+
+    setAction("reject");
+    setActionError(null);
+
+    const { error } = await supabase.rpc("reject_initial_claim", {
+      p_claim_id: selectedClaimId,
+      p_reason: normalizedReason,
+    });
+
+    if (error) {
+      setActionError(getRpcErrorMessage(error));
+      if (error.code === "40001") {
+        await loadDetail(selectedClaimId, false);
+        router.refresh();
+      }
+      setAction(null);
+      return;
+    }
+
+    removeResolvedClaim(selectedClaimId);
+    setAction(null);
+  };
+
+  const reviewSurface = (
+    <ReviewContent
+      action={action}
+      actionError={actionError}
+      detail={selectedDetail}
+      detailLoading={detailLoading}
+      onApprove={handleApprove}
+      onClose={closeClaim}
+      onReject={handleReject}
+      rejectionReason={rejectionReason}
+      setRejectionReason={setRejectionReason}
+    />
+  );
+
+  return (
+    <section className="min-h-[calc(100vh-5rem)] bg-muted/20 px-4 py-8 md:px-6 md:py-12">
+      <div className="mx-auto max-w-7xl">
+        <div className="flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
+          <div>
+            <div className="flex items-center gap-2 text-sm font-medium uppercase tracking-[0.18em] text-muted-foreground">
+              <ShieldCheck className="size-4" aria-hidden="true" />
+              Association administration
+            </div>
+            <h1 className="mt-3 text-4xl font-semibold tracking-tight">
+              Initial payment claims
+            </h1>
+            <p className="mt-3 max-w-2xl text-muted-foreground">
+              Verify a payment and admit one applicant at a time. Every action
+              is checked and committed by the database as one decision.
+            </p>
+          </div>
+          <div className="flex items-center gap-2 rounded-2xl border bg-card px-4 py-3 text-sm shadow-sm">
+            <span className="flex size-8 items-center justify-center rounded-full bg-primary/10 text-primary">
+              <FileText className="size-4" aria-hidden="true" />
+            </span>
+            <span>
+              <span className="block font-semibold tabular-nums">
+                {visibleClaims.length}
+              </span>
+              <span className="text-muted-foreground">visible claims</span>
+            </span>
+          </div>
+        </div>
+
+        <Card className="mt-8 overflow-hidden rounded-3xl border-0 shadow-[0_20px_70px_-40px_hsl(var(--foreground)/0.45)]">
+          <CardHeader className="border-b bg-card/80 pb-5">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+              <div>
+                <CardTitle>Queue</CardTitle>
+                <CardDescription className="mt-1">
+                  Current initial claims from the associations you administer.
+                </CardDescription>
+              </div>
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                <label className="relative block min-w-0 sm:w-72">
+                  <span className="sr-only">Search claims</span>
+                  <Search
+                    className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+                    aria-hidden="true"
+                  />
+                  <Input
+                    type="search"
+                    value={search}
+                    onChange={(event) => setSearch(event.target.value)}
+                    placeholder="Search applicant or payer"
+                    className="h-11 rounded-xl pl-9"
+                  />
+                </label>
+                <label>
+                  <span className="sr-only">Filter payment state</span>
+                  <select
+                    value={statusFilter}
+                    onChange={(event) =>
+                      setStatusFilter(event.target.value as QueueStatusFilter)
+                    }
+                    className="h-11 min-w-44 rounded-xl border border-input bg-background px-3 text-sm shadow-sm outline-none focus:ring-1 focus:ring-ring"
+                  >
+                    <option value="all">{statusLabel("all")}</option>
+                    <option value="under_review">
+                      {statusLabel("under_review")}
+                    </option>
+                  </select>
+                </label>
+                <label>
+                  <span className="sr-only">Sort claims</span>
+                  <select
+                    value={sort}
+                    onChange={(event) =>
+                      setSort(event.target.value as QueueSort)
+                    }
+                    className="h-11 min-w-40 rounded-xl border border-input bg-background px-3 text-sm shadow-sm outline-none focus:ring-1 focus:ring-ring"
+                  >
+                    <option value="oldest">Oldest first</option>
+                    <option value="newest">Newest first</option>
+                    <option value="amount">Highest amount</option>
+                    <option value="applicant">Applicant name</option>
+                  </select>
+                </label>
+              </div>
+            </div>
+          </CardHeader>
+
+          <CardContent className="p-0">
+            {visibleClaims.length === 0 ? (
+              <div className="flex min-h-72 flex-col items-center justify-center px-6 py-16 text-center">
+                <span className="flex size-14 items-center justify-center rounded-full bg-emerald-500/10 text-emerald-600 dark:text-emerald-400">
+                  <CheckCircle2 className="size-7" aria-hidden="true" />
+                </span>
+                <h2 className="mt-5 text-xl font-semibold">
+                  {initialClaims.length === 0
+                    ? "The queue is clear"
+                    : "No claims match these filters"}
+                </h2>
+                <p className="mt-2 max-w-md text-sm text-muted-foreground">
+                  {initialClaims.length === 0
+                    ? "New initial payment claims will appear here when an applicant submits one."
+                    : "Try clearing the search or changing the sort and payment-state filters."}
+                </p>
+              </div>
+            ) : (
+              <div role="list" aria-label="Initial payment claims">
+                {visibleClaims.map((claim) => (
+                  <div key={claim.claim_id} role="listitem">
+                    <button
+                      type="button"
+                      onClick={() => void openClaim(claim.claim_id)}
+                      className="group grid w-full grid-cols-[auto_1fr_auto] items-center gap-4 px-5 py-4 text-left transition-[background-color,transform] duration-200 hover:bg-muted/40 focus-visible:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring active:scale-[0.996] md:grid-cols-[minmax(14rem,1.7fr)_minmax(8rem,0.8fr)_minmax(8rem,0.7fr)_minmax(8rem,0.7fr)_auto] md:px-6"
+                    >
+                      <div className="flex min-w-0 items-center gap-3">
+                        <ApplicantAvatar
+                          name={claim.applicant_name}
+                          handle={claim.applicant_handle}
+                          picture={claim.applicant_profile_picture}
+                          size="sm"
+                        />
+                        <div className="min-w-0">
+                          <p className="truncate font-semibold">
+                            {claim.applicant_name || "Unnamed applicant"}
+                          </p>
+                          <p className="truncate text-sm text-muted-foreground">
+                            {claim.applicant_handle || "No handle"}
+                          </p>
+                        </div>
+                      </div>
+                      <div className="hidden min-w-0 md:block">
+                        <p className="truncate text-sm font-medium">
+                          {claim.payer_type === "applicant"
+                            ? "Applicant"
+                            : claim.payer_name || "Other payer"}
+                        </p>
+                        <p className="text-xs text-muted-foreground">Payer</p>
+                      </div>
+                      <div className="hidden md:block">
+                        <p className="font-semibold">
+                          {claim.plan_type === "annual" ? "Annual" : "Monthly"}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          {claim.attempt_count} attempt
+                          {claim.attempt_count === 1 ? "" : "s"}
+                        </p>
+                      </div>
+                      <div className="hidden md:block">
+                        <p className="font-semibold tabular-nums">
+                          {formatAmount(claim.amount, claim.currency)}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          {formatDate(claim.claim_created_at)}
+                        </p>
+                      </div>
+                      <div className="flex items-center justify-end gap-3">
+                        <QueueStatusBadge status={claim.claim_status} />
+                        <ChevronRight
+                          className="size-5 text-muted-foreground transition-transform duration-200 group-hover:translate-x-0.5"
+                          aria-hidden="true"
+                        />
+                      </div>
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="hidden md:block">
+        <Dialog
+          open={selectedClaimId !== null}
+          onOpenChange={(open) => {
+            if (!open) closeClaim();
+          }}
+        >
+          <DialogContent className="max-h-[90vh] max-w-3xl overflow-hidden rounded-3xl p-0">
+            <DialogHeader className="sr-only">
+              <DialogTitle>Review initial payment claim</DialogTitle>
+              <DialogDescription>
+                Inspect the submitted application revision and decide this
+                payment claim.
+              </DialogDescription>
+            </DialogHeader>
+            {reviewSurface}
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      <div className="md:hidden">
+        <Drawer
+          open={selectedClaimId !== null}
+          onOpenChange={(open) => {
+            if (!open) closeClaim();
+          }}
+        >
+          <DrawerContent className="max-h-[96vh] overflow-hidden rounded-t-3xl p-0">
+            <DrawerHeader className="sr-only">
+              <DrawerTitle>Review initial payment claim</DrawerTitle>
+              <DrawerDescription>
+                Inspect the submitted application revision and decide this
+                payment claim.
+              </DrawerDescription>
+            </DrawerHeader>
+            {reviewSurface}
+          </DrawerContent>
+        </Drawer>
+      </div>
+    </section>
+  );
+}
+
+function ReviewContent({
+  action,
+  actionError,
+  detail,
+  detailLoading,
+  onApprove,
+  onClose,
+  onReject,
+  rejectionReason,
+  setRejectionReason,
+}: {
+  action: Action;
+  actionError: string | null;
+  detail: InitialPaymentClaimDetail | null;
+  detailLoading: boolean;
+  onApprove: () => Promise<void>;
+  onClose: () => void;
+  onReject: () => Promise<void>;
+  rejectionReason: string;
+  setRejectionReason: (value: string) => void;
+}) {
+  const claimHistory = getHistory(detail?.claim_history);
+  const auditHistory = getHistory(detail?.audit_history);
+  const isActionable = detail?.claim_status === "under_review";
+
+  return (
+    <div className="flex max-h-[90vh] flex-col bg-background">
+      <div className="flex items-start justify-between gap-4 border-b px-5 py-5 md:px-7">
+        <div className="flex min-w-0 items-center gap-3">
+          {detail ? (
+            <ApplicantAvatar
+              name={detail.applicant_name}
+              handle={detail.applicant_handle}
+              picture={detail.applicant_profile_picture}
+            />
+          ) : (
+            <span className="flex size-14 shrink-0 items-center justify-center rounded-full bg-muted">
+              <UserRound
+                className="size-6 text-muted-foreground"
+                aria-hidden="true"
+              />
+            </span>
+          )}
+          <div className="min-w-0">
+            <p className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
+              Initial claim review
+            </p>
+            <h2 className="mt-1 truncate text-xl font-semibold">
+              {detail?.applicant_name || "Loading applicant"}
+            </h2>
+            <p className="truncate text-sm text-muted-foreground">
+              {detail?.applicant_handle || detail?.organization_name || ""}
+            </p>
+          </div>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={onClose}
+          disabled={action !== null}
+          aria-label="Close review"
+          className="shrink-0 rounded-xl"
+        >
+          <X className="size-5" aria-hidden="true" />
+        </Button>
+      </div>
+
+      <div className="scrollbar overflow-y-auto px-5 py-5 md:px-7 md:py-6">
+        {detailLoading ? (
+          <div className="flex min-h-72 items-center justify-center">
+            <Loader2
+              className="size-7 animate-spin text-muted-foreground"
+              aria-label="Loading claim details"
+            />
+          </div>
+        ) : !detail ? (
+          <div className="flex min-h-72 items-center justify-center">
+            <Alert variant="destructive" className="max-w-lg">
+              <AlertTriangle className="size-4" aria-hidden="true" />
+              <AlertTitle>Review unavailable</AlertTitle>
+              <AlertDescription>
+                {actionError || "Refresh the queue and try again."}
+              </AlertDescription>
+            </Alert>
+          </div>
+        ) : (
+          <div className="space-y-6">
+            <div className="flex flex-wrap items-center gap-2">
+              <QueueStatusBadge status={detail.claim_status} />
+              <Badge variant="secondary">
+                Revision {detail.revision_number}
+              </Badge>
+              <Badge variant="secondary">{detail.organization_name}</Badge>
+            </div>
+
+            {actionError ? (
+              <Alert variant="destructive" aria-live="assertive">
+                <AlertTriangle className="size-4" aria-hidden="true" />
+                <AlertTitle>Decision not completed</AlertTitle>
+                <AlertDescription>{actionError}</AlertDescription>
+              </Alert>
+            ) : null}
+
+            <div className="grid gap-3 sm:grid-cols-3">
+              <SummaryCard
+                label="Claim amount"
+                value={formatAmount(detail.amount, detail.currency)}
+              />
+              <SummaryCard
+                label="Plan"
+                value={detail.plan_type === "annual" ? "Annual" : "Monthly"}
+              />
+              <SummaryCard
+                label="Submitted"
+                value={formatDate(detail.claim_created_at)}
+              />
+            </div>
+
+            <section aria-labelledby="payment-evidence-title">
+              <SectionHeading
+                id="payment-evidence-title"
+                icon={<CheckCircle2 className="size-4" aria-hidden="true" />}
+                title="Payment evidence"
+              />
+              <div className="mt-3 grid gap-x-6 gap-y-4 rounded-2xl border bg-muted/20 p-4 sm:grid-cols-2">
+                <DetailField label="Payer">
+                  {detail.payer_type === "applicant"
+                    ? "Applicant"
+                    : detail.payer_name || "Other payer"}
+                </DetailField>
+                <DetailField label="Claim attempts">
+                  {detail.attempt_count}
+                </DetailField>
+                <DetailField label="Claim created">
+                  {formatDate(detail.claim_created_at)}
+                </DetailField>
+                <DetailField label="Terms version">
+                  {detail.terms_version}
+                </DetailField>
+              </div>
+            </section>
+
+            <section aria-labelledby="application-title">
+              <SectionHeading
+                id="application-title"
+                icon={<FileText className="size-4" aria-hidden="true" />}
+                title="Submitted application revision"
+              />
+              <div className="mt-3 grid gap-x-6 gap-y-4 rounded-2xl border bg-muted/20 p-4 sm:grid-cols-2">
+                <DetailField label="Full name">{detail.full_name}</DetailField>
+                <DetailField label="Handle">
+                  {detail.applicant_handle}
+                </DetailField>
+                <DetailField label="Birth date">
+                  {detail.birth_date}
+                </DetailField>
+                <DetailField label="Nationality">
+                  {detail.nationality}
+                </DetailField>
+                <DetailField label="Marital status">
+                  {detail.marital_status}
+                </DetailField>
+                <DetailField label="Profession">
+                  {detail.profession}
+                </DetailField>
+                <DetailField label="Birthplace">
+                  {detail.birthplace}
+                </DetailField>
+                <DetailField label="Email">{detail.email}</DetailField>
+                <DetailField label="Phone">{detail.phone}</DetailField>
+                <DetailField label="CPF">{detail.cpf}</DetailField>
+                <DetailField label="ID document">
+                  {detail.id_document_number}
+                </DetailField>
+                <DetailField label="Issuing authority">
+                  {detail.id_document_issuer}
+                </DetailField>
+                <DetailField label="Postal code">
+                  {detail.postal_code}
+                </DetailField>
+                <DetailField label="Address">{detail.address_line}</DetailField>
+                <DetailField label="City / state">
+                  {[detail.city, detail.state].filter(Boolean).join(" / ")}
+                </DetailField>
+                <DetailField label="Blood type">
+                  {detail.blood_type}
+                </DetailField>
+                <DetailField label="Allergies">
+                  {detail.has_allergies ? detail.allergies : "None reported"}
+                </DetailField>
+                <DetailField label="Dietary restrictions">
+                  {detail.has_dietary_restrictions
+                    ? detail.dietary_restrictions
+                    : "None reported"}
+                </DetailField>
+                <DetailField label="Highline experience">
+                  {detail.highline_experience}
+                </DetailField>
+                <DetailField label="Rescue course">
+                  {detail.has_rescue_course ? "Yes" : "No"}
+                </DetailField>
+                <DetailField label="First-aid course">
+                  {detail.first_aid_course}
+                </DetailField>
+                <DetailField label="Emergency contact">
+                  {[
+                    detail.emergency_contact_name,
+                    detail.emergency_contact_relationship,
+                    detail.emergency_contact_phone,
+                  ]
+                    .filter(Boolean)
+                    .join(" · ")}
+                </DetailField>
+              </div>
+            </section>
+
+            {claimHistory.length > 0 || auditHistory.length > 0 ? (
+              <section aria-labelledby="history-title">
+                <SectionHeading
+                  id="history-title"
+                  icon={<CalendarDays className="size-4" aria-hidden="true" />}
+                  title="Immutable history"
+                />
+                <div className="mt-3 grid gap-3 rounded-2xl border bg-muted/20 p-4 lg:grid-cols-2">
+                  <div>
+                    <p className="text-xs font-medium uppercase tracking-[0.08em] text-muted-foreground">
+                      Claim states
+                    </p>
+                    <div className="mt-2 space-y-2">
+                      {claimHistory.map((history) => (
+                        <div
+                          key={String(history.claim_id)}
+                          className="flex flex-wrap items-center justify-between gap-2 text-sm"
+                        >
+                          <span className="font-medium">
+                            {String(history.status)}
+                          </span>
+                          <span className="text-muted-foreground">
+                            {formatDate(String(history.created_at))}
+                            {history.decision_reason
+                              ? ` · ${String(history.decision_reason)}`
+                              : ""}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                  <div>
+                    <p className="text-xs font-medium uppercase tracking-[0.08em] text-muted-foreground">
+                      Audit events
+                    </p>
+                    <div className="mt-2 space-y-2">
+                      {auditHistory.map((history) => (
+                        <div
+                          key={String(history.id)}
+                          className="flex flex-wrap items-center justify-between gap-2 text-sm"
+                        >
+                          <span className="font-medium">
+                            {String(history.previous_state)} →{" "}
+                            {String(history.next_state)}
+                          </span>
+                          <span className="text-muted-foreground">
+                            {formatDate(String(history.created_at))}
+                            {history.reason
+                              ? ` · ${String(history.reason)}`
+                              : ""}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </section>
+            ) : null}
+          </div>
+        )}
+      </div>
+
+      {detail && isActionable ? (
+        <div className="border-t bg-card px-5 py-4 md:px-7">
+          <label htmlFor="rejection-reason" className="text-sm font-medium">
+            Rejection reason
+            <span className="ml-1 text-destructive" aria-hidden="true">
+              *
+            </span>
+          </label>
+          <Textarea
+            id="rejection-reason"
+            value={rejectionReason}
+            onChange={(event) => setRejectionReason(event.target.value)}
+            maxLength={500}
+            placeholder="Explain what the applicant needs to correct."
+            className="mt-2 min-h-20 rounded-xl"
+            disabled={action !== null}
+          />
+          <div className="mt-3 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={() => void onReject()}
+              disabled={action !== null}
+              className="h-11 rounded-xl px-5 active:scale-[0.96]"
+            >
+              {action === "reject" ? (
+                <Loader2
+                  className="mr-2 size-4 animate-spin"
+                  aria-hidden="true"
+                />
+              ) : (
+                <XCircle className="mr-2 size-4" aria-hidden="true" />
+              )}
+              Reject claim
+            </Button>
+            <Button
+              type="button"
+              onClick={() => void onApprove()}
+              disabled={action !== null}
+              className="h-11 rounded-xl px-5 active:scale-[0.96]"
+            >
+              {action === "approve" ? (
+                <Loader2
+                  className="mr-2 size-4 animate-spin"
+                  aria-hidden="true"
+                />
+              ) : (
+                <Check className="mr-2 size-4" aria-hidden="true" />
+              )}
+              Verify payment and admit member.
+            </Button>
+          </div>
+        </div>
+      ) : detail ? (
+        <div className="border-t bg-muted/20 px-5 py-4 md:px-7">
+          <div className="flex items-start gap-3 text-sm text-muted-foreground">
+            {detail.claim_status === "approved" ? (
+              <CheckCircle2
+                className="mt-0.5 size-5 shrink-0 text-emerald-600"
+                aria-hidden="true"
+              />
+            ) : (
+              <XCircle
+                className="mt-0.5 size-5 shrink-0 text-destructive"
+                aria-hidden="true"
+              />
+            )}
+            <p>
+              This claim is {detail.claim_status}. The authoritative state has
+              been preserved; close this review and refresh the queue.
+            </p>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function SummaryCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-2xl border bg-card p-4 shadow-sm">
+      <p className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
+        {label}
+      </p>
+      <p className="mt-2 truncate font-semibold tabular-nums">{value}</p>
+    </div>
+  );
+}
+
+function SectionHeading({
+  icon,
+  id,
+  title,
+}: {
+  icon: ReactNode;
+  id: string;
+  title: string;
+}) {
+  return (
+    <h3 id={id} className="flex items-center gap-2 text-sm font-semibold">
+      <span className="text-muted-foreground">{icon}</span>
+      {title}
+    </h3>
+  );
+}
+
+function DetailField({
+  children,
+  label,
+}: {
+  children: ReactNode;
+  label: string;
+}) {
+  return (
+    <div className="min-w-0">
+      <dt className="text-xs font-medium uppercase tracking-[0.08em] text-muted-foreground">
+        {label}
+      </dt>
+      <dd className="mt-1 break-words text-sm font-medium">
+        {children || "—"}
+      </dd>
+    </div>
+  );
+}

--- a/next/app/[locale]/admin/claims/page.tsx
+++ b/next/app/[locale]/admin/claims/page.tsx
@@ -1,0 +1,52 @@
+import { createSupabaseClient } from "@/utils/supabase/server";
+
+import InitialPaymentClaimsQueue from "./_components/initial-payment-claims-queue";
+
+export default async function InitialPaymentClaimsPage() {
+  const supabase = await createSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return (
+      <section className="mx-auto flex min-h-[60vh] max-w-3xl items-center px-4 py-12 md:px-6">
+        <div className="w-full rounded-3xl border bg-card p-8 shadow-sm">
+          <p className="text-sm font-medium uppercase tracking-[0.18em] text-muted-foreground">
+            Association administration
+          </p>
+          <h1 className="mt-3 text-3xl font-semibold tracking-tight">
+            Sign in to open the review queue
+          </h1>
+          <p className="mt-3 max-w-xl text-muted-foreground">
+            Only an authorized association admin can inspect or decide an
+            initial payment claim.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  const { data, error } = await supabase.rpc("get_initial_payment_claim_queue");
+
+  if (error) {
+    return (
+      <section className="mx-auto flex min-h-[60vh] max-w-3xl items-center px-4 py-12 md:px-6">
+        <div className="w-full rounded-3xl border border-destructive/40 bg-card p-8 shadow-sm">
+          <p className="text-sm font-medium uppercase tracking-[0.18em] text-destructive">
+            Review queue unavailable
+          </p>
+          <h1 className="mt-3 text-3xl font-semibold tracking-tight">
+            We could not load this queue
+          </h1>
+          <p className="mt-3 text-muted-foreground">
+            Refresh the page and try again. Your account and the association
+            authorization are checked by the database for every request.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  return <InitialPaymentClaimsQueue initialClaims={data ?? []} />;
+}

--- a/next/components/layout/navbar/ProfileMenu.tsx
+++ b/next/components/layout/navbar/ProfileMenu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { AvatarIcon, ExitIcon } from "@radix-ui/react-icons";
+import { ShieldCheck } from "lucide-react";
 import { User } from "@supabase/supabase-js";
 import { useTranslations } from "next-intl";
 
@@ -50,6 +51,12 @@ export default function ProfileMenu({ user }: { user: User }) {
           <DropdownMenuItem asChild>
             <Link href={`/profile/${username.replace("@", "")}`}>
               {t("myProfile")}
+            </Link>
+          </DropdownMenuItem>
+          <DropdownMenuItem asChild>
+            <Link href="/admin/claims">
+              <ShieldCheck className="mr-2 size-4" aria-hidden="true" />
+              Review payment claims
             </Link>
           </DropdownMenuItem>
           <DropdownMenuItem onClick={signOut}>

--- a/next/lib/initial-payment-claims.ts
+++ b/next/lib/initial-payment-claims.ts
@@ -1,0 +1,13 @@
+import type { Database } from "@chooselife/database";
+
+export type InitialPaymentClaimQueueRow =
+  Database["public"]["Functions"]["get_initial_payment_claim_queue"]["Returns"][number];
+
+export type InitialPaymentClaimDetail =
+  Database["public"]["Functions"]["get_initial_payment_claim_detail"]["Returns"][number];
+
+export type ApproveInitialClaimResult =
+  Database["public"]["Functions"]["approve_initial_claim"]["Returns"][number];
+
+export type RejectInitialClaimResult =
+  Database["public"]["Functions"]["reject_initial_claim"]["Returns"][number];

--- a/packages/database/database-generated.types.ts
+++ b/packages/database/database-generated.types.ts
@@ -1667,6 +1667,21 @@ export type Database = {
         Args: { p_payment_id: string }
         Returns: boolean
       }
+      approve_initial_claim: {
+        Args: { p_claim_id: string }
+        Returns: {
+          audit_event_id: string
+          claim_id: string
+          claim_status: Database["public"]["Enums"]["payment_claim_status_enum"]
+          decision_applied_now: boolean
+          membership_user_id: string
+          obligation_id: string
+          obligation_status: Database["public"]["Enums"]["payment_obligation_status_enum"]
+          subscription_current_period_end: string
+          subscription_id: string
+          subscription_status: Database["public"]["Enums"]["subscription_status_enum"]
+        }[]
+      }
       book_festival_schedule_slot: {
         Args: {
           target_display_name?: string
@@ -1803,6 +1818,87 @@ export type Database = {
           name: string
           sector_id: number
           status: string
+        }[]
+      }
+      get_initial_payment_claim_detail: {
+        Args: { p_claim_id: string }
+        Returns: {
+          accepted_terms_at: string
+          address_line: string
+          allergies: string
+          amount: number
+          applicant_handle: string
+          applicant_name: string
+          applicant_profile_picture: string
+          application_id: string
+          application_revision_id: string
+          attempt_count: number
+          audit_history: Json
+          birth_date: string
+          birthplace: string
+          blood_type: Database["public"]["Enums"]["blood_type_enum"]
+          city: string
+          claim_created_at: string
+          claim_history: Json
+          claim_id: string
+          claim_status: Database["public"]["Enums"]["payment_claim_status_enum"]
+          claimant_user_id: string
+          cpf: string
+          currency: string
+          decided_at: string
+          decision_reason: string
+          dietary_restrictions: string
+          draft_version: number
+          email: string
+          emergency_contact_name: string
+          emergency_contact_phone: string
+          emergency_contact_relationship: string
+          first_aid_course: Database["public"]["Enums"]["first_aid_course_enum"]
+          full_name: string
+          has_allergies: boolean
+          has_dietary_restrictions: boolean
+          has_rescue_course: boolean
+          highline_experience: Database["public"]["Enums"]["highline_experience_enum"]
+          id_document_issuer: string
+          id_document_number: string
+          marital_status: Database["public"]["Enums"]["marital_status_enum"]
+          nationality: string
+          obligation_id: string
+          organization_id: string
+          organization_name: string
+          organization_slug: string
+          payer_name: string
+          payer_type: Database["public"]["Enums"]["payment_claim_payer_type_enum"]
+          phone: string
+          plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"]
+          postal_code: string
+          profession: string
+          revision_number: number
+          state: string
+          submitted_at: string
+          terms_version: string
+        }[]
+      }
+      get_initial_payment_claim_queue: {
+        Args: never
+        Returns: {
+          amount: number
+          applicant_handle: string
+          applicant_name: string
+          applicant_profile_picture: string
+          application_revision_id: string
+          attempt_count: number
+          claim_created_at: string
+          claim_id: string
+          claim_status: Database["public"]["Enums"]["payment_claim_status_enum"]
+          claimant_user_id: string
+          currency: string
+          obligation_id: string
+          organization_id: string
+          organization_name: string
+          payer_name: string
+          payer_type: Database["public"]["Enums"]["payment_claim_payer_type_enum"]
+          plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"]
         }[]
       }
       get_manual_payment_instructions: {
@@ -1952,6 +2048,18 @@ export type Database = {
       regenerate_festival_schedule_window: {
         Args: { target_window_id: string }
         Returns: number
+      }
+      reject_initial_claim: {
+        Args: { p_claim_id: string; p_reason: string }
+        Returns: {
+          audit_event_id: string
+          claim_id: string
+          claim_status: Database["public"]["Enums"]["payment_claim_status_enum"]
+          decision_applied_now: boolean
+          decision_reason: string
+          obligation_id: string
+          obligation_status: Database["public"]["Enums"]["payment_obligation_status_enum"]
+        }[]
       }
       submit_association_application: {
         Args: {

--- a/supabase/migrations/20260823000000_verify_initial_payment_and_admit_member.sql
+++ b/supabase/migrations/20260823000000_verify_initial_payment_and_admit_member.sql
@@ -1,0 +1,1053 @@
+-- Verify an initial payment claim and admit the applicant in one transaction.
+--
+-- The initial-admission workflow deliberately does not use the generic payment
+-- settlement path. A payment row is a renewal billing primitive; an initial
+-- obligation becomes settled only after an authorized association admin
+-- verifies a claim.
+
+create index if not exists payment_claims_current_queue_idx
+  on public.payment_claims (organization_id, created_at asc, id)
+  where status = 'under_review'::public.payment_claim_status_enum;
+
+create index if not exists payment_obligations_initial_queue_idx
+  on public.payment_obligations (organization_id, status, application_revision_id)
+  where purpose = 'initial_admission'::public.payment_obligation_purpose_enum;
+
+-- A generic succeeded-payment webhook must not turn a legacy initial payment
+-- into admission. The admin command below is the only admission boundary.
+create or replace function public.apply_payment_settlement_effects(
+  p_payment_id uuid
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  payment_record record;
+  subscription_record record;
+  period_start timestamp with time zone;
+begin
+  select
+    p.id,
+    p.subscription_id,
+    p.user_id,
+    p.organization_id,
+    p.status,
+    p.settlement_applied_at
+  into payment_record
+  from public.payments p
+  where p.id = p_payment_id
+  for update;
+
+  if not found then
+    raise exception 'Payment % was not found.', p_payment_id
+      using errcode = 'P0002';
+  end if;
+
+  if payment_record.status <> 'succeeded'::public.payment_status_enum then
+    return false;
+  end if;
+
+  -- Legacy rows can be linked to an initial obligation during migration. They
+  -- remain reconciliation evidence; succeeding them is never admission.
+  if exists (
+    select 1
+    from public.payment_obligations po
+    where po.legacy_payment_id = payment_record.id
+      and po.purpose = 'initial_admission'::public.payment_obligation_purpose_enum
+  ) then
+    return false;
+  end if;
+
+  if payment_record.settlement_applied_at is not null then
+    return false;
+  end if;
+
+  select s.current_period_end, s.plan_type
+  into subscription_record
+  from public.subscriptions s
+  where s.id = payment_record.subscription_id
+  for update;
+
+  if not found then
+    raise warning 'Cannot apply payment effects. Subscription % was not found for payment %.',
+      payment_record.subscription_id,
+      payment_record.id;
+    return false;
+  end if;
+
+  period_start = greatest(
+    coalesce(subscription_record.current_period_end, timezone('utc'::text, now())),
+    timezone('utc'::text, now())
+  );
+
+  update public.subscriptions s
+  set
+    status = 'active'::public.subscription_status_enum,
+    current_period_end = period_start + case subscription_record.plan_type
+      when 'annual'::public.subscription_plan_type_enum then interval '1 year'
+      else interval '1 month'
+    end
+  where s.id = payment_record.subscription_id;
+
+  insert into public.organization_members (organization_id, user_id, role)
+  values (
+    payment_record.organization_id,
+    payment_record.user_id,
+    'member'::public.organization_role_enum
+  )
+  on conflict (organization_id, user_id) do update
+  set role = case
+    when public.organization_members.role = 'admin'::public.organization_role_enum
+      then 'admin'::public.organization_role_enum
+    else excluded.role
+  end;
+
+  update public.payments p
+  set settlement_applied_at = timezone('utc'::text, now())
+  where p.id = payment_record.id
+    and p.settlement_applied_at is null;
+
+  return true;
+end;
+$$;
+
+comment on function public.apply_payment_settlement_effects(uuid) is
+  'Applies renewal payment effects exactly once. Initial-admission obligations are excluded; admission uses approve_initial_claim.';
+
+revoke all on function public.apply_payment_settlement_effects(uuid) from public;
+revoke all on function public.apply_payment_settlement_effects(uuid) from anon;
+revoke all on function public.apply_payment_settlement_effects(uuid) from authenticated;
+grant execute on function public.apply_payment_settlement_effects(uuid) to service_role;
+
+create or replace function public.apply_succeeded_payment_effects()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if new.status <> 'succeeded'::public.payment_status_enum then
+    return new;
+  end if;
+
+  perform public.apply_payment_settlement_effects(new.id);
+  return new;
+end;
+$$;
+
+revoke all on function public.apply_succeeded_payment_effects() from public;
+revoke all on function public.apply_succeeded_payment_effects() from anon;
+revoke all on function public.apply_succeeded_payment_effects() from authenticated;
+
+-- Only the intention-revealing decision commands may change decision fields.
+-- Evidence fields remain immutable as before.
+create or replace function public.reject_payment_claim_evidence_mutation()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if tg_op = 'DELETE' then
+    raise exception 'Payment claim evidence is immutable.'
+      using errcode = '55000';
+  end if;
+
+  if old.id is distinct from new.id
+    or old.obligation_id is distinct from new.obligation_id
+    or old.organization_id is distinct from new.organization_id
+    or old.claimant_user_id is distinct from new.claimant_user_id
+    or old.payer_type is distinct from new.payer_type
+    or old.payer_name is distinct from new.payer_name
+    or old.created_at is distinct from new.created_at then
+    raise exception 'Payment claim evidence is immutable.'
+      using errcode = '55000';
+  end if;
+
+  if old.status is distinct from new.status
+    or old.decided_at is distinct from new.decided_at
+    or old.decision_reason is distinct from new.decision_reason then
+    if current_setting('app.payment_claim_decision_command', true) <> 'on' then
+      raise exception 'Payment claim decisions must use the decision command.'
+        using errcode = '42501';
+    end if;
+
+    if old.status <> 'under_review'::public.payment_claim_status_enum
+      or new.status not in (
+        'approved'::public.payment_claim_status_enum,
+        'rejected'::public.payment_claim_status_enum
+      )
+      or new.decided_at is null
+      or (new.status = 'approved'::public.payment_claim_status_enum
+        and new.decision_reason is not null)
+      or (new.status = 'rejected'::public.payment_claim_status_enum
+        and nullif(btrim(new.decision_reason), '') is null) then
+      raise exception 'Invalid payment claim decision transition.'
+        using errcode = '23514';
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+revoke all on function public.reject_payment_claim_evidence_mutation() from public;
+revoke all on function public.reject_payment_claim_evidence_mutation() from anon;
+revoke all on function public.reject_payment_claim_evidence_mutation() from authenticated;
+
+create or replace function public.get_initial_payment_claim_queue()
+returns table (
+  claim_id uuid,
+  obligation_id uuid,
+  application_revision_id uuid,
+  organization_id uuid,
+  organization_name text,
+  claimant_user_id uuid,
+  applicant_name text,
+  applicant_handle text,
+  applicant_profile_picture text,
+  payer_type public.payment_claim_payer_type_enum,
+  payer_name text,
+  plan_type public.subscription_plan_type_enum,
+  amount integer,
+  currency text,
+  claim_created_at timestamp with time zone,
+  attempt_count bigint,
+  claim_status public.payment_claim_status_enum
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select
+    pc.id,
+    po.id,
+    po.application_revision_id,
+    pc.organization_id,
+    o.name,
+    pc.claimant_user_id,
+    p.name,
+    p.username,
+    p.profile_picture,
+    pc.payer_type,
+    pc.payer_name,
+    po.plan_type,
+    po.amount,
+    po.currency,
+    pc.created_at,
+    (
+      select count(*)
+      from public.payment_claims attempts
+      where attempts.obligation_id = po.id
+    ),
+    pc.status
+  from public.payment_claims pc
+  join public.payment_obligations po on po.id = pc.obligation_id
+  join public.membership_application_revisions mar
+    on mar.id = po.application_revision_id
+  join public.membership_applications ma on ma.id = mar.application_id
+  join public.organizations o on o.id = pc.organization_id
+  join public.profiles p on p.id = pc.claimant_user_id
+  where pc.status = 'under_review'::public.payment_claim_status_enum
+    and po.purpose = 'initial_admission'::public.payment_obligation_purpose_enum
+    and po.status = 'available'::public.payment_obligation_status_enum
+    and pc.organization_id = po.organization_id
+    and po.organization_id = mar.organization_id
+    and po.user_id = mar.user_id
+    and ma.organization_id = mar.organization_id
+    and ma.user_id = mar.user_id
+    and ma.status = 'submitted'::public.membership_application_status_enum
+    and o.organization_type = 'association'::public.organization_type_enum
+    and pc.claimant_user_id <> (select auth.uid())
+    and exists (
+      select 1
+      from public.organization_members reviewer_membership
+      where reviewer_membership.organization_id = pc.organization_id
+        and reviewer_membership.user_id = (select auth.uid())
+        and reviewer_membership.role = 'admin'::public.organization_role_enum
+    )
+  order by pc.created_at asc, pc.id asc;
+$$;
+
+comment on function public.get_initial_payment_claim_queue() is
+  'Returns a privacy-preserving queue of current initial claims for associations where the caller is an admin.';
+
+revoke all on function public.get_initial_payment_claim_queue() from public;
+revoke all on function public.get_initial_payment_claim_queue() from anon;
+grant execute on function public.get_initial_payment_claim_queue() to authenticated;
+
+create or replace function public.get_initial_payment_claim_detail(
+  p_claim_id uuid
+)
+returns table (
+  claim_id uuid,
+  obligation_id uuid,
+  application_id uuid,
+  application_revision_id uuid,
+  revision_number integer,
+  draft_version bigint,
+  organization_id uuid,
+  organization_name text,
+  organization_slug text,
+  claimant_user_id uuid,
+  applicant_name text,
+  applicant_handle text,
+  applicant_profile_picture text,
+  claim_status public.payment_claim_status_enum,
+  payer_type public.payment_claim_payer_type_enum,
+  payer_name text,
+  claim_created_at timestamp with time zone,
+  decided_at timestamp with time zone,
+  decision_reason text,
+  attempt_count bigint,
+  plan_type public.subscription_plan_type_enum,
+  amount integer,
+  currency text,
+  terms_version text,
+  accepted_terms_at timestamp with time zone,
+  submitted_at timestamp with time zone,
+  full_name text,
+  birth_date date,
+  nationality text,
+  marital_status public.marital_status_enum,
+  profession text,
+  birthplace text,
+  cpf text,
+  id_document_number text,
+  id_document_issuer text,
+  postal_code text,
+  address_line text,
+  city text,
+  state text,
+  email text,
+  phone text,
+  blood_type public.blood_type_enum,
+  has_allergies boolean,
+  allergies text,
+  has_dietary_restrictions boolean,
+  dietary_restrictions text,
+  highline_experience public.highline_experience_enum,
+  has_rescue_course boolean,
+  first_aid_course public.first_aid_course_enum,
+  emergency_contact_name text,
+  emergency_contact_relationship text,
+  emergency_contact_phone text,
+  claim_history jsonb,
+  audit_history jsonb
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select
+    pc.id,
+    po.id,
+    mar.application_id,
+    mar.id,
+    mar.revision_number,
+    mar.draft_version,
+    pc.organization_id,
+    o.name,
+    o.slug,
+    pc.claimant_user_id,
+    p.name,
+    p.username,
+    p.profile_picture,
+    pc.status,
+    pc.payer_type,
+    pc.payer_name,
+    pc.created_at,
+    pc.decided_at,
+    pc.decision_reason,
+    (
+      select count(*)
+      from public.payment_claims attempts
+      where attempts.obligation_id = po.id
+    ),
+    mar.plan_type,
+    mar.plan_amount,
+    mar.currency,
+    mar.terms_version,
+    mar.accepted_terms_at,
+    mar.submitted_at,
+    mar.full_name,
+    mar.birth_date,
+    mar.nationality,
+    mar.marital_status,
+    mar.profession,
+    mar.birthplace,
+    mar.cpf,
+    mar.id_document_number,
+    mar.id_document_issuer,
+    mar.postal_code,
+    mar.address_line,
+    mar.city,
+    mar.state,
+    mar.email,
+    mar.phone,
+    mar.blood_type,
+    mar.has_allergies,
+    mar.allergies,
+    mar.has_dietary_restrictions,
+    mar.dietary_restrictions,
+    mar.highline_experience,
+    mar.has_rescue_course,
+    mar.first_aid_course,
+    mar.emergency_contact_name,
+    mar.emergency_contact_relationship,
+    mar.emergency_contact_phone,
+    coalesce(
+      (
+        select jsonb_agg(
+          jsonb_build_object(
+            'claim_id', history.id,
+            'status', history.status,
+            'payer_type', history.payer_type,
+            'payer_name', history.payer_name,
+            'created_at', history.created_at,
+            'decided_at', history.decided_at,
+            'decision_reason', history.decision_reason
+          )
+          order by history.created_at asc, history.id asc
+        )
+        from public.payment_claims history
+        where history.obligation_id = po.id
+      ),
+      '[]'::jsonb
+    ),
+    coalesce(
+      (
+        select jsonb_agg(
+          jsonb_build_object(
+            'id', audit.id,
+            'claim_id', audit.claim_id,
+            'actor_user_id', audit.actor_user_id,
+            'previous_state', audit.previous_state,
+            'next_state', audit.next_state,
+            'reason', audit.reason,
+            'created_at', audit.created_at
+          )
+          order by audit.created_at asc, audit.id asc
+        )
+        from public.payment_claim_audit_events audit
+        where audit.obligation_id = po.id
+      ),
+      '[]'::jsonb
+    )
+  from public.payment_claims pc
+  join public.payment_obligations po on po.id = pc.obligation_id
+  join public.membership_application_revisions mar
+    on mar.id = po.application_revision_id
+  join public.membership_applications ma on ma.id = mar.application_id
+  join public.organizations o on o.id = pc.organization_id
+  join public.profiles p on p.id = pc.claimant_user_id
+  where pc.id = p_claim_id
+    and pc.organization_id = po.organization_id
+    and po.organization_id = mar.organization_id
+    and po.user_id = mar.user_id
+    and ma.organization_id = mar.organization_id
+    and ma.user_id = mar.user_id
+    and ma.status = 'submitted'::public.membership_application_status_enum
+    and o.organization_type = 'association'::public.organization_type_enum
+    and pc.claimant_user_id <> (select auth.uid())
+    and exists (
+      select 1
+      from public.organization_members reviewer_membership
+      where reviewer_membership.organization_id = pc.organization_id
+        and reviewer_membership.user_id = (select auth.uid())
+        and reviewer_membership.role = 'admin'::public.organization_role_enum
+    );
+$$;
+
+comment on function public.get_initial_payment_claim_detail(uuid) is
+  'Returns the exact immutable submitted application revision and authorized claim history for an association admin.';
+
+revoke all on function public.get_initial_payment_claim_detail(uuid) from public;
+revoke all on function public.get_initial_payment_claim_detail(uuid) from anon;
+grant execute on function public.get_initial_payment_claim_detail(uuid) to authenticated;
+
+create or replace function public.approve_initial_claim(
+  p_claim_id uuid
+)
+returns table (
+  claim_id uuid,
+  obligation_id uuid,
+  claim_status public.payment_claim_status_enum,
+  obligation_status public.payment_obligation_status_enum,
+  membership_user_id uuid,
+  subscription_id uuid,
+  subscription_status public.subscription_status_enum,
+  subscription_current_period_end timestamp with time zone,
+  audit_event_id uuid,
+  decision_applied_now boolean
+)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  actor_id uuid := auth.uid();
+  claim_record public.payment_claims%rowtype;
+  organization_record public.organizations%rowtype;
+  reviewer_membership public.organization_members%rowtype;
+  obligation_record public.payment_obligations%rowtype;
+  revision_record public.membership_application_revisions%rowtype;
+  application_record public.membership_applications%rowtype;
+  applicant_membership public.organization_members%rowtype;
+  subscription_record public.subscriptions%rowtype;
+  audit_record public.payment_claim_audit_events%rowtype;
+  applicant_membership_found boolean;
+  subscription_found boolean;
+  audit_found boolean;
+  decision_timestamp timestamp with time zone := timezone('utc'::text, clock_timestamp());
+  subscription_end timestamp with time zone;
+begin
+  if actor_id is null then
+    raise exception 'Authentication is required.' using errcode = '42501';
+  end if;
+
+  select pc.*
+  into claim_record
+  from public.payment_claims pc
+  where pc.id = p_claim_id
+  for update;
+
+  if not found then
+    raise exception 'This claim is unavailable to the current reviewer.'
+      using errcode = '42501';
+  end if;
+
+  select o.*
+  into organization_record
+  from public.organizations o
+  where o.id = claim_record.organization_id
+  for update;
+
+  if not found then
+    raise exception 'This claim is unavailable to the current reviewer.'
+      using errcode = '42501';
+  end if;
+
+  if organization_record.organization_type <> 'association'::public.organization_type_enum then
+    raise exception 'This claim is unavailable to the current reviewer.'
+      using errcode = '42501';
+  end if;
+
+  select om.*
+  into reviewer_membership
+  from public.organization_members om
+  where om.organization_id = claim_record.organization_id
+    and om.user_id = actor_id
+  for update;
+
+  if not found then
+    raise exception 'This claim is unavailable to the current reviewer.'
+      using errcode = '42501';
+  end if;
+
+  if reviewer_membership.role <> 'admin'::public.organization_role_enum
+    or claim_record.claimant_user_id = actor_id then
+    raise exception 'This claim is unavailable to the current reviewer.'
+      using errcode = '42501';
+  end if;
+
+  select po.*
+  into obligation_record
+  from public.payment_obligations po
+  where po.id = claim_record.obligation_id
+  for update;
+
+  if not found then
+    raise exception 'This claim no longer has a valid payment obligation.'
+      using errcode = '23514';
+  end if;
+
+  select mar.*
+  into revision_record
+  from public.membership_application_revisions mar
+  where mar.id = obligation_record.application_revision_id
+  for update;
+
+  if not found then
+    raise exception 'This claim no longer has a valid application revision.'
+      using errcode = '23514';
+  end if;
+
+  select ma.*
+  into application_record
+  from public.membership_applications ma
+  where ma.id = revision_record.application_id
+  for update;
+
+  if not found then
+    raise exception 'This claim no longer has a valid application.'
+      using errcode = '23514';
+  end if;
+
+  -- Lock the applicant membership and subscription in the same order for
+  -- approve and reject. This keeps concurrent decisions deterministic.
+  select om.*
+  into applicant_membership
+  from public.organization_members om
+  where om.organization_id = obligation_record.organization_id
+    and om.user_id = obligation_record.user_id
+  for update;
+  applicant_membership_found := found;
+
+  select s.*
+  into subscription_record
+  from public.subscriptions s
+  where s.organization_id = obligation_record.organization_id
+    and s.user_id = obligation_record.user_id
+  for update;
+  subscription_found := found;
+
+  if claim_record.status = 'approved'::public.payment_claim_status_enum then
+    if obligation_record.status <> 'settled'::public.payment_obligation_status_enum then
+      raise exception 'The approved claim is missing its settled obligation.'
+        using errcode = '23514';
+    end if;
+
+    select pcae.*
+    into audit_record
+    from public.payment_claim_audit_events pcae
+    where pcae.claim_id = claim_record.id
+      and pcae.next_state = 'payment_settled'
+    order by pcae.created_at asc, pcae.id asc
+    limit 1;
+    audit_found := found;
+
+    if not audit_found then
+      raise exception 'The approved claim is missing its audit event.'
+        using errcode = '23514';
+    end if;
+
+    if not applicant_membership_found
+      or not subscription_found
+      or subscription_record.status <> 'active'::public.subscription_status_enum then
+      raise exception 'The approved claim is missing its admission effects.'
+        using errcode = '23514';
+    end if;
+
+    return query
+    select
+      claim_record.id,
+      obligation_record.id,
+      claim_record.status,
+      obligation_record.status,
+      applicant_membership.user_id,
+      subscription_record.id,
+      subscription_record.status,
+      subscription_record.current_period_end,
+      audit_record.id,
+      false;
+    return;
+  end if;
+
+  if claim_record.status = 'rejected'::public.payment_claim_status_enum then
+    raise exception 'This claim was already rejected. Refresh before deciding.'
+      using errcode = '40001';
+  end if;
+
+  if claim_record.status <> 'under_review'::public.payment_claim_status_enum then
+    raise exception 'This claim is no longer awaiting review. Refresh before deciding.'
+      using errcode = '40001';
+  end if;
+
+  if obligation_record.purpose <> 'initial_admission'::public.payment_obligation_purpose_enum
+    or obligation_record.status <> 'available'::public.payment_obligation_status_enum
+    or obligation_record.payment_method <> 'manual_pix'
+    or nullif(btrim(obligation_record.pix_copy_paste), '') is null
+    or obligation_record.organization_id <> claim_record.organization_id
+    or obligation_record.user_id <> claim_record.claimant_user_id
+    or obligation_record.plan_type <> revision_record.plan_type
+    or obligation_record.amount <> revision_record.plan_amount
+    or obligation_record.currency <> revision_record.currency
+    or obligation_record.application_revision_id <> revision_record.id
+    or revision_record.organization_id <> claim_record.organization_id
+    or revision_record.user_id <> claim_record.claimant_user_id
+    or application_record.organization_id <> claim_record.organization_id
+    or application_record.user_id <> claim_record.claimant_user_id
+    or application_record.status <> 'submitted'::public.membership_application_status_enum then
+    raise exception 'This claim no longer matches an actionable initial application.'
+      using errcode = '40001';
+  end if;
+
+  if subscription_found
+    and subscription_record.plan_type <> revision_record.plan_type then
+    raise exception 'The applicant has a conflicting subscription plan.'
+      using errcode = '23514';
+  end if;
+
+  -- Preserve an existing admin role. A prior member row is also reused so the
+  -- approval is idempotent at the organization-membership boundary.
+  insert into public.organization_members (organization_id, user_id, role)
+  values (
+    obligation_record.organization_id,
+    obligation_record.user_id,
+    'member'::public.organization_role_enum
+  )
+  on conflict (organization_id, user_id) do update
+  set role = case
+    when public.organization_members.role = 'admin'::public.organization_role_enum
+      then 'admin'::public.organization_role_enum
+    else excluded.role
+  end
+  returning * into applicant_membership;
+
+  subscription_end = case revision_record.plan_type
+    when 'annual'::public.subscription_plan_type_enum
+      then decision_timestamp + interval '1 year'
+    else decision_timestamp + interval '1 month'
+  end;
+
+  if subscription_found then
+    update public.subscriptions s
+    set
+      plan_type = revision_record.plan_type,
+      status = 'active'::public.subscription_status_enum,
+      current_period_end = case
+        when subscription_record.status = 'active'::public.subscription_status_enum
+          and subscription_record.current_period_end is not null
+          and subscription_record.current_period_end > decision_timestamp
+          then subscription_record.current_period_end
+        else subscription_end
+      end
+    where s.id = subscription_record.id
+    returning * into subscription_record;
+  else
+    insert into public.subscriptions (
+      organization_id,
+      user_id,
+      plan_type,
+      status,
+      current_period_end
+    )
+    values (
+      obligation_record.organization_id,
+      obligation_record.user_id,
+      revision_record.plan_type,
+      'active'::public.subscription_status_enum,
+      subscription_end
+    )
+    returning * into subscription_record;
+  end if;
+
+  perform set_config('app.payment_claim_decision_command', 'on', true);
+
+  update public.payment_claims pc
+  set
+    status = 'approved'::public.payment_claim_status_enum,
+    decided_at = decision_timestamp,
+    decision_reason = null
+  where pc.id = claim_record.id;
+
+  perform set_config('app.payment_claim_decision_command', 'off', true);
+
+  update public.payment_obligations po
+  set
+    status = 'settled'::public.payment_obligation_status_enum,
+    settled_at = decision_timestamp
+  where po.id = obligation_record.id;
+
+  insert into public.payment_claim_audit_events (
+    organization_id,
+    obligation_id,
+    claim_id,
+    actor_user_id,
+    previous_state,
+    next_state,
+    reason,
+    created_at
+  )
+  values (
+    obligation_record.organization_id,
+    obligation_record.id,
+    claim_record.id,
+    actor_id,
+    'under_review',
+    'payment_settled',
+    null,
+    decision_timestamp
+  )
+  returning * into audit_record;
+
+  return query
+  select
+    claim_record.id,
+    obligation_record.id,
+    'approved'::public.payment_claim_status_enum,
+    'settled'::public.payment_obligation_status_enum,
+    applicant_membership.user_id,
+    subscription_record.id,
+    subscription_record.status,
+    subscription_record.current_period_end,
+    audit_record.id,
+    true;
+end;
+$$;
+
+comment on function public.approve_initial_claim(uuid) is
+  'Atomically verifies an actionable initial claim, settles its obligation, admits the applicant, activates the selected subscription schedule, and appends one audit event.';
+
+revoke all on function public.approve_initial_claim(uuid) from public;
+revoke all on function public.approve_initial_claim(uuid) from anon;
+grant execute on function public.approve_initial_claim(uuid) to authenticated;
+
+create or replace function public.reject_initial_claim(
+  p_claim_id uuid,
+  p_reason text
+)
+returns table (
+  claim_id uuid,
+  obligation_id uuid,
+  claim_status public.payment_claim_status_enum,
+  obligation_status public.payment_obligation_status_enum,
+  decision_reason text,
+  audit_event_id uuid,
+  decision_applied_now boolean
+)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  actor_id uuid := auth.uid();
+  claim_record public.payment_claims%rowtype;
+  organization_record public.organizations%rowtype;
+  reviewer_membership public.organization_members%rowtype;
+  obligation_record public.payment_obligations%rowtype;
+  revision_record public.membership_application_revisions%rowtype;
+  application_record public.membership_applications%rowtype;
+  applicant_membership public.organization_members%rowtype;
+  subscription_record public.subscriptions%rowtype;
+  audit_record public.payment_claim_audit_events%rowtype;
+  normalized_reason text;
+  decision_timestamp timestamp with time zone := timezone('utc'::text, clock_timestamp());
+begin
+  if actor_id is null then
+    raise exception 'Authentication is required.' using errcode = '42501';
+  end if;
+
+  normalized_reason = nullif(
+    btrim(regexp_replace(coalesce(p_reason, ''), '\s+', ' ', 'g')),
+    ''
+  );
+
+  if normalized_reason is null then
+    raise exception 'A rejection reason is required.' using errcode = '22023';
+  end if;
+
+  if char_length(normalized_reason) > 500 then
+    raise exception 'The rejection reason must be 500 characters or fewer.'
+      using errcode = '22023';
+  end if;
+
+  select pc.*
+  into claim_record
+  from public.payment_claims pc
+  where pc.id = p_claim_id
+  for update;
+
+  if not found then
+    raise exception 'This claim is unavailable to the current reviewer.'
+      using errcode = '42501';
+  end if;
+
+  select o.*
+  into organization_record
+  from public.organizations o
+  where o.id = claim_record.organization_id
+  for update;
+
+  if not found then
+    raise exception 'This claim is unavailable to the current reviewer.'
+      using errcode = '42501';
+  end if;
+
+  if organization_record.organization_type <> 'association'::public.organization_type_enum then
+    raise exception 'This claim is unavailable to the current reviewer.'
+      using errcode = '42501';
+  end if;
+
+  select om.*
+  into reviewer_membership
+  from public.organization_members om
+  where om.organization_id = claim_record.organization_id
+    and om.user_id = actor_id
+  for update;
+
+  if not found then
+    raise exception 'This claim is unavailable to the current reviewer.'
+      using errcode = '42501';
+  end if;
+
+  if reviewer_membership.role <> 'admin'::public.organization_role_enum
+    or claim_record.claimant_user_id = actor_id then
+    raise exception 'This claim is unavailable to the current reviewer.'
+      using errcode = '42501';
+  end if;
+
+  select po.*
+  into obligation_record
+  from public.payment_obligations po
+  where po.id = claim_record.obligation_id
+  for update;
+
+  if not found then
+    raise exception 'This claim no longer has a valid payment obligation.'
+      using errcode = '23514';
+  end if;
+
+  select mar.*
+  into revision_record
+  from public.membership_application_revisions mar
+  where mar.id = obligation_record.application_revision_id
+  for update;
+
+  if not found then
+    raise exception 'This claim no longer has a valid application revision.'
+      using errcode = '23514';
+  end if;
+
+  select ma.*
+  into application_record
+  from public.membership_applications ma
+  where ma.id = revision_record.application_id
+  for update;
+
+  if not found then
+    raise exception 'This claim no longer has a valid application.'
+      using errcode = '23514';
+  end if;
+
+  select om.*
+  into applicant_membership
+  from public.organization_members om
+  where om.organization_id = obligation_record.organization_id
+    and om.user_id = obligation_record.user_id
+  for update;
+
+  select s.*
+  into subscription_record
+  from public.subscriptions s
+  where s.organization_id = obligation_record.organization_id
+    and s.user_id = obligation_record.user_id
+  for update;
+
+  if claim_record.status = 'rejected'::public.payment_claim_status_enum then
+    if claim_record.decision_reason is distinct from normalized_reason then
+      raise exception 'This claim was already rejected with a different reason. Refresh before deciding.'
+        using errcode = '40001';
+    end if;
+
+    select pcae.*
+    into audit_record
+    from public.payment_claim_audit_events pcae
+    where pcae.claim_id = claim_record.id
+      and pcae.next_state = 'payment_available'
+    order by pcae.created_at asc, pcae.id asc
+    limit 1;
+
+    if not found then
+      raise exception 'The rejected claim is missing its audit event.'
+        using errcode = '23514';
+    end if;
+
+    return query
+    select
+      claim_record.id,
+      obligation_record.id,
+      claim_record.status,
+      obligation_record.status,
+      claim_record.decision_reason,
+      audit_record.id,
+      false;
+    return;
+  end if;
+
+  if claim_record.status = 'approved'::public.payment_claim_status_enum then
+    raise exception 'This claim was already approved. Refresh before deciding.'
+      using errcode = '40001';
+  end if;
+
+  if claim_record.status <> 'under_review'::public.payment_claim_status_enum then
+    raise exception 'This claim is no longer awaiting review. Refresh before deciding.'
+      using errcode = '40001';
+  end if;
+
+  if obligation_record.purpose <> 'initial_admission'::public.payment_obligation_purpose_enum
+    or obligation_record.status <> 'available'::public.payment_obligation_status_enum
+    or obligation_record.payment_method <> 'manual_pix'
+    or nullif(btrim(obligation_record.pix_copy_paste), '') is null
+    or obligation_record.organization_id <> claim_record.organization_id
+    or obligation_record.user_id <> claim_record.claimant_user_id
+    or obligation_record.plan_type <> revision_record.plan_type
+    or obligation_record.amount <> revision_record.plan_amount
+    or obligation_record.currency <> revision_record.currency
+    or obligation_record.application_revision_id <> revision_record.id
+    or revision_record.organization_id <> claim_record.organization_id
+    or revision_record.user_id <> claim_record.claimant_user_id
+    or application_record.organization_id <> claim_record.organization_id
+    or application_record.user_id <> claim_record.claimant_user_id
+    or application_record.status <> 'submitted'::public.membership_application_status_enum then
+    raise exception 'This claim no longer matches an actionable initial application.'
+      using errcode = '40001';
+  end if;
+
+  -- A rejected claim leaves the obligation and all admission effects untouched.
+  perform set_config('app.payment_claim_decision_command', 'on', true);
+
+  update public.payment_claims pc
+  set
+    status = 'rejected'::public.payment_claim_status_enum,
+    decided_at = decision_timestamp,
+    decision_reason = normalized_reason
+  where pc.id = claim_record.id;
+
+  perform set_config('app.payment_claim_decision_command', 'off', true);
+
+  insert into public.payment_claim_audit_events (
+    organization_id,
+    obligation_id,
+    claim_id,
+    actor_user_id,
+    previous_state,
+    next_state,
+    reason,
+    created_at
+  )
+  values (
+    obligation_record.organization_id,
+    obligation_record.id,
+    claim_record.id,
+    actor_id,
+    'under_review',
+    'payment_available',
+    normalized_reason,
+    decision_timestamp
+  )
+  returning * into audit_record;
+
+  return query
+  select
+    claim_record.id,
+    obligation_record.id,
+    'rejected'::public.payment_claim_status_enum,
+    obligation_record.status,
+    normalized_reason,
+    audit_record.id,
+    true;
+end;
+$$;
+
+comment on function public.reject_initial_claim(uuid, text) is
+  'Atomically rejects only the current initial claim, records a normalized reason, keeps the obligation available, and appends one audit event.';
+
+revoke all on function public.reject_initial_claim(uuid, text) from public;
+revoke all on function public.reject_initial_claim(uuid, text) from anon;
+grant execute on function public.reject_initial_claim(uuid, text) to authenticated;

--- a/supabase/tests/verify_initial_payment_claim_test.sql
+++ b/supabase/tests/verify_initial_payment_claim_test.sql
@@ -1,0 +1,905 @@
+begin;
+
+select * from no_plan();
+
+insert into public.organizations (
+  id,
+  name,
+  slug,
+  organization_type,
+  billing_currency,
+  membership_terms_version,
+  monthly_price_amount,
+  annual_price_amount,
+  monthly_pix_copy_paste,
+  annual_pix_copy_paste
+)
+values
+  (
+    '70000000-0000-4000-8000-000000000001'::uuid,
+    'Admission Association',
+    'admission-association',
+    'association',
+    'BRL',
+    'estatuto-v1',
+    12500,
+    120000,
+    '000201initial-monthly',
+    '000201initial-annual'
+  ),
+  (
+    '70000000-0000-4000-8000-000000000002'::uuid,
+    'Informal Group',
+    'informal-group',
+    'group',
+    'BRL',
+    'group-v1',
+    12500,
+    120000,
+    '000201group-monthly',
+    '000201group-annual'
+  );
+
+insert into auth.users (
+  id,
+  aud,
+  role,
+  email,
+  email_confirmed_at,
+  raw_user_meta_data,
+  created_at,
+  updated_at
+)
+values
+  (
+    '70000000-0000-4000-8000-000000000101'::uuid,
+    'authenticated',
+    'authenticated',
+    'admission-applicant@example.com',
+    timezone('utc'::text, now()),
+    '{"full_name":"Admission Applicant"}'::jsonb,
+    timezone('utc'::text, now()),
+    timezone('utc'::text, now())
+  ),
+  (
+    '70000000-0000-4000-8000-000000000102'::uuid,
+    'authenticated',
+    'authenticated',
+    'admission-applicant-two@example.com',
+    timezone('utc'::text, now()),
+    '{"full_name":"Second Applicant"}'::jsonb,
+    timezone('utc'::text, now()),
+    timezone('utc'::text, now())
+  ),
+  (
+    '70000000-0000-4000-8000-000000000103'::uuid,
+    'authenticated',
+    'authenticated',
+    'admission-reviewer@example.com',
+    timezone('utc'::text, now()),
+    '{"full_name":"Association Reviewer"}'::jsonb,
+    timezone('utc'::text, now()),
+    timezone('utc'::text, now())
+  ),
+  (
+    '70000000-0000-4000-8000-000000000104'::uuid,
+    'authenticated',
+    'authenticated',
+    'admission-outsider@example.com',
+    timezone('utc'::text, now()),
+    '{"full_name":"Outside Reviewer"}'::jsonb,
+    timezone('utc'::text, now()),
+    timezone('utc'::text, now())
+  ),
+  (
+    '70000000-0000-4000-8000-000000000105'::uuid,
+    'authenticated',
+    'authenticated',
+    'admission-legacy@example.com',
+    timezone('utc'::text, now()),
+    '{"full_name":"Legacy Applicant"}'::jsonb,
+    timezone('utc'::text, now()),
+    timezone('utc'::text, now())
+  );
+
+insert into public.profiles (id, name, username, profile_picture)
+values
+  (
+    '70000000-0000-4000-8000-000000000101'::uuid,
+    'Admission Applicant',
+    '@admission_applicant',
+    'https://example.com/admission-applicant.jpg'
+  ),
+  (
+    '70000000-0000-4000-8000-000000000102'::uuid,
+    'Second Applicant',
+    '@second_applicant',
+    null
+  ),
+  (
+    '70000000-0000-4000-8000-000000000103'::uuid,
+    'Association Reviewer',
+    '@association_reviewer',
+    null
+  ),
+  (
+    '70000000-0000-4000-8000-000000000104'::uuid,
+    'Outside Reviewer',
+    '@outside_reviewer',
+    null
+  ),
+  (
+    '70000000-0000-4000-8000-000000000105'::uuid,
+    'Legacy Applicant',
+    '@legacy_applicant',
+    null
+  )
+on conflict (id) do update
+set name = excluded.name,
+    username = excluded.username,
+    profile_picture = excluded.profile_picture;
+
+insert into public.organization_members (organization_id, user_id, role)
+values
+  (
+    '70000000-0000-4000-8000-000000000001'::uuid,
+    '70000000-0000-4000-8000-000000000103'::uuid,
+    'admin'
+  ),
+  (
+    '70000000-0000-4000-8000-000000000002'::uuid,
+    '70000000-0000-4000-8000-000000000103'::uuid,
+    'admin'
+  );
+
+insert into public.membership_applications (
+  id,
+  organization_id,
+  user_id,
+  status,
+  accepted_terms_at,
+  submitted_at
+)
+values
+  (
+    '70000000-0000-4000-8000-000000000201'::uuid,
+    '70000000-0000-4000-8000-000000000001'::uuid,
+    '70000000-0000-4000-8000-000000000101'::uuid,
+    'submitted',
+    timezone('utc'::text, now()),
+    timezone('utc'::text, now())
+  ),
+  (
+    '70000000-0000-4000-8000-000000000202'::uuid,
+    '70000000-0000-4000-8000-000000000001'::uuid,
+    '70000000-0000-4000-8000-000000000102'::uuid,
+    'submitted',
+    timezone('utc'::text, now()),
+    timezone('utc'::text, now())
+  ),
+  (
+    '70000000-0000-4000-8000-000000000205'::uuid,
+    '70000000-0000-4000-8000-000000000001'::uuid,
+    '70000000-0000-4000-8000-000000000105'::uuid,
+    'submitted',
+    timezone('utc'::text, now()),
+    timezone('utc'::text, now())
+  ),
+  (
+    '70000000-0000-4000-8000-000000000203'::uuid,
+    '70000000-0000-4000-8000-000000000002'::uuid,
+    '70000000-0000-4000-8000-000000000102'::uuid,
+    'submitted',
+    timezone('utc'::text, now()),
+    timezone('utc'::text, now())
+  );
+
+insert into public.membership_application_revisions (
+  id,
+  application_id,
+  organization_id,
+  user_id,
+  revision_number,
+  draft_version,
+  plan_type,
+  terms_version,
+  accepted_terms_at,
+  submitted_at,
+  full_name,
+  birth_date,
+  nationality,
+  marital_status,
+  profession,
+  birthplace,
+  cpf,
+  id_document_number,
+  id_document_issuer,
+  postal_code,
+  address_line,
+  city,
+  state,
+  email,
+  phone,
+  has_allergies,
+  allergies,
+  has_dietary_restrictions,
+  dietary_restrictions,
+  plan_amount,
+  currency,
+  pix_copy_paste
+)
+values
+  (
+    '70000000-0000-4000-8000-000000000301'::uuid,
+    '70000000-0000-4000-8000-000000000201'::uuid,
+    '70000000-0000-4000-8000-000000000001'::uuid,
+    '70000000-0000-4000-8000-000000000101'::uuid,
+    1,
+    1,
+    'monthly',
+    'estatuto-v1',
+    timezone('utc'::text, now()),
+    timezone('utc'::text, now()),
+    'Frozen Applicant Name',
+    '1990-01-01',
+    'Brazilian',
+    'single',
+    'Engineer',
+    'Sao Paulo',
+    '12345678901',
+    'RG-1',
+    'SSP',
+    '01001000',
+    'Main Street 1',
+    'Sao Paulo',
+    'SP',
+    'frozen@example.com',
+    '11999999999',
+    false,
+    null,
+    false,
+    null,
+    12500,
+    'BRL',
+    '000201initial-monthly'
+  ),
+  (
+    '70000000-0000-4000-8000-000000000302'::uuid,
+    '70000000-0000-4000-8000-000000000202'::uuid,
+    '70000000-0000-4000-8000-000000000001'::uuid,
+    '70000000-0000-4000-8000-000000000102'::uuid,
+    1,
+    1,
+    'annual',
+    'estatuto-v1',
+    timezone('utc'::text, now()),
+    timezone('utc'::text, now()),
+    'Second Applicant',
+    '1991-02-02',
+    'Brazilian',
+    'single',
+    'Designer',
+    'Rio',
+    '12345678902',
+    'RG-2',
+    'SSP',
+    '20000000',
+    'Second Street 2',
+    'Rio',
+    'RJ',
+    'second@example.com',
+    '21999999999',
+    false,
+    null,
+    false,
+    null,
+    120000,
+    'BRL',
+    '000201initial-annual'
+  ),
+  (
+    '70000000-0000-4000-8000-000000000305'::uuid,
+    '70000000-0000-4000-8000-000000000205'::uuid,
+    '70000000-0000-4000-8000-000000000001'::uuid,
+    '70000000-0000-4000-8000-000000000105'::uuid,
+    1,
+    1,
+    'monthly',
+    'estatuto-v1',
+    timezone('utc'::text, now()),
+    timezone('utc'::text, now()),
+    'Legacy Applicant',
+    '1992-03-03',
+    'Brazilian',
+    'single',
+    'Guide',
+    'Belo Horizonte',
+    '12345678903',
+    'RG-3',
+    'SSP',
+    '30000000',
+    'Third Street 3',
+    'Belo Horizonte',
+    'MG',
+    'legacy@example.com',
+    '31999999999',
+    false,
+    null,
+    false,
+    null,
+    12500,
+    'BRL',
+    '000201initial-monthly'
+  ),
+  (
+    '70000000-0000-4000-8000-000000000303'::uuid,
+    '70000000-0000-4000-8000-000000000203'::uuid,
+    '70000000-0000-4000-8000-000000000002'::uuid,
+    '70000000-0000-4000-8000-000000000102'::uuid,
+    1,
+    1,
+    'monthly',
+    'group-v1',
+    timezone('utc'::text, now()),
+    timezone('utc'::text, now()),
+    'Group Applicant',
+    '1993-04-04',
+    'Brazilian',
+    'single',
+    'Athlete',
+    'Curitiba',
+    '12345678904',
+    'RG-4',
+    'SSP',
+    '80000000',
+    'Fourth Street 4',
+    'Curitiba',
+    'PR',
+    'group@example.com',
+    '41999999999',
+    false,
+    null,
+    false,
+    null,
+    12500,
+    'BRL',
+    '000201group-monthly'
+  );
+
+insert into public.payment_obligations (
+  id,
+  organization_id,
+  user_id,
+  application_revision_id,
+  purpose,
+  status,
+  plan_type,
+  amount,
+  currency,
+  payment_method,
+  pix_copy_paste,
+  available_at
+)
+values
+  (
+    '70000000-0000-4000-8000-000000000401'::uuid,
+    '70000000-0000-4000-8000-000000000001'::uuid,
+    '70000000-0000-4000-8000-000000000101'::uuid,
+    '70000000-0000-4000-8000-000000000301'::uuid,
+    'initial_admission',
+    'available',
+    'monthly',
+    12500,
+    'BRL',
+    'manual_pix',
+    '000201initial-monthly',
+    timezone('utc'::text, now())
+  ),
+  (
+    '70000000-0000-4000-8000-000000000402'::uuid,
+    '70000000-0000-4000-8000-000000000001'::uuid,
+    '70000000-0000-4000-8000-000000000102'::uuid,
+    '70000000-0000-4000-8000-000000000302'::uuid,
+    'initial_admission',
+    'available',
+    'annual',
+    120000,
+    'BRL',
+    'manual_pix',
+    '000201initial-annual',
+    timezone('utc'::text, now())
+  ),
+  (
+    '70000000-0000-4000-8000-000000000403'::uuid,
+    '70000000-0000-4000-8000-000000000001'::uuid,
+    '70000000-0000-4000-8000-000000000105'::uuid,
+    '70000000-0000-4000-8000-000000000305'::uuid,
+    'initial_admission',
+    'available',
+    'monthly',
+    12500,
+    'BRL',
+    'manual_pix',
+    '000201initial-monthly',
+    timezone('utc'::text, now())
+  ),
+  (
+    '70000000-0000-4000-8000-000000000404'::uuid,
+    '70000000-0000-4000-8000-000000000002'::uuid,
+    '70000000-0000-4000-8000-000000000102'::uuid,
+    '70000000-0000-4000-8000-000000000303'::uuid,
+    'initial_admission',
+    'available',
+    'monthly',
+    12500,
+    'BRL',
+    'manual_pix',
+    '000201group-monthly',
+    timezone('utc'::text, now())
+  );
+
+insert into public.payment_claims (
+  id,
+  obligation_id,
+  organization_id,
+  claimant_user_id,
+  payer_type,
+  payer_name,
+  status,
+  created_at
+)
+values
+  (
+    '70000000-0000-4000-8000-000000000501'::uuid,
+    '70000000-0000-4000-8000-000000000401'::uuid,
+    '70000000-0000-4000-8000-000000000001'::uuid,
+    '70000000-0000-4000-8000-000000000101'::uuid,
+    'applicant',
+    null,
+    'under_review',
+    timezone('utc'::text, now()) - interval '2 hours'
+  ),
+  (
+    '70000000-0000-4000-8000-000000000502'::uuid,
+    '70000000-0000-4000-8000-000000000402'::uuid,
+    '70000000-0000-4000-8000-000000000001'::uuid,
+    '70000000-0000-4000-8000-000000000102'::uuid,
+    'other',
+    'Another person',
+    'under_review',
+    timezone('utc'::text, now()) - interval '1 hour'
+  ),
+  (
+    '70000000-0000-4000-8000-000000000504'::uuid,
+    '70000000-0000-4000-8000-000000000404'::uuid,
+    '70000000-0000-4000-8000-000000000002'::uuid,
+    '70000000-0000-4000-8000-000000000102'::uuid,
+    'applicant',
+    null,
+    'under_review',
+    timezone('utc'::text, now())
+  );
+
+insert into public.payment_claim_audit_events (
+  organization_id,
+  obligation_id,
+  claim_id,
+  actor_user_id,
+  previous_state,
+  next_state,
+  created_at
+)
+values
+  (
+    '70000000-0000-4000-8000-000000000001'::uuid,
+    '70000000-0000-4000-8000-000000000401'::uuid,
+    '70000000-0000-4000-8000-000000000501'::uuid,
+    '70000000-0000-4000-8000-000000000101'::uuid,
+    'payment_available',
+    'under_review',
+    timezone('utc'::text, now()) - interval '2 hours'
+  ),
+  (
+    '70000000-0000-4000-8000-000000000001'::uuid,
+    '70000000-0000-4000-8000-000000000402'::uuid,
+    '70000000-0000-4000-8000-000000000502'::uuid,
+    '70000000-0000-4000-8000-000000000102'::uuid,
+    'payment_available',
+    'under_review',
+    timezone('utc'::text, now()) - interval '1 hour'
+  ),
+  (
+    '70000000-0000-4000-8000-000000000002'::uuid,
+    '70000000-0000-4000-8000-000000000404'::uuid,
+    '70000000-0000-4000-8000-000000000504'::uuid,
+    '70000000-0000-4000-8000-000000000102'::uuid,
+    'payment_available',
+    'under_review',
+    timezone('utc'::text, now())
+  );
+
+-- The queue is summary-only and scoped to association admins.
+set local role authenticated;
+select set_config('request.jwt.claim.role', 'authenticated', true);
+select set_config(
+  'request.jwt.claim.sub',
+  '70000000-0000-4000-8000-000000000103',
+  true
+);
+
+select is(
+  (select count(*)::integer from public.get_initial_payment_claim_queue()),
+  2,
+  'an association admin sees only current association claims'
+);
+
+select is(
+  (select applicant_name from public.get_initial_payment_claim_queue()
+   where claim_id = '70000000-0000-4000-8000-000000000501'::uuid),
+  'Admission Applicant',
+  'queue uses the safe profile identity'
+);
+
+select is(
+  (select attempt_count::integer from public.get_initial_payment_claim_queue()
+   where claim_id = '70000000-0000-4000-8000-000000000501'::uuid),
+  1,
+  'queue reports the immutable claim attempt count'
+);
+
+select is(
+  (select count(*)::integer from public.get_initial_payment_claim_detail(
+    '70000000-0000-4000-8000-000000000501'::uuid
+  )),
+  1,
+  'an association admin can inspect one authorized claim detail'
+);
+
+select is(
+  (select full_name from public.get_initial_payment_claim_detail(
+    '70000000-0000-4000-8000-000000000501'::uuid
+  )),
+  'Frozen Applicant Name',
+  'detail reads the exact immutable application revision'
+);
+
+select is(
+  (select claim_history->0->>'claim_id'
+   from public.get_initial_payment_claim_detail(
+     '70000000-0000-4000-8000-000000000501'::uuid
+   )),
+  '70000000-0000-4000-8000-000000000501',
+  'detail preserves ordered claim history'
+);
+
+create temp table approved_claim as
+select *
+from public.approve_initial_claim(
+  '70000000-0000-4000-8000-000000000501'::uuid
+);
+
+select is(
+  (select claim_status::text from approved_claim),
+  'approved',
+  'approval returns the authoritative claim decision'
+);
+
+select is(
+  (select obligation_status::text from approved_claim),
+  'settled',
+  'approval settles the initial obligation atomically'
+);
+
+set local role postgres;
+
+select is(
+  (select status::text from public.subscriptions
+   where organization_id = '70000000-0000-4000-8000-000000000001'::uuid
+     and user_id = '70000000-0000-4000-8000-000000000101'::uuid),
+  'active',
+  'approval activates the selected subscription'
+);
+
+select ok(
+  (select current_period_end is not null from public.subscriptions
+   where organization_id = '70000000-0000-4000-8000-000000000001'::uuid
+     and user_id = '70000000-0000-4000-8000-000000000101'::uuid),
+  'approval creates the first recurring schedule'
+);
+
+set local role authenticated;
+
+select is(
+  (select count(*)::integer from public.organization_members
+   where organization_id = '70000000-0000-4000-8000-000000000001'::uuid
+     and user_id = '70000000-0000-4000-8000-000000000101'::uuid),
+  1,
+  'approval creates exactly one membership'
+);
+
+select is(
+  (select count(*)::integer from public.payment_claim_audit_events
+   where claim_id = '70000000-0000-4000-8000-000000000501'::uuid),
+  2,
+  'approval appends one payment-settled audit event'
+);
+
+select is(
+  (select actor_user_id from public.payment_claim_audit_events
+   where claim_id = '70000000-0000-4000-8000-000000000501'::uuid
+     and next_state = 'payment_settled'),
+  '70000000-0000-4000-8000-000000000103'::uuid,
+  'approval audit derives the reviewer actor'
+);
+
+select is(
+  (select decision_applied_now from public.approve_initial_claim(
+    '70000000-0000-4000-8000-000000000501'::uuid
+  )),
+  false,
+  'identical approval retry returns the existing result'
+);
+
+select is(
+  (select count(*)::integer from public.organization_members
+   where organization_id = '70000000-0000-4000-8000-000000000001'::uuid
+     and user_id = '70000000-0000-4000-8000-000000000101'::uuid),
+  1,
+  'identical approval retry does not duplicate membership'
+);
+
+select throws_ok(
+  $$select * from public.reject_initial_claim(
+    '70000000-0000-4000-8000-000000000501'::uuid,
+    'Too late'
+  )$$,
+  '40001',
+  'This claim was already approved. Refresh before deciding.',
+  'an approved claim cannot be rejected'
+);
+
+select throws_ok(
+  $$select * from public.reject_initial_claim(
+    '70000000-0000-4000-8000-000000000502'::uuid,
+    '   '
+  )$$,
+  '22023',
+  'A rejection reason is required.',
+  'rejection requires a nonblank reason'
+);
+
+create temp table rejected_claim as
+select *
+from public.reject_initial_claim(
+  '70000000-0000-4000-8000-000000000502'::uuid,
+  '  Incorrect   payer  '
+);
+
+select is(
+  (select decision_reason from rejected_claim),
+  'Incorrect payer',
+  'rejection reasons are normalized server-side'
+);
+
+set local role postgres;
+
+select is(
+  (select status::text from public.payment_obligations
+   where id = '70000000-0000-4000-8000-000000000402'::uuid),
+  'available',
+  'rejection leaves the same obligation actionable'
+);
+
+select is(
+  (select count(*)::integer from public.organization_members
+   where organization_id = '70000000-0000-4000-8000-000000000001'::uuid
+     and user_id = '70000000-0000-4000-8000-000000000102'::uuid),
+  0,
+  'rejection creates no membership'
+);
+
+select is(
+  (select count(*)::integer from public.subscriptions
+   where organization_id = '70000000-0000-4000-8000-000000000001'::uuid
+     and user_id = '70000000-0000-4000-8000-000000000102'::uuid),
+  0,
+  'rejection creates no subscription schedule'
+);
+
+set local role authenticated;
+
+select is(
+  (select decision_applied_now from public.reject_initial_claim(
+    '70000000-0000-4000-8000-000000000502'::uuid,
+    'Incorrect payer'
+  )),
+  false,
+  'identical rejection retry returns the existing result'
+);
+
+select throws_ok(
+  $$select * from public.reject_initial_claim(
+    '70000000-0000-4000-8000-000000000502'::uuid,
+    'Different reason'
+  )$$,
+  '40001',
+  'This claim was already rejected with a different reason. Refresh before deciding.',
+  'a conflicting rejection retry cannot rewrite history'
+);
+
+set local role postgres;
+
+insert into public.organization_members (organization_id, user_id, role)
+values (
+  '70000000-0000-4000-8000-000000000001'::uuid,
+  '70000000-0000-4000-8000-000000000102'::uuid,
+  'admin'
+);
+
+set local role authenticated;
+select set_config(
+  'request.jwt.claim.sub',
+  '70000000-0000-4000-8000-000000000102',
+  true
+);
+
+select is(
+  (select count(*)::integer from public.claim_initial_payment(
+    '70000000-0000-4000-8000-000000000402'::uuid,
+    true,
+    null
+  )),
+  1,
+  'a later claim can be submitted against the same obligation after rejection'
+);
+
+select set_config(
+  'request.jwt.claim.sub',
+  '70000000-0000-4000-8000-000000000103',
+  true
+);
+
+select is(
+  (select decision_applied_now from public.approve_initial_claim(
+    (
+      select id
+      from public.payment_claims
+      where obligation_id = '70000000-0000-4000-8000-000000000402'::uuid
+        and status = 'under_review'
+    )
+  )),
+  true,
+  'an authorized reviewer can approve the later claim'
+);
+
+select is(
+  (select role::text from public.organization_members
+   where organization_id = '70000000-0000-4000-8000-000000000001'::uuid
+     and user_id = '70000000-0000-4000-8000-000000000102'::uuid),
+  'admin',
+  'approval never demotes an existing admin role'
+);
+
+select is(
+  (select count(*)::integer from public.organization_members
+   where organization_id = '70000000-0000-4000-8000-000000000001'::uuid
+     and user_id = '70000000-0000-4000-8000-000000000102'::uuid),
+  1,
+  'approving a later claim admits the applicant exactly once'
+);
+
+set local role postgres;
+
+create temp table legacy_subscription as
+select gen_random_uuid() as id;
+
+insert into public.subscriptions (
+  id,
+  organization_id,
+  user_id,
+  plan_type,
+  status
+)
+select
+  id,
+  '70000000-0000-4000-8000-000000000001'::uuid,
+  '70000000-0000-4000-8000-000000000105'::uuid,
+  'monthly',
+  'pending_payment'
+from legacy_subscription;
+
+insert into public.payments (
+  id,
+  organization_id,
+  user_id,
+  subscription_id,
+  amount,
+  status
+)
+select
+  '70000000-0000-4000-8000-000000000601'::uuid,
+  '70000000-0000-4000-8000-000000000001'::uuid,
+  '70000000-0000-4000-8000-000000000105'::uuid,
+  id,
+  12500,
+  'pending'
+from legacy_subscription;
+
+update public.payment_obligations
+set legacy_payment_id = '70000000-0000-4000-8000-000000000601'::uuid
+where id = '70000000-0000-4000-8000-000000000403'::uuid;
+
+update public.payments
+set status = 'succeeded', paid_at = timezone('utc'::text, now())
+where id = '70000000-0000-4000-8000-000000000601'::uuid;
+
+select is(
+  (select status::text from public.subscriptions
+   where user_id = '70000000-0000-4000-8000-000000000105'::uuid),
+  'pending_payment',
+  'generic payment settlement cannot activate an initial-admission subscription'
+);
+
+select is(
+  (select count(*)::integer from public.organization_members
+   where organization_id = '70000000-0000-4000-8000-000000000001'::uuid
+     and user_id = '70000000-0000-4000-8000-000000000105'::uuid),
+  0,
+  'generic payment settlement cannot admit an initial applicant'
+);
+
+set local role authenticated;
+select set_config(
+  'request.jwt.claim.sub',
+  '70000000-0000-4000-8000-000000000104',
+  true
+);
+
+select is(
+  (select count(*)::integer from public.get_initial_payment_claim_queue()),
+  0,
+  'an admin of another association cannot list this queue'
+);
+
+select is(
+  (select count(*)::integer from public.get_initial_payment_claim_detail(
+    '70000000-0000-4000-8000-000000000502'::uuid
+  )),
+  0,
+  'an admin of another association cannot inspect this claim'
+);
+
+select throws_ok(
+  $$select * from public.approve_initial_claim(
+    '70000000-0000-4000-8000-000000000502'::uuid
+  )$$,
+  '42501',
+  'This claim is unavailable to the current reviewer.',
+  'an admin of another association cannot decide this claim'
+);
+
+select ok(
+  not has_table_privilege('authenticated', 'public.payment_claims', 'UPDATE'),
+  'authenticated clients cannot update claims directly'
+);
+
+select ok(
+  not has_table_privilege('authenticated', 'public.payment_claim_audit_events', 'INSERT'),
+  'authenticated clients cannot insert audit events directly'
+);
+
+set local role postgres;
+
+select throws_ok(
+  $$update public.payment_claims
+    set status = 'rejected',
+        decided_at = timezone('utc'::text, now()),
+        decision_reason = 'Bypass'
+    where id = '70000000-0000-4000-8000-000000000504'::uuid$$,
+  '42501',
+  'Payment claim decisions must use the decision command.',
+  'raw server-side decision mutation cannot bypass the command'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary

- add an authorized association-admin queue for current initial PIX payment claims
- expose the exact submitted application revision and immutable claim/audit history
- make approval and rejection atomic, idempotent, concurrency-safe, and scoped to the association admin
- preserve existing admin roles and keep generic payment settlement from admitting initial claims
- add focused pgTAP coverage and the desktop-dialog/mobile-drawer review surface

## Verification

- `supabase test db supabase/tests/verify_initial_payment_claim_test.sql` — 35 tests passed
- `supabase test db supabase/tests/claim_initial_pix_payment_test.sql` — 32 tests passed
- `pnpm --dir next exec tsc --noEmit` reaches the existing missing `highline-walk.webp` asset error

Fixes #207