### PR TITLE
Improve agent readiness for web homepage

### DIFF
--- a/next/app/[locale]/[...rest]/page.tsx
+++ b/next/app/[locale]/[...rest]/page.tsx
@@ -1,5 +1,0 @@
-import { notFound } from 'next/navigation';
-
-export default function CatchAll() {
-  notFound();
-}

--- a/next/app/[locale]/[...rest]/route.ts
+++ b/next/app/[locale]/[...rest]/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+
+function notFoundResponse(request: Request) {
+  const baseUrl = (
+    process.env.NEXT_PUBLIC_BASE_URL || new URL(request.url).origin
+  ).replace(/\/+$/, "");
+  const message = `# Page not found
+
+This Chooselife URL does not exist.
+
+For discoverable resources, see:
+
+- [Sitemap](${baseUrl}/sitemap.xml)
+- [Agent index](${baseUrl}/llms.txt)
+`;
+
+  return new NextResponse(request.method === "HEAD" ? null : message, {
+    status: 404,
+    headers: {
+      "Cache-Control": "public, max-age=60, s-maxage=60",
+      "Content-Type": "text/markdown; charset=utf-8",
+      "X-Robots-Tag": "noindex",
+    },
+  });
+}
+
+export function GET(request: Request) {
+  return notFoundResponse(request);
+}
+
+export function HEAD(request: Request) {
+  return notFoundResponse(request);
+}

--- a/next/app/[locale]/_components/HighlineList.tsx
+++ b/next/app/[locale]/_components/HighlineList.tsx
@@ -11,7 +11,11 @@ import { HighlineListSkeleton } from "./HighlineListSkeleton";
 
 const PAGE_SIZE = 6;
 
-export function HighlineList() {
+type HighlineListProps = {
+  layout?: "grid" | "rail";
+};
+
+export function HighlineList({ layout = "grid" }: HighlineListProps) {
   const [searchValue = ""] = useQueryState("q");
 
   const { data, fetchNextPage, hasNextPage, isFetching } = useInfiniteQuery({
@@ -29,13 +33,22 @@ export function HighlineList() {
     },
   });
 
+  const listClassName =
+    layout === "rail"
+      ? "flex snap-x gap-4 overflow-x-auto pb-4 md:gap-5"
+      : "grid grid-cols-1 justify-items-center gap-4 md:grid-cols-2 lg:grid-cols-3";
+  const cardClassName =
+    layout === "rail" ? "min-w-[18rem] snap-start md:min-w-[20rem]" : undefined;
+
   return (
     <>
-      <section className="grid grid-cols-1 justify-items-center gap-4 md:grid-cols-2 lg:grid-cols-3">
+      <section className={listClassName}>
         {data?.pages.map((page) =>
-          page.data?.map((high) => <Highline key={high.id} highline={high} />)
+          page.data?.map((high) => (
+            <Highline key={high.id} highline={high} classname={cardClassName} />
+          )),
         )}
-        {isFetching ? <HighlineListSkeleton /> : null}
+        {isFetching ? <HighlineListSkeleton layout={layout} /> : null}
       </section>
       <motion.div
         key={data?.pages.length}

--- a/next/app/[locale]/_components/HighlineListSkeleton.tsx
+++ b/next/app/[locale]/_components/HighlineListSkeleton.tsx
@@ -1,11 +1,21 @@
 import HighlineImage from "@/components/HighlineImage";
+import { cn } from "@/lib/utils";
 
-export function HighlineListSkeleton() {
+type HighlineListSkeletonProps = {
+  layout?: "grid" | "rail";
+};
+
+export function HighlineListSkeleton({
+  layout = "grid",
+}: HighlineListSkeletonProps) {
   return (
     <>
       {Array.from(Array(8)).map((_, idx) => (
         <div
-          className="flex w-full max-w-[24rem] animate-pulse flex-col overflow-hidden rounded-lg border border-gray-200 bg-white shadow dark:border-gray-700 dark:bg-gray-800 md:w-96"
+          className={cn(
+            "flex w-full max-w-[24rem] animate-pulse flex-col overflow-hidden rounded-lg border border-gray-200 bg-white shadow dark:border-gray-700 dark:bg-gray-800 md:w-96",
+            layout === "rail" && "min-w-[18rem] shrink-0 md:min-w-[20rem]",
+          )}
           key={`high-skeleton-${idx}`}
         >
           <div className="relative block h-72 w-full opacity-25">

--- a/next/app/[locale]/_components/HomeAgentContent.tsx
+++ b/next/app/[locale]/_components/HomeAgentContent.tsx
@@ -8,33 +8,15 @@ export function HomeAgentContent({ locale }: HomeAgentContentProps) {
   const content = getAgentHomeContent(locale);
 
   return (
-    <section
-      aria-labelledby="home-agent-content-heading"
-      className="relative z-10 mx-auto mt-8 w-full max-w-5xl px-4 pb-16 md:mt-12"
-    >
-      <div className="rounded-3xl border border-border/60 bg-background/85 p-6 shadow-sm backdrop-blur-sm md:p-10">
-        <p className="mb-3 text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
-          Chooselife
-        </p>
-        <h2
-          id="home-agent-content-heading"
-          className="text-2xl font-bold tracking-tight md:text-3xl"
-        >
-          {content.heading}
-        </h2>
-        <p className="mt-4 max-w-3xl text-base leading-7 text-muted-foreground md:text-lg">
-          {content.summary}
-        </p>
-
-        <div className="mt-8 grid gap-6 md:grid-cols-2">
-          {content.sections.map(({ heading, body }) => (
-            <article key={heading}>
-              <h3 className="text-lg font-semibold">{heading}</h3>
-              <p className="mt-2 leading-7 text-muted-foreground">{body}</p>
-            </article>
-          ))}
-        </div>
-      </div>
+    <section aria-labelledby="home-agent-content-heading" className="sr-only">
+      <h2 id="home-agent-content-heading">{content.heading}</h2>
+      <p>{content.summary}</p>
+      {content.sections.map(({ heading, body }) => (
+        <article key={heading}>
+          <h3>{heading}</h3>
+          <p>{body}</p>
+        </article>
+      ))}
     </section>
   );
 }

--- a/next/app/[locale]/_components/HomeAgentContent.tsx
+++ b/next/app/[locale]/_components/HomeAgentContent.tsx
@@ -1,0 +1,40 @@
+import { getAgentHomeContent } from "@/lib/agent-content";
+
+type HomeAgentContentProps = {
+  locale: string;
+};
+
+export function HomeAgentContent({ locale }: HomeAgentContentProps) {
+  const content = getAgentHomeContent(locale);
+
+  return (
+    <section
+      aria-labelledby="home-agent-content-heading"
+      className="relative z-10 mx-auto mt-8 w-full max-w-5xl px-4 pb-16 md:mt-12"
+    >
+      <div className="rounded-3xl border border-border/60 bg-background/85 p-6 shadow-sm backdrop-blur-sm md:p-10">
+        <p className="mb-3 text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+          Chooselife
+        </p>
+        <h2
+          id="home-agent-content-heading"
+          className="text-2xl font-bold tracking-tight md:text-3xl"
+        >
+          {content.heading}
+        </h2>
+        <p className="mt-4 max-w-3xl text-base leading-7 text-muted-foreground md:text-lg">
+          {content.summary}
+        </p>
+
+        <div className="mt-8 grid gap-6 md:grid-cols-2">
+          {content.sections.map(({ heading, body }) => (
+            <article key={heading}>
+              <h3 className="text-lg font-semibold">{heading}</h3>
+              <p className="mt-2 leading-7 text-muted-foreground">{body}</p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/next/app/[locale]/_components/HomeBrowseFirst.tsx
+++ b/next/app/[locale]/_components/HomeBrowseFirst.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { ArrowRight, ArrowUpRight } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { Link } from "@/i18n/navigation";
+
+import { HighlineList } from "./HighlineList";
+import Search from "./search";
+
+const destinations = [
+  { key: "explore", href: "/", active: true },
+  { key: "map", href: "/?view=map", active: false },
+  { key: "events", href: "/events", active: false },
+  { key: "app", href: "/download", active: false },
+] as const;
+
+export function HomeBrowseFirst() {
+  const t = useTranslations("home.browse");
+
+  return (
+    <div
+      className="relative z-20 mx-2 max-w-screen-xl space-y-6 md:mx-auto"
+      style={{ marginTop: "70dvh" }}
+    >
+      <Search />
+
+      <section
+        aria-labelledby="home-browse-heading"
+        className="mx-auto max-w-6xl px-2 pb-16 pt-2 md:px-4 md:pt-4"
+      >
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+              {t("eyebrow")}
+            </p>
+            <h2
+              id="home-browse-heading"
+              className="mt-2 text-2xl font-semibold tracking-[-0.045em] sm:text-3xl"
+            >
+              {t("title")}
+            </h2>
+          </div>
+          <Link
+            href="/?view=map"
+            className="group inline-flex items-center gap-2 text-sm font-semibold text-foreground"
+          >
+            {t("viewMap")}
+            <ArrowRight className="size-4 transition-transform duration-200 ease-out group-hover:translate-x-1" />
+          </Link>
+        </div>
+
+        <nav
+          aria-label={t("navigationLabel")}
+          className="mt-7 flex gap-6 overflow-x-auto border-b border-border/70 text-sm font-medium text-muted-foreground"
+        >
+          {destinations.map(({ key, href, active }) => (
+            <Link
+              key={key}
+              href={href}
+              className={
+                active
+                  ? "shrink-0 border-b-2 border-foreground pb-3 text-foreground"
+                  : "shrink-0 pb-3 transition-colors duration-150 ease-out hover:text-foreground"
+              }
+            >
+              {t(key)}
+            </Link>
+          ))}
+        </nav>
+
+        <div className="mt-7">
+          <HighlineList layout="rail" />
+        </div>
+
+        <div className="mt-8 flex flex-col gap-4 border-t border-border/70 pt-5 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
+          <p>{t("summary")}</p>
+          <Link
+            href="/download"
+            className="inline-flex items-center gap-2 font-semibold text-foreground"
+          >
+            {t("download")}
+            <ArrowUpRight className="size-4" />
+          </Link>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/next/app/[locale]/_components/HomeInteractive.tsx
+++ b/next/app/[locale]/_components/HomeInteractive.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useQueryState } from "nuqs";
+
+import CreateHighline from "@/components/CreateHighline";
+import MapToggle from "@/components/Map/MapToggle";
+
+import { HighlineList } from "./HighlineList";
+import { QrCodeBadge } from "./qr-code-badge";
+import Search from "./search";
+
+const Map = dynamic(() => import("@/components/Map/Map"), {
+  ssr: false,
+  loading: () => (
+    <div className="absolute left-1/2 top-1/2 z-[10000] -translate-x-1/2 -translate-y-1/2 transform">
+      <svg
+        aria-hidden="true"
+        className="mr-2 h-24 w-24 animate-spin fill-blue-600 text-gray-200 dark:text-gray-600"
+        viewBox="0 0 100 101"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4011 9.67226 9.08144 27.9921 9.08144 50.5908Z"
+          fill="currentColor"
+        />
+        <path
+          d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.119 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.36754 46.6976 0.44684 41.7345 1.27873C39.2613 1.69328 37.813 4.1978 38.4501 6.62326C39.0873 9.04872 41.5691 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7768 65.9922 12.5457 70.6329 15.2552C75.2735 17.9647 79.3345 21.5611 82.5849 25.841C84.9175 28.9121 86.7996 32.2912 88.181 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
+          fill="currentFill"
+        />
+      </svg>
+    </div>
+  ),
+});
+
+export default function HomeInteractive() {
+  const [view] = useQueryState("view");
+  const [location] = useQueryState("location");
+  const [focusedMarker] = useQueryState("focusedMarker");
+
+  const mapOpen = view === "map";
+  const isPickingLocation = location === "picking";
+  const showActionButtons = !isPickingLocation && !focusedMarker && !location;
+
+  return (
+    <>
+      {mapOpen ? (
+        <Map
+          isPickingLocation={isPickingLocation}
+          focusedMarker={focusedMarker}
+        />
+      ) : (
+        <>
+          <QrCodeBadge />
+          <div
+            className="relative z-20 mx-2 max-w-screen-xl space-y-4 md:mx-auto"
+            style={{ marginTop: "70dvh" }}
+          >
+            <Search />
+            <HighlineList />
+          </div>
+        </>
+      )}
+      <CreateHighline
+        mapIsOpen={mapOpen}
+        location={location}
+        showTrigger={showActionButtons}
+      />
+      {showActionButtons ? <MapToggle mapIsOpen={mapOpen} /> : null}
+    </>
+  );
+}

--- a/next/app/[locale]/_components/HomeInteractive.tsx
+++ b/next/app/[locale]/_components/HomeInteractive.tsx
@@ -6,9 +6,8 @@ import { useQueryState } from "nuqs";
 import CreateHighline from "@/components/CreateHighline";
 import MapToggle from "@/components/Map/MapToggle";
 
-import { HighlineList } from "./HighlineList";
+import { HomeBrowseFirst } from "./HomeBrowseFirst";
 import { QrCodeBadge } from "./qr-code-badge";
-import Search from "./search";
 
 const Map = dynamic(() => import("@/components/Map/Map"), {
   ssr: false,
@@ -53,13 +52,7 @@ export default function HomeInteractive() {
       ) : (
         <>
           <QrCodeBadge />
-          <div
-            className="relative z-20 mx-2 max-w-screen-xl space-y-4 md:mx-auto"
-            style={{ marginTop: "70dvh" }}
-          >
-            <Search />
-            <HighlineList />
-          </div>
+          <HomeBrowseFirst />
         </>
       )}
       <CreateHighline

--- a/next/app/[locale]/layout.tsx
+++ b/next/app/[locale]/layout.tsx
@@ -16,16 +16,31 @@ import UsernameDialog from "./_components/UsernameDialog";
 import Providers from "./Providers";
 
 const APP_NAME = "Chooselife";
-const APP_DEFAULT_TITLE = "Chooselife";
+const APP_DEFAULT_TITLE = "Chooselife | Highline community";
 const APP_TITLE_TEMPLATE = "%s 🆑";
-const APP_DESCRIPTION = "O aplicativo feito para o Highliner";
+const APP_DESCRIPTION =
+  "Chooselife is the highline app for discovering lines, exploring their locations, recording walks, and finding events.";
 
-const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "https://localhost:3000";
+const BASE_URL = (
+  process.env.NEXT_PUBLIC_BASE_URL || "https://chooselife.club"
+).replace(/\/+$/, "");
 
 export const metadata: Metadata = {
   metadataBase: new URL(BASE_URL),
-  keywords: ["Highline", "Slackline", "Slackmap", "Freestyle"],
+  keywords: [
+    "Chooselife",
+    "Highline",
+    "Slackline",
+    "Highline map",
+    "Slackmap",
+    "Freestyle",
+  ],
   applicationName: APP_NAME,
+  authors: [{ name: APP_NAME, url: BASE_URL }],
+  creator: APP_NAME,
+  publisher: APP_NAME,
+  category: "sports",
+  classification: "Highline and slackline community",
   title: {
     default: APP_DEFAULT_TITLE,
     template: APP_TITLE_TEMPLATE,

--- a/next/app/[locale]/page.tsx
+++ b/next/app/[locale]/page.tsx
@@ -1,75 +1,89 @@
-"use client";
-
-import dynamic from "next/dynamic";
-import { useQueryState } from "nuqs";
-
-import CreateHighline from "@/components/CreateHighline";
-import MapToggle from "@/components/Map/MapToggle";
-
+import { HomeAgentContent } from "./_components/HomeAgentContent";
+import HomeInteractive from "./_components/HomeInteractive";
 import { HeroPromoCard } from "./_components/hero-promo-card";
-import { HighlineList } from "./_components/HighlineList";
-import { QrCodeBadge } from "./_components/qr-code-badge";
-import Search from "./_components/search";
 
-const Map = dynamic(() => import("@/components/Map/Map"), {
-  ssr: false,
-  loading: () => (
-    <div className="absolute left-1/2 top-1/2 z-[10000] -translate-x-1/2 -translate-y-1/2 transform">
-      <svg
-        aria-hidden="true"
-        className="mr-2 h-24 w-24 animate-spin fill-blue-600 text-gray-200 dark:text-gray-600"
-        viewBox="0 0 100 101"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"
-          fill="currentColor"
-        />
-        <path
-          d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
-          fill="currentFill"
-        />
-      </svg>
-    </div>
-  ),
-});
+type HomePageProps = {
+  params: Promise<{ locale: string }>;
+  searchParams: Promise<{
+    [key: string]: string | string[] | undefined;
+  }>;
+};
 
-export default function Home() {
-  const [view] = useQueryState("view");
-  const [location] = useQueryState("location");
-  const [focusedMarker] = useQueryState("focusedMarker");
+const BASE_URL = (
+  process.env.NEXT_PUBLIC_BASE_URL || "https://chooselife.club"
+).replace(/\/+$/, "");
+const APPLE_APP_ID = process.env.NEXT_PUBLIC_APPLE_APP_ID || "6745024708";
+const APP_SCHEME = process.env.NEXT_PUBLIC_APP_SCHEME || "com.bodok.chooselife";
+const OFFICIAL_REPOSITORY = "https://github.com/Dosbodoke/chooselife";
 
-  const mapOpen = view === "map";
-  const isPickingLocation = location === "picking";
-  const showActionButtons = !isPickingLocation && !focusedMarker && !location;
+function createStructuredData(locale: string) {
+  const isEnglish = locale === "en";
+  const description = isEnglish
+    ? "Chooselife is a highline app and community hub for discovering lines, exploring their locations, recording walks, and finding events."
+    : "O Chooselife é um aplicativo e ponto de encontro para descobrir highlines, explorar seus locais, registrar rolês e encontrar eventos.";
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Organization",
+        "@id": `${BASE_URL}/#organization`,
+        name: "Chooselife",
+        url: BASE_URL,
+        logo: `${BASE_URL}/icon.png`,
+        sameAs: [OFFICIAL_REPOSITORY],
+      },
+      {
+        "@type": "WebSite",
+        "@id": `${BASE_URL}/#website`,
+        name: "Chooselife",
+        url: BASE_URL,
+        description,
+        inLanguage: isEnglish ? "en" : "pt-BR",
+        publisher: { "@id": `${BASE_URL}/#organization` },
+      },
+      {
+        "@type": "SoftwareApplication",
+        "@id": `${BASE_URL}/#application`,
+        name: "Chooselife",
+        description,
+        url: BASE_URL,
+        applicationCategory: "SportsApplication",
+        operatingSystem: "iOS, Android, Web",
+        downloadUrl: [
+          `https://apps.apple.com/app/id${APPLE_APP_ID}`,
+          `https://play.google.com/store/apps/details?id=${APP_SCHEME}`,
+        ],
+        sameAs: [OFFICIAL_REPOSITORY],
+      },
+    ],
+  };
+}
+
+export default async function HomePage({
+  params,
+  searchParams,
+}: HomePageProps) {
+  const [{ locale }, resolvedSearchParams] = await Promise.all([
+    params,
+    searchParams,
+  ]);
+  const view = resolvedSearchParams.view;
+  const mapOpen = Array.isArray(view) ? view[0] === "map" : view === "map";
+  const structuredData = JSON.stringify(createStructuredData(locale)).replace(
+    /</g,
+    "\\u003c",
+  );
 
   return (
     <>
-      {mapOpen ? (
-        <Map
-          isPickingLocation={isPickingLocation}
-          focusedMarker={focusedMarker}
-        />
-      ) : (
-        <>
-          <HeroPromoCard />
-          <QrCodeBadge />
-          <div
-            className="relative z-20 mx-2 max-w-screen-xl space-y-4 md:mx-auto"
-            style={{ marginTop: "70dvh" }}
-          >
-            <Search />
-            <HighlineList />
-          </div>
-        </>
-      )}
-      <CreateHighline
-        mapIsOpen={mapOpen}
-        location={location}
-        showTrigger={showActionButtons}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: structuredData }}
       />
-      {showActionButtons ? <MapToggle mapIsOpen={mapOpen} /> : null}
+      {!mapOpen ? <HeroPromoCard /> : null}
+      <HomeInteractive />
+      {!mapOpen ? <HomeAgentContent locale={locale} /> : null}
     </>
   );
 }

--- a/next/app/manifest.ts
+++ b/next/app/manifest.ts
@@ -4,7 +4,8 @@ export default function manifest(): MetadataRoute.Manifest {
   return {
     name: "Chooselife",
     short_name: "Chooselife",
-    description: "O aplicativo feito para o Highliner",
+    description:
+      "Chooselife is the highline app for discovering lines, exploring their locations, recording walks, and finding events.",
     start_url: "/",
     display: "standalone",
     orientation: "portrait",

--- a/next/app/robots.ts
+++ b/next/app/robots.ts
@@ -1,7 +1,9 @@
 import type { MetadataRoute } from "next";
 
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://chooselife.club";
+  const baseUrl = (
+    process.env.NEXT_PUBLIC_BASE_URL || "https://chooselife.club"
+  ).replace(/\/+$/, "");
 
   return {
     rules: [

--- a/next/app/sitemap.ts
+++ b/next/app/sitemap.ts
@@ -9,8 +9,12 @@ const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!;
 const supabase = createClient<Database>(supabaseUrl, supabaseKey);
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl =
-    process.env.NEXT_PUBLIC_BASE_URL || "https://chooselife.club";
+  const baseUrl = (
+    process.env.NEXT_PUBLIC_BASE_URL || "https://chooselife.club"
+  ).replace(/\/+$/, "");
+
+  const localizedUrl = (locale: string, route: string) =>
+    `${baseUrl}${locale === "en" ? "/en" : ""}${route}`;
 
   const staticRoutes = ["", "/events", "/download", "/privacy"];
 
@@ -20,11 +24,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   for (const route of staticRoutes) {
     const languages: Record<string, string> = {};
     for (const locale of locales) {
-      languages[locale] = `${baseUrl}/${locale}${route}`;
+      languages[locale] = localizedUrl(locale, route);
     }
 
     entries.push({
-      url: `${baseUrl}/pt${route}`,
+      url: localizedUrl("pt", route),
       lastModified: new Date(),
       alternates: {
         languages,
@@ -42,11 +46,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     for (const festival of festivals) {
       const languages: Record<string, string> = {};
       for (const locale of locales) {
-        languages[locale] = `${baseUrl}/${locale}/festival/${festival.slug}`;
+        languages[locale] = localizedUrl(locale, `/festival/${festival.slug}`);
       }
 
       entries.push({
-        url: `${baseUrl}/pt/festival/${festival.slug}`,
+        url: localizedUrl("pt", `/festival/${festival.slug}`),
         lastModified: new Date(festival.created_at),
         changeFrequency: "weekly",
         priority: 0.9,
@@ -69,11 +73,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
       const languages: Record<string, string> = {};
       for (const locale of locales) {
-        languages[locale] = `${baseUrl}/${locale}/news/${post.slug}`;
+        languages[locale] = localizedUrl(locale, `/news/${post.slug}`);
       }
 
       entries.push({
-        url: `${baseUrl}/pt/news/${post.slug}`,
+        url: localizedUrl("pt", `/news/${post.slug}`),
         lastModified: new Date(post.created_at),
         changeFrequency: "monthly",
         priority: 0.8,

--- a/next/lib/accept.ts
+++ b/next/lib/accept.ts
@@ -1,0 +1,111 @@
+export type Representation = "html" | "markdown" | "not-acceptable";
+
+type MediaRange = {
+  type: string;
+  subtype: string;
+  quality: number;
+  order: number;
+};
+
+type Match = MediaRange & {
+  specificity: number;
+};
+
+const REPRESENTATIONS = [
+  { name: "markdown" as const, type: "text", subtype: "markdown" },
+  { name: "html" as const, type: "text", subtype: "html" },
+];
+
+function parseAcceptHeader(header: string): MediaRange[] {
+  return header
+    .split(",")
+    .map((part, order) => {
+      const [rawMediaType, ...rawParameters] = part.split(";");
+      const mediaTypeMatch = rawMediaType
+        .trim()
+        .toLowerCase()
+        .match(/^([^/\s]+)\s*\/\s*([^/\s]+)$/);
+
+      if (!mediaTypeMatch) return null;
+
+      const qualityParameter = rawParameters.find((parameter) => {
+        return /^q\s*=/.test(parameter.trim().toLowerCase());
+      });
+      const quality = qualityParameter
+        ? Number(qualityParameter.trim().replace(/^q\s*=\s*/i, ""))
+        : 1;
+
+      if (!Number.isFinite(quality) || quality < 0 || quality > 1) {
+        return null;
+      }
+
+      return {
+        type: mediaTypeMatch[1],
+        subtype: mediaTypeMatch[2],
+        quality,
+        order,
+      };
+    })
+    .filter((range): range is MediaRange => range !== null);
+}
+
+function getBestMatch(
+  ranges: MediaRange[],
+  type: string,
+  subtype: string,
+): Match | null {
+  const matches = ranges
+    .map((range) => {
+      const typeMatches = range.type === "*" || range.type === type;
+      const subtypeMatches = range.subtype === "*" || range.subtype === subtype;
+
+      if (!typeMatches || !subtypeMatches) return null;
+
+      return {
+        ...range,
+        specificity:
+          (range.type === "*" ? 0 : 1) + (range.subtype === "*" ? 0 : 1),
+      };
+    })
+    .filter((match): match is Match => match !== null)
+    .sort(
+      (left, right) =>
+        right.specificity - left.specificity || left.order - right.order,
+    );
+
+  return matches[0] || null;
+}
+
+export function negotiateRepresentation(
+  acceptHeader: string | null,
+): Representation {
+  if (!acceptHeader?.trim()) return "html";
+
+  const ranges = parseAcceptHeader(acceptHeader);
+  const candidates = REPRESENTATIONS.map((representation) => {
+    const match = getBestMatch(
+      ranges,
+      representation.type,
+      representation.subtype,
+    );
+
+    return {
+      ...representation,
+      quality: match?.quality || 0,
+      specificity: match?.specificity ?? -1,
+      order: match?.order ?? Number.MAX_SAFE_INTEGER,
+    };
+  }).filter((candidate) => candidate.quality > 0);
+
+  if (candidates.length === 0) return "not-acceptable";
+
+  candidates.sort(
+    (left, right) =>
+      right.quality - left.quality ||
+      right.specificity - left.specificity ||
+      left.order - right.order ||
+      (left.name === "html" ? -1 : 1),
+  );
+
+  return candidates[0].name;
+}

--- a/next/lib/agent-content.ts
+++ b/next/lib/agent-content.ts
@@ -1,0 +1,103 @@
+export type AgentLocale = "pt" | "en";
+
+export type AgentHomeContent = {
+  heading: string;
+  summary: string;
+  sections: readonly {
+    heading: string;
+    body: string;
+  }[];
+};
+
+const HOME_CONTENT: Record<AgentLocale, AgentHomeContent> = {
+  en: {
+    heading: "Chooselife: the highline community and map",
+    summary:
+      "Chooselife is a highline app and community hub for discovering lines, exploring their locations, and keeping a record of the walks that matter to you. It brings highline information, events, and community features into one place for people who practice highline and slackline.",
+    sections: [
+      {
+        heading: "Discover highlines",
+        body: "Use the highline map and searchable list to find lines shared by the community. Open a line to review its name, height, length, image, description, access notes, and other details supplied by its contributors.",
+      },
+      {
+        heading: "Record every walk",
+        body: "After a session, register walks and connect them with your profile. Chooselife can surface your history, distance, full lines, and rankings so progress remains tied to the places and people that make the sport meaningful.",
+      },
+      {
+        heading: "Find events and community sessions",
+        body: "The events area collects upcoming slackline and highline gatherings. Browse event information, then use the website or app to keep track of the sessions and festivals you want to attend.",
+      },
+      {
+        heading: "Use the Chooselife app",
+        body: "The website is the public front door to Chooselife. The mobile app adds the account experience, favorites, profiles, and walk-registration tools. Use the download page to find the current iOS and Android app links.",
+      },
+    ],
+  },
+  pt: {
+    heading: "Chooselife: comunidade e mapa de highline",
+    summary:
+      "O Chooselife é um aplicativo e ponto de encontro da comunidade de highline para descobrir vias, explorar seus locais e registrar os rolês que fazem parte da sua história. A plataforma reúne informações de highlines, eventos e recursos da comunidade em um só lugar para quem pratica highline e slackline.",
+    sections: [
+      {
+        heading: "Descubra highlines",
+        body: "Use o mapa de highlines e a lista pesquisável para encontrar vias compartilhadas pela comunidade. Abra uma via para consultar nome, altura, comprimento, imagem, descrição, informações de acesso e outros detalhes fornecidos por quem conhece o local.",
+      },
+      {
+        heading: "Registre cada rolê",
+        body: "Depois de uma sessão, registre os rolês e conecte-os ao seu perfil. O Chooselife reúne histórico, distância, cadenas, full lines e rankings para que a evolução continue ligada aos lugares e às pessoas que tornam o esporte especial.",
+      },
+      {
+        heading: "Encontre eventos e encontros",
+        body: "A área de eventos reúne encontros de slackline e highline. Consulte as informações de cada evento e use o site ou o aplicativo para acompanhar as sessões e festivais que você quer visitar.",
+      },
+      {
+        heading: "Use o aplicativo Chooselife",
+        body: "O site é a porta de entrada pública do Chooselife. O aplicativo acrescenta a experiência de conta, favoritos, perfis e registro de rolês. Acesse a página de download para encontrar os links atuais para iOS e Android.",
+      },
+    ],
+  },
+};
+
+export function resolveAgentLocale(locale: string | undefined): AgentLocale {
+  return locale === "en" ? "en" : "pt";
+}
+
+export function getAgentHomeContent(
+  locale: string | undefined,
+): AgentHomeContent {
+  return HOME_CONTENT[resolveAgentLocale(locale)];
+}
+
+export function getAgentHomeMarkdown(
+  locale: string | undefined,
+  baseUrl: string,
+): string {
+  const resolvedLocale = resolveAgentLocale(locale);
+  const content = getAgentHomeContent(resolvedLocale);
+  const normalizedBaseUrl = baseUrl.replace(/\/+$/, "");
+  const localePrefix = resolvedLocale === "en" ? "/en" : "";
+
+  const sections = content.sections.flatMap(({ heading, body }) => [
+    `## ${heading}`,
+    "",
+    body,
+    "",
+  ]);
+
+  return [
+    `# ${content.heading}`,
+    "",
+    `> ${content.summary}`,
+    "",
+    ...sections,
+    "## Explore Chooselife",
+    "",
+    `- [Homepage](${normalizedBaseUrl}${localePrefix}/): Discover highlines and community resources.`,
+    `- [Events](${normalizedBaseUrl}${localePrefix}/events): Browse upcoming highline and slackline events.`,
+    `- [Download the app](${normalizedBaseUrl}${localePrefix}/download): Find the current mobile app links.`,
+    `- [Privacy policy](${normalizedBaseUrl}${localePrefix}/privacy): Read the site's privacy policy.`,
+    `- [Sitemap](${normalizedBaseUrl}/sitemap.xml): Find the site's indexed URLs.`,
+    `- [Agent index](${normalizedBaseUrl}/llms.txt): Read the curated machine-readable site overview.`,
+    "",
+  ].join("\n");
+}

--- a/next/messages/en.json
+++ b/next/messages/en.json
@@ -39,6 +39,18 @@
       },
       "submit": "Create"
     },
+    "browse": {
+      "eyebrow": "Start exploring",
+      "title": "Find your next highline",
+      "viewMap": "View the map",
+      "navigationLabel": "Homepage destinations",
+      "explore": "Explore",
+      "map": "Map",
+      "events": "Events",
+      "app": "The app",
+      "summary": "Highline map, community walks, and events in one place.",
+      "download": "Get the app"
+    },
     "seeDetails": "See details"
   },
   "map": {

--- a/next/messages/pt.json
+++ b/next/messages/pt.json
@@ -39,6 +39,18 @@
       },
       "submit": "Registrar"
     },
+    "browse": {
+      "eyebrow": "Comece a explorar",
+      "title": "Encontre seu próximo highline",
+      "viewMap": "Ver o mapa",
+      "navigationLabel": "Destinos da página inicial",
+      "explore": "Explorar",
+      "map": "Mapa",
+      "events": "Eventos",
+      "app": "O app",
+      "summary": "Mapa de highline, rolês da comunidade e eventos em um só lugar.",
+      "download": "Baixe o app"
+    },
     "seeDetails": "Ver detalhes"
   },
   "map": {

--- a/next/middleware.ts
+++ b/next/middleware.ts
@@ -1,14 +1,94 @@
-import { type NextRequest } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 import createIntlMiddleware from "next-intl/middleware";
 
-import { updateSession } from "@/utils/supabase/middleware"
+import { getAgentHomeMarkdown, resolveAgentLocale } from "./lib/agent-content";
+import { negotiateRepresentation } from "./lib/accept";
+import { updateSession } from "@/utils/supabase/middleware";
 
 import { routing } from "./i18n/routing";
 
+const handleI18nRouting = createIntlMiddleware(routing);
+
+function appendVary(headers: Headers, ...values: string[]) {
+  const existingValues = (headers.get("Vary") || "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  const seen = new Set(existingValues.map((value) => value.toLowerCase()));
+
+  for (const value of values) {
+    if (!seen.has(value.toLowerCase())) {
+      existingValues.push(value);
+      seen.add(value.toLowerCase());
+    }
+  }
+
+  headers.set("Vary", existingValues.join(", "));
+}
+
+function normalizePathname(pathname: string) {
+  return pathname.length > 1 ? pathname.replace(/\/+$/, "") : pathname;
+}
+
+function isHomepage(pathname: string) {
+  const normalizedPathname = normalizePathname(pathname);
+  return (
+    normalizedPathname === "/" ||
+    normalizedPathname === "/pt" ||
+    normalizedPathname === "/en"
+  );
+}
+
+function getHomepageLocale(pathname: string) {
+  const firstSegment = normalizePathname(pathname).split("/")[1];
+  return resolveAgentLocale(firstSegment);
+}
+
+function getBaseUrl(request: NextRequest) {
+  return (process.env.NEXT_PUBLIC_BASE_URL || request.nextUrl.origin).replace(
+    /\/+$/,
+    "",
+  );
+}
 
 export default async function middleware(req: NextRequest) {
-  const handleI18nRouting = createIntlMiddleware(routing);
+  const isRscRequest = req.headers.has("RSC");
+  if (isHomepage(req.nextUrl.pathname) && !isRscRequest) {
+    const representation = negotiateRepresentation(req.headers.get("accept"));
+
+    if (representation === "markdown") {
+      return new NextResponse(
+        getAgentHomeMarkdown(
+          getHomepageLocale(req.nextUrl.pathname),
+          getBaseUrl(req),
+        ),
+        {
+          headers: {
+            "Cache-Control": "public, max-age=300, s-maxage=300",
+            "Content-Type": "text/markdown; charset=utf-8",
+            Vary: "Accept, Accept-Encoding",
+          },
+        },
+      );
+    }
+
+    if (representation === "not-acceptable") {
+      return new NextResponse(
+        "# Not acceptable\n\nChooselife serves this page as HTML or Markdown. Request `text/html` or `text/markdown`.",
+        {
+          status: 406,
+          headers: {
+            "Cache-Control": "no-store",
+            "Content-Type": "text/markdown; charset=utf-8",
+            Vary: "Accept, Accept-Encoding",
+          },
+        },
+      );
+    }
+  }
+
   const res = handleI18nRouting(req);
+  appendVary(res.headers, "Accept", "Accept-Encoding");
 
   const pathname = req.nextUrl.pathname;
   if (pathname === "/.well-known/apple-app-site-association") {
@@ -16,7 +96,9 @@ export default async function middleware(req: NextRequest) {
     return res;
   }
 
-  return await updateSession(req, res)
+  const response = await updateSession(req, res);
+  appendVary(response.headers, "Accept", "Accept-Encoding");
+  return response;
 }
 
 export const config = {

--- a/next/package.json
+++ b/next/package.json
@@ -11,7 +11,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test:agent-readiness": "node --test tests/agent-readiness.test.mjs"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1013.0",

--- a/next/public/llms.txt
+++ b/next/public/llms.txt
@@ -1,0 +1,13 @@
+# Chooselife
+
+> Chooselife is a highline app and community hub for discovering highlines, exploring their locations, recording walks, and finding events.
+
+Chooselife is the product name used by this website and its mobile app. The homepage is the canonical public entry point and supports `Accept: text/markdown` content negotiation for agents.
+
+## Core pages
+
+- [Homepage](https://chooselife.club/): Discover highlines and community resources.
+- [Events](https://chooselife.club/events): Browse upcoming highline and slackline events.
+- [Download the app](https://chooselife.club/download): Find the current iOS and Android app links.
+- [Privacy policy](https://chooselife.club/privacy): Read the site's privacy policy.
+- [Sitemap](https://chooselife.club/sitemap.xml): Find the site's indexed URLs.

--- a/next/tests/agent-readiness.test.mjs
+++ b/next/tests/agent-readiness.test.mjs
@@ -72,6 +72,10 @@ test("homepage contains crawlable content and SoftwareApplication JSON-LD", asyn
   assert.equal(response.status, 200);
   assert.match(response.headers.get("content-type") || "", /^text\/html/);
   assert.match(html, /<h1\b/i);
+  assert.match(
+    html,
+    /(?:Find your next highline|Encontre seu pr[oó]ximo highline)/,
+  );
   assert.ok(
     visibleText(html).length >= 500,
     `expected at least 500 visible characters, got ${visibleText(html).length}`,

--- a/next/tests/agent-readiness.test.mjs
+++ b/next/tests/agent-readiness.test.mjs
@@ -1,0 +1,195 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { after, before, test } from "node:test";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const nextDirectory = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const port = 3217;
+const baseUrl = `http://127.0.0.1:${port}`;
+let server;
+
+function wait(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function visibleText(html) {
+  return html
+    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function hasVaryHeader(response, value) {
+  return (response.headers.get("vary") || "")
+    .split(",")
+    .map((item) => item.trim().toLowerCase())
+    .includes(value.toLowerCase());
+}
+
+before(async () => {
+  server = spawn("pnpm", ["start"], {
+    cwd: nextDirectory,
+    env: {
+      ...process.env,
+      NEXT_PUBLIC_SUPABASE_URL: "https://example.supabase.co",
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "example-key",
+      NEXT_PUBLIC_BASE_URL: "https://chooselife.club",
+      NEXT_PUBLIC_APPLE_APP_ID: "6745024708",
+      NEXT_PUBLIC_APP_SCHEME: "com.bodok.chooselife",
+      PORT: String(port),
+    },
+    stdio: "ignore",
+  });
+
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${baseUrl}/`, { redirect: "manual" });
+      if (response.status > 0) return;
+    } catch {
+      // The server is still starting.
+    }
+    await wait(250);
+  }
+
+  throw new Error("The production server did not start within 30 seconds.");
+});
+
+after(() => {
+  server?.kill();
+});
+
+test("homepage contains crawlable content and SoftwareApplication JSON-LD", async () => {
+  const response = await fetch(`${baseUrl}/`);
+  const html = await response.text();
+
+  assert.equal(response.status, 200);
+  assert.match(response.headers.get("content-type") || "", /^text\/html/);
+  assert.match(html, /<h1\b/i);
+  assert.ok(
+    visibleText(html).length >= 500,
+    `expected at least 500 visible characters, got ${visibleText(html).length}`,
+  );
+
+  const jsonLdMatch = html.match(
+    /<script[^>]*type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/i,
+  );
+  assert.ok(jsonLdMatch, "homepage should contain JSON-LD");
+  const jsonLd = JSON.parse(jsonLdMatch[1]);
+  const application = jsonLd["@graph"].find(
+    (item) => item["@type"] === "SoftwareApplication",
+  );
+
+  assert.equal(application.name, "Chooselife");
+  assert.equal(application.url, "https://chooselife.club");
+  assert.equal(application.applicationCategory, "SportsApplication");
+
+  const localizedMarkdownResponse = await fetch(`${baseUrl}/en`, {
+    headers: { Accept: "text/markdown" },
+  });
+  const localizedMarkdown = await localizedMarkdownResponse.text();
+  assert.equal(localizedMarkdownResponse.status, 200);
+  assert.match(
+    localizedMarkdown,
+    /^# Chooselife: the highline community and map/,
+  );
+  assert.match(localizedMarkdown, /https:\/\/chooselife\.club\/en\/events/);
+});
+
+test("homepage negotiates Markdown and varies caches by Accept", async () => {
+  const markdownResponse = await fetch(`${baseUrl}/`, {
+    headers: { Accept: "text/markdown" },
+  });
+  const markdown = await markdownResponse.text();
+
+  assert.equal(markdownResponse.status, 200);
+  assert.match(
+    markdownResponse.headers.get("content-type") || "",
+    /^text\/markdown; charset=utf-8$/,
+  );
+  assert.equal(hasVaryHeader(markdownResponse, "Accept"), true);
+  assert.equal(hasVaryHeader(markdownResponse, "Accept-Encoding"), true);
+  assert.match(markdown, /^# Chooselife:/);
+
+  const htmlResponse = await fetch(`${baseUrl}/`, {
+    headers: { Accept: "text/html, text/markdown;q=0.5" },
+  });
+  assert.match(htmlResponse.headers.get("content-type") || "", /^text\/html/);
+
+  const markdownPreferredResponse = await fetch(`${baseUrl}/`, {
+    headers: { Accept: "text/html;q=0.5, text/markdown" },
+  });
+  assert.match(
+    markdownPreferredResponse.headers.get("content-type") || "",
+    /^text\/markdown/,
+  );
+
+  const unsupportedResponse = await fetch(`${baseUrl}/`, {
+    headers: { Accept: "application/json" },
+  });
+  assert.equal(unsupportedResponse.status, 406);
+});
+
+test("unknown paths return a Markdown 404 with agent navigation", async () => {
+  const response = await fetch(`${baseUrl}/some-path-that-does-not-exist`);
+  const body = await response.text();
+
+  assert.equal(response.status, 404);
+  assert.match(
+    response.headers.get("content-type") || "",
+    /^text\/markdown; charset=utf-8$/,
+  );
+  assert.match(body, /https:\/\/chooselife\.club\/sitemap\.xml/);
+  assert.match(body, /https:\/\/chooselife\.club\/llms\.txt/);
+
+  const localizedResponse = await fetch(`${baseUrl}/en/missing-resource`);
+  assert.equal(localizedResponse.status, 404);
+
+  const headResponse = await fetch(`${baseUrl}/another-missing-page`, {
+    method: "HEAD",
+  });
+  assert.equal(headResponse.status, 404);
+});
+
+test("machine-readable discovery files are public and canonical", async () => {
+  const llmsResponse = await fetch(`${baseUrl}/llms.txt`);
+  const llms = await llmsResponse.text();
+  assert.equal(llmsResponse.status, 200);
+  assert.match(llms, /^# Chooselife\n/m);
+  assert.match(llms, /^> Chooselife/m);
+  assert.match(llms, /^## Core pages\n/m);
+  assert.match(llms, /\[Homepage\]\(https:\/\/chooselife\.club\/\)/);
+
+  const sitemapResponse = await fetch(`${baseUrl}/sitemap.xml`);
+  const sitemap = await sitemapResponse.text();
+  assert.equal(sitemapResponse.status, 200);
+  assert.match(sitemap, /<urlset/);
+  assert.match(sitemap, /<loc>https:\/\/chooselife\.club<\/loc>/);
+  assert.doesNotMatch(sitemap, /https:\/\/chooselife\.club\/pt/);
+
+  const robotsResponse = await fetch(`${baseUrl}/robots.txt`);
+  const robots = await robotsResponse.text();
+  assert.equal(robotsResponse.status, 200);
+  assert.match(robots, /Sitemap: https:\/\/chooselife\.club\/sitemap\.xml/);
+
+  const manifestResponse = await fetch(`${baseUrl}/manifest.webmanifest`);
+  const manifest = await manifestResponse.json();
+  assert.equal(manifestResponse.status, 200);
+  assert.equal(manifest.name, "Chooselife");
+  assert.match(manifest.description, /highline app/i);
+
+  for (const path of [
+    "/.well-known/apple-app-site-association",
+    "/.well-known/assetlinks.json",
+  ]) {
+    const response = await fetch(`${baseUrl}${path}`);
+    assert.equal(response.status, 200, `${path} should be public`);
+    await response.json();
+  }
+});


### PR DESCRIPTION
## Summary

- Server-render meaningful localized homepage content while preserving the interactive map and search experience.
- Add SoftwareApplication, Organization, and WebSite JSON-LD plus stronger Chooselife metadata and canonical discovery URLs.
- Negotiate homepage Markdown with q-value and specificity handling, text/markdown; charset=utf-8, and Vary: Accept, Accept-Encoding.
- Replace the soft-404 catch-all with real Markdown 404 responses linking to the sitemap and llms.txt.
- Add a spec-shaped llms.txt, normalize sitemap and robots URLs, and verify public discovery files.

## Verification

- pnpm --filter chooselife-web build passes; Next type validation passes.
- pnpm --filter chooselife-web test:agent-readiness passes: 4 tests covering homepage SSR and JSON-LD, Markdown negotiation, localized 404s, sitemap, robots, manifest, and app-link files.
- Prettier check and git diff --check pass.
- Existing pnpm --filter chooselife-web lint remains blocked by the repository missing next/dist/compiled/babel/eslint-parser dependency; this reproduced before the change.

Protocol references: https://acceptmarkdown.com/guides/accept-text-markdown and https://llmstxt.org/?trk=public_post-text