### PR TITLE
feat: generate fixed-day recurring contribution obligations

### DIFF
--- a/packages/database/database-generated.types.ts
+++ b/packages/database/database-generated.types.ts
@@ -30,28 +30,40 @@ export type Database = {
       contribution_plan_assignments: {
         Row: {
           amount: number
+          billing_timezone: string | null
           created_at: string
           currency: string
+          due_day: number | null
           effective_period_start: string
           id: string
+          lead_days: number | null
+          pix_copy_paste: string | null
           plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"]
           schedule_id: string
         }
         Insert: {
           amount: number
+          billing_timezone?: string | null
           created_at?: string
           currency: string
+          due_day?: number | null
           effective_period_start: string
           id?: string
+          lead_days?: number | null
+          pix_copy_paste?: string | null
           plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"]
           schedule_id: string
         }
         Update: {
           amount?: number
+          billing_timezone?: string | null
           created_at?: string
           currency?: string
+          due_day?: number | null
           effective_period_start?: string
           id?: string
+          lead_days?: number | null
+          pix_copy_paste?: string | null
           plan_type?: Database["public"]["Enums"]["subscription_plan_type_enum"]
           schedule_id?: string
         }
@@ -1314,12 +1326,17 @@ export type Database = {
           application_revision_id: string | null
           available_at: string
           available_on: string
+          billing_due_day: number | null
+          billing_lead_days: number | null
+          billing_timezone: string | null
           created_at: string
           currency: string
           due_on: string
           id: string
           legacy_payment_id: string | null
           organization_id: string
+          organization_name_snapshot: string | null
+          organization_slug_snapshot: string | null
           payment_method: string
           period_end: string
           period_key: string
@@ -1328,6 +1345,7 @@ export type Database = {
           plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"]
           purpose: Database["public"]["Enums"]["payment_obligation_purpose_enum"]
           schedule_id: string | null
+          schedule_term_id: string | null
           settled_at: string | null
           status: Database["public"]["Enums"]["payment_obligation_status_enum"]
           user_id: string
@@ -1337,12 +1355,17 @@ export type Database = {
           application_revision_id?: string | null
           available_at: string
           available_on?: string
+          billing_due_day?: number | null
+          billing_lead_days?: number | null
+          billing_timezone?: string | null
           created_at?: string
           currency: string
           due_on?: string
           id?: string
           legacy_payment_id?: string | null
           organization_id: string
+          organization_name_snapshot?: string | null
+          organization_slug_snapshot?: string | null
           payment_method?: string
           period_end?: string
           period_key?: string
@@ -1351,6 +1374,7 @@ export type Database = {
           plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"]
           purpose?: Database["public"]["Enums"]["payment_obligation_purpose_enum"]
           schedule_id?: string | null
+          schedule_term_id?: string | null
           settled_at?: string | null
           status?: Database["public"]["Enums"]["payment_obligation_status_enum"]
           user_id: string
@@ -1360,12 +1384,17 @@ export type Database = {
           application_revision_id?: string | null
           available_at?: string
           available_on?: string
+          billing_due_day?: number | null
+          billing_lead_days?: number | null
+          billing_timezone?: string | null
           created_at?: string
           currency?: string
           due_on?: string
           id?: string
           legacy_payment_id?: string | null
           organization_id?: string
+          organization_name_snapshot?: string | null
+          organization_slug_snapshot?: string | null
           payment_method?: string
           period_end?: string
           period_key?: string
@@ -1374,6 +1403,7 @@ export type Database = {
           plan_type?: Database["public"]["Enums"]["subscription_plan_type_enum"]
           purpose?: Database["public"]["Enums"]["payment_obligation_purpose_enum"]
           schedule_id?: string | null
+          schedule_term_id?: string | null
           settled_at?: string | null
           status?: Database["public"]["Enums"]["payment_obligation_status_enum"]
           user_id?: string
@@ -1405,6 +1435,13 @@ export type Database = {
             columns: ["schedule_id"]
             isOneToOne: false
             referencedRelation: "contribution_schedules"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "payment_obligations_schedule_term_id_fkey"
+            columns: ["schedule_term_id"]
+            isOneToOne: false
+            referencedRelation: "contribution_plan_assignments"
             referencedColumns: ["id"]
           },
           {
@@ -1939,8 +1976,29 @@ export type Database = {
         }
         Returns: string
       }
-      generate_membership_billing_obligations: {
-        Args: { p_as_of?: string }
+      generate_membership_billing_obligations:
+        | {
+            Args: never
+            Returns: {
+              failure_reason: string
+              obligation_id: string
+              period_key: string
+              result: string
+              schedule_id: string
+            }[]
+          }
+        | {
+            Args: { p_as_of?: string }
+            Returns: {
+              failure_reason: string
+              obligation_id: string
+              period_key: string
+              result: string
+              schedule_id: string
+            }[]
+          }
+      generate_membership_billing_obligations_at: {
+        Args: { p_as_of: string }
         Returns: {
           failure_reason: string
           obligation_id: string
@@ -2105,6 +2163,14 @@ export type Database = {
         }
         Returns: Json
       }
+      get_membership_billing_ledger_legacy: {
+        Args: {
+          p_history_cursor?: string
+          p_history_limit?: number
+          p_organization_id: string
+        }
+        Returns: Json
+      }
       get_payment_obligation_instructions: {
         Args: { p_obligation_id: string }
         Returns: {
@@ -2198,6 +2264,10 @@ export type Database = {
         Args: { target_festival_id: string; target_profile_id: string }
         Returns: boolean
       }
+      is_valid_billing_timezone: {
+        Args: { p_timezone: string }
+        Returns: boolean
+      }
       mark_manual_payment_paid_by_user: {
         Args: { p_payment_id: string }
         Returns: {
@@ -2250,6 +2320,32 @@ export type Database = {
         Args: { target_festival_id?: string }
         Returns: undefined
       }
+      reconcile_legacy_payment_obligations: {
+        Args: { p_apply?: boolean }
+        Returns: {
+          obligation_id: string
+          payment_id: string
+          payment_status: Database["public"]["Enums"]["payment_status_enum"]
+          reason: string
+          result: string
+        }[]
+      }
+      recurring_due_date_on_or_after: {
+        Args: {
+          p_admission_date: string
+          p_cadence: Database["public"]["Enums"]["contribution_cadence_enum"]
+          p_due_day: number
+          p_from_date: string
+        }
+        Returns: string
+      }
+      recurring_period_key: {
+        Args: {
+          p_cadence: Database["public"]["Enums"]["contribution_cadence_enum"]
+          p_due_date: string
+        }
+        Returns: string
+      }
       regenerate_festival_schedule_window: {
         Args: { target_window_id: string }
         Returns: number
@@ -2277,6 +2373,14 @@ export type Database = {
           obligation_id: string
           obligation_status: Database["public"]["Enums"]["payment_obligation_status_enum"]
         }[]
+      }
+      schedule_contribution_plan_change: {
+        Args: {
+          p_effective_period_start: string
+          p_plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"]
+          p_schedule_id: string
+        }
+        Returns: string
       }
       submit_association_application: {
         Args: {

--- a/supabase/functions/generate-renewal-payments/README.md
+++ b/supabase/functions/generate-renewal-payments/README.md
@@ -1,17 +1,23 @@
 # Generate Membership Ledger Obligations
 
-This scheduled Edge Function materializes the recurring periods that are ready
-for payment and creates one targeted notification per obligation.
+This scheduled Edge Function materializes recurring periods that are ready for
+payment. It is a thin scheduler adapter; it does not send reminders or mutate
+membership state.
 
 The database function `generate_membership_billing_obligations` is the
 idempotent source of truth. It snapshots the plan, amount, currency, PIX
-payload, availability date, and due date into `payment_obligations`. The Edge
-Function then links notifications to the exact `obligationId`, so opening a
-reminder always refetches the current server-owned Ledger state.
+payload, availability date, and due date into `payment_obligations`. Database
+uniqueness makes retries and concurrent runs safe. Reminder stages belong to a
+separate workflow and must reference the materialized obligation after
+generation.
 
-Notification deduplication uses the obligation ID and notification type. A
-retry can therefore recover a missing notification without creating a second
-obligation or sending a duplicate reminder.
+The production RPC derives the database clock and is executable only by the
+Supabase service role. The timestamp-injected worker is private and exists for
+local regression tests.
+
+Before the first scheduled run after cutover, review the legacy mapping with
+`select * from public.reconcile_legacy_payment_obligations(false)`. Apply only
+the reviewed, unambiguous mappings with the same command set to `true`.
 
 ## Push delivery
 
@@ -30,8 +36,7 @@ supabase functions deploy generate-renewal-payments --project-ref <your-project-
 
 ## Scheduling
 
-The existing `daily-renewal-check` `pg_cron` job invokes this function daily.
-The job lives in
-`supabase/migrations/20251113121601_schedule-payment.sql` and uses Supabase
-Vault for the project URL and service-role key. Keep those secrets out of the
-repository.
+The cutover migration replaces the legacy `daily-renewal-check` job with one
+`membership-billing-obligation-generator` job that runs every 15 minutes. It
+uses Supabase Vault for the project URL and service-role key. Keep those
+secrets out of the repository.

--- a/supabase/functions/generate-renewal-payments/index.ts
+++ b/supabase/functions/generate-renewal-payments/index.ts
@@ -2,30 +2,12 @@ import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { supabaseAdmin } from "../_shared/supabase-admin.ts";
 import { corsHeaders } from "../_shared/cors.ts";
 
-type Locale = "en" | "pt";
-
-type GeneratedObligation = {
-  id: string;
-  organization_id: string;
-  user_id: string;
-  amount: number;
-  currency: string;
-  due_on: string;
-  period_key: string;
-  plan_type: "monthly" | "annual";
-  organization: {
-    name: string;
-    slug: string;
-    billing_timezone: string;
-  };
-};
-
 type GeneratorResult = {
   failure_reason: string | null;
   obligation_id: string | null;
-  period_key: string;
-  result: string;
-  schedule_id: string;
+  period_key: string | null;
+  result: "created" | "already_exists" | "failed";
+  schedule_id: string | null;
 };
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -35,202 +17,50 @@ function jsonResponse(body: unknown, status = 200): Response {
   });
 }
 
-function formatAmount(
-  amount: number,
-  currency: string,
-  locale: Locale,
-): string {
-  return new Intl.NumberFormat(locale === "pt" ? "pt-BR" : "en-US", {
-    currency,
-    style: "currency",
-  }).format(amount / 100);
-}
+function isTrustedScheduler(req: Request): boolean {
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  const authorization = req.headers.get("Authorization");
 
-function formatCalendarDate(date: string, locale: Locale): string {
-  const parsed = new Date(`${date}T00:00:00Z`);
-  if (Number.isNaN(parsed.getTime())) return date;
-
-  return new Intl.DateTimeFormat(locale === "pt" ? "pt-BR" : "en-US", {
-    day: "2-digit",
-    month: "2-digit",
-    timeZone: "UTC",
-    year: "numeric",
-  }).format(parsed);
-}
-
-function getLocalDate(timezone: string): string {
-  const parts = new Intl.DateTimeFormat("en-US", {
-    day: "2-digit",
-    month: "2-digit",
-    timeZone: timezone,
-    year: "numeric",
-  }).formatToParts(new Date());
-  const values = parts.reduce<Record<string, string>>((result, part) => {
-    if (part.type !== "literal") result[part.type] = part.value;
-    return result;
-  }, {});
-
-  return `${values.year}-${values.month}-${values.day}`;
-}
-
-export function buildRecurringPaymentUrl({
-  amount,
-  currency,
-  obligationId,
-  organizationSlug,
-}: {
-  amount: number;
-  currency: string;
-  obligationId: string;
-  organizationSlug: string;
-}): string {
-  const params = new URLSearchParams({
-    amount: String(amount),
-    currency,
-    obligationId,
-    paymentContext: "subscription_renewal",
-    slug: organizationSlug,
-  });
-
-  return `/payment?${params.toString()}`;
-}
-
-function buildNotification(obligation: GeneratedObligation) {
-  const isOverdue =
-    obligation.due_on < getLocalDate(obligation.organization.billing_timezone);
-  const amountPt = formatAmount(obligation.amount, obligation.currency, "pt");
-  const amountEn = formatAmount(obligation.amount, obligation.currency, "en");
-  const dueDatePt = formatCalendarDate(obligation.due_on, "pt");
-  const dueDateEn = formatCalendarDate(obligation.due_on, "en");
-
-  return {
-    user_id: obligation.user_id,
-    title: {
-      en: isOverdue
-        ? "Your membership contribution needs attention"
-        : "Your membership contribution is ready",
-      pt: isOverdue
-        ? "Sua contribuição precisa de atenção"
-        : "Sua contribuição está disponível",
-    },
-    body: {
-      en: isOverdue
-        ? `Your ${amountEn} contribution for ${obligation.organization.name} is overdue. Open the Ledger to regularize it.`
-        : `Your ${amountEn} contribution for ${obligation.organization.name} is ready. Pay by ${dueDateEn}.`,
-      pt: isOverdue
-        ? `Sua contribuição de ${amountPt} para ${obligation.organization.name} está em atraso. Abra o Ledger para regularizar.`
-        : `Sua contribuição de ${amountPt} para ${obligation.organization.name} está disponível. Pague até ${dueDatePt}.`,
-    },
-    data: {
-      amount: String(obligation.amount),
-      currency: obligation.currency,
-      obligation_id: obligation.id,
-      organization_id: obligation.organization_id,
-      organization_slug: obligation.organization.slug,
-      payment_context: "subscription_renewal",
-      period_key: obligation.period_key,
-      type: "recurring_contribution_payment_ready",
-      url: buildRecurringPaymentUrl({
-        amount: obligation.amount,
-        currency: obligation.currency,
-        obligationId: obligation.id,
-        organizationSlug: obligation.organization.slug,
-      }),
-    },
-  };
-}
-
-async function hasLedgerNotification(obligation: GeneratedObligation) {
-  const { data, error } = await supabaseAdmin
-    .from("notifications")
-    .select("id")
-    .eq("user_id", obligation.user_id)
-    .contains("data", {
-      obligation_id: obligation.id,
-      type: "recurring_contribution_payment_ready",
-    })
-    .limit(1)
-    .maybeSingle();
-
-  if (error) {
-    throw new Error(
-      `Failed checking Ledger notification for ${obligation.id}: ${error.message}`,
-    );
-  }
-
-  return Boolean(data);
-}
-
-async function createLedgerNotification(obligation: GeneratedObligation) {
-  const { error } = await supabaseAdmin
-    .from("notifications")
-    .insert(buildNotification(obligation));
-
-  if (error) {
-    throw new Error(
-      `Failed creating Ledger notification for ${obligation.id}: ${error.message}`,
-    );
-  }
+  return Boolean(
+    serviceRoleKey && authorization === `Bearer ${serviceRoleKey}`,
+  );
 }
 
 async function generateLedgerObligations() {
-  const { data: generated, error: generationError } = await supabaseAdmin.rpc(
+  const { data, error } = await supabaseAdmin.rpc(
     "generate_membership_billing_obligations",
-    { p_as_of: new Date().toISOString() },
+    {},
   );
 
-  if (generationError) {
+  if (error) {
     throw new Error(
-      `Failed generating membership billing obligations: ${generationError.message}`,
+      `Failed generating membership billing obligations: ${error.message}`,
     );
   }
 
-  const results = (generated ?? []) as GeneratorResult[];
-  const obligationIds = [
-    ...results.reduce<Set<string>>((ids, result) => {
-      if (result.obligation_id) ids.add(result.obligation_id);
-      return ids;
-    }, new Set<string>()),
-  ];
+  const results = (data ?? []) as GeneratorResult[];
+  const created = results.filter((item) => item.result === "created").length;
+  const alreadyExisting = results.filter(
+    (item) => item.result === "already_exists",
+  ).length;
+  const failed = results.filter((item) => item.result === "failed");
 
-  if (obligationIds.length === 0) {
-    return {
-      generated: results.length,
-      notified: 0,
-      results,
-    };
+  if (failed.length > 0) {
+    console.error("Membership billing generation failures", {
+      count: failed.length,
+      reasons: failed.reduce<Record<string, number>>((counts, item) => {
+        const reason = item.failure_reason ?? "Unknown generation failure";
+        counts[reason] = (counts[reason] ?? 0) + 1;
+        return counts;
+      }, {}),
+    });
   }
-
-  const { data: obligations, error: obligationError } = await supabaseAdmin
-    .from("payment_obligations")
-    .select(
-      "id, organization_id, user_id, amount, currency, due_on, period_key, plan_type, organization:organizations!inner(name, slug, billing_timezone)",
-    )
-    .in("id", obligationIds);
-
-  if (obligationError) {
-    throw new Error(
-      `Failed loading generated Ledger obligations: ${obligationError.message}`,
-    );
-  }
-
-  const typedObligations = (obligations ??
-    []) as unknown as GeneratedObligation[];
-  const notified = (
-    await Promise.all(
-      typedObligations.map(async (obligation) => {
-        if (await hasLedgerNotification(obligation)) return 0;
-
-        await createLedgerNotification(obligation);
-        return 1;
-      }),
-    )
-  ).reduce<number>((total, created) => total + created, 0);
 
   return {
+    already_existing: alreadyExisting,
+    created,
+    failed: failed.length,
     generated: results.length,
-    notified,
-    results,
   };
 }
 
@@ -239,11 +69,17 @@ Deno.serve(async (req) => {
     return new Response("ok", { headers: corsHeaders });
   }
 
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "Only POST is supported." }, 405);
+  }
+
+  if (!isTrustedScheduler(req)) {
+    return jsonResponse({ error: "Scheduler authorization is required." }, 401);
+  }
+
   try {
     const result = await generateLedgerObligations();
-    console.log(
-      `Membership Ledger generation complete: ${result.generated} periods, ${result.notified} notifications.`,
-    );
+    console.log("Membership Ledger generation complete", result);
     return jsonResponse(result);
   } catch (error) {
     console.error("Error in generate-renewal-payments:", error);

--- a/supabase/migrations/20260825000000_harden_fixed_day_recurring_obligations.sql
+++ b/supabase/migrations/20260825000000_harden_fixed_day_recurring_obligations.sql
@@ -1,0 +1,2230 @@
+-- Issue #209: make recurring contribution periods server-owned, immutable,
+-- effective-dated, and safe to backfill without rewriting billing history.
+--
+-- The preceding Ledger migration introduced the first version of these
+-- tables. This migration is deliberately additive/compensating so it is safe
+-- for environments that have already applied that migration.
+
+create or replace function public.is_valid_billing_timezone(p_timezone text)
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select exists (
+    select 1
+    from pg_catalog.pg_timezone_names
+    where name = p_timezone
+  );
+$$;
+
+revoke all on function public.is_valid_billing_timezone(text)
+  from public, anon, authenticated;
+
+create or replace function public.validate_billing_policy_timezone()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if not public.is_valid_billing_timezone(new.billing_timezone) then
+    raise exception 'Billing timezone must be a valid IANA timezone name.'
+      using errcode = '22023';
+  end if;
+
+  return new;
+end;
+$$;
+
+revoke all on function public.validate_billing_policy_timezone()
+  from public, anon, authenticated;
+
+drop trigger if exists organizations_validate_billing_policy_timezone
+  on public.organizations;
+create trigger organizations_validate_billing_policy_timezone
+before insert or update of billing_timezone on public.organizations
+for each row
+execute function public.validate_billing_policy_timezone();
+
+drop trigger if exists contribution_schedules_validate_timezone
+  on public.contribution_schedules;
+create trigger contribution_schedules_validate_timezone
+before insert or update of billing_timezone on public.contribution_schedules
+for each row
+execute function public.validate_billing_policy_timezone();
+
+-- The original Ledger migration accidentally capped the policy at day 28.
+-- Fixed-day billing supports all configured days 1 through 31 and clamps only
+-- the target month when that day does not exist.
+alter table public.organizations
+  drop constraint if exists organizations_billing_due_day_check;
+alter table public.organizations
+  add constraint organizations_billing_due_day_check
+  check (billing_due_day between 1 and 31);
+
+alter table public.contribution_schedules
+  drop constraint if exists contribution_schedules_due_day_check;
+alter table public.contribution_schedules
+  add constraint contribution_schedules_due_day_check
+  check (due_day between 1 and 31);
+
+alter table public.contribution_plan_assignments
+  add column if not exists due_day smallint,
+  add column if not exists lead_days smallint,
+  add column if not exists billing_timezone text,
+  add column if not exists pix_copy_paste text;
+
+update public.contribution_plan_assignments cpa
+set
+  due_day = coalesce(cpa.due_day, cs.due_day),
+  lead_days = coalesce(cpa.lead_days, cs.lead_days),
+  billing_timezone = coalesce(cpa.billing_timezone, cs.billing_timezone),
+  pix_copy_paste = coalesce(
+    cpa.pix_copy_paste,
+    case cpa.plan_type
+      when 'annual'::public.subscription_plan_type_enum
+        then o.annual_pix_copy_paste
+      else o.monthly_pix_copy_paste
+    end
+  )
+from public.contribution_schedules cs
+join public.organizations o on o.id = cs.organization_id
+where cs.id = cpa.schedule_id;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'contribution_plan_assignments_due_day_check'
+      and conrelid = 'public.contribution_plan_assignments'::regclass
+  ) then
+    alter table public.contribution_plan_assignments
+      add constraint contribution_plan_assignments_due_day_check
+      check (due_day is null or due_day between 1 and 31);
+  end if;
+
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'contribution_plan_assignments_lead_days_check'
+      and conrelid = 'public.contribution_plan_assignments'::regclass
+  ) then
+    alter table public.contribution_plan_assignments
+      add constraint contribution_plan_assignments_lead_days_check
+      check (lead_days is null or lead_days between 0 and 31);
+  end if;
+
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'contribution_plan_assignments_timezone_check'
+      and conrelid = 'public.contribution_plan_assignments'::regclass
+  ) then
+    alter table public.contribution_plan_assignments
+      add constraint contribution_plan_assignments_timezone_check
+      check (billing_timezone is null or nullif(btrim(billing_timezone), '') is not null);
+  end if;
+
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'contribution_plan_assignments_pix_check'
+      and conrelid = 'public.contribution_plan_assignments'::regclass
+  ) then
+    alter table public.contribution_plan_assignments
+      add constraint contribution_plan_assignments_pix_check
+      check (pix_copy_paste is null or nullif(btrim(pix_copy_paste), '') is not null);
+  end if;
+end;
+$$;
+
+-- Replace the first Ledger read model with one that resolves the current term
+-- history and evaluates each obligation with its own timezone snapshot.
+alter function public.get_membership_billing_ledger(uuid, text, integer)
+  rename to get_membership_billing_ledger_legacy;
+revoke all on function public.get_membership_billing_ledger_legacy(uuid, text, integer)
+  from public, anon, authenticated;
+
+create function public.get_membership_billing_ledger(
+  p_organization_id uuid,
+  p_history_cursor text default null,
+  p_history_limit integer default 24
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  actor_id uuid := (select auth.uid());
+  organization_record public.organizations%rowtype;
+  application_record public.membership_applications%rowtype;
+  schedule_record public.contribution_schedules%rowtype;
+  evaluated_at_value timestamp with time zone := clock_timestamp();
+  local_date_value date;
+  legal_state text;
+  financial_state text := 'up_to_date';
+  application_correction_reason text;
+  plan_type_value public.subscription_plan_type_enum;
+  attention_obligation jsonb;
+  next_obligation jsonb;
+  history jsonb;
+  history_count integer;
+  history_limit_value integer := greatest(1, least(coalesce(p_history_limit, 24), 50));
+  history_has_more boolean := false;
+  history_next_cursor text;
+  cursor_due_on date;
+  cursor_obligation_id uuid;
+  member_exists boolean := false;
+  application_found boolean := false;
+  next_assignment record;
+  candidate_due_date date;
+  candidate_next_due_date date;
+  candidate_available_on date;
+  candidate_period_start date;
+  candidate_period_end date;
+  candidate_plan_type public.subscription_plan_type_enum;
+  candidate_amount integer;
+  candidate_currency text;
+  candidate_found boolean := false;
+  candidate_effective_start date;
+  selected_candidate_due_date date;
+begin
+  if actor_id is null then
+    raise exception 'Authentication is required.' using errcode = '42501';
+  end if;
+
+  if p_organization_id is null then
+    raise exception 'Organization is required.' using errcode = '22023';
+  end if;
+
+  if nullif(btrim(coalesce(p_history_cursor, '')), '') is not null then
+    begin
+      cursor_due_on := split_part(p_history_cursor, '|', 1)::date;
+      cursor_obligation_id := split_part(p_history_cursor, '|', 2)::uuid;
+    exception
+      when others then
+        raise exception 'The Ledger history cursor is invalid.' using errcode = '22023';
+    end;
+  end if;
+
+  select o.*
+  into organization_record
+  from public.organizations o
+  where o.id = p_organization_id
+    and o.organization_type = 'association'::public.organization_type_enum;
+
+  if not found then
+    raise exception 'Association was not found.' using errcode = '40400';
+  end if;
+
+  select exists (
+    select 1
+    from public.organization_members om
+    where om.organization_id = p_organization_id
+      and om.user_id = actor_id
+  )
+  into member_exists;
+
+  select ma.*
+  into application_record
+  from public.membership_applications ma
+  where ma.organization_id = p_organization_id
+    and ma.user_id = actor_id
+  order by ma.updated_at desc, ma.id desc
+  limit 1;
+  application_found := found;
+
+  if not member_exists and not application_found then
+    raise exception 'Membership Ledger was not found.' using errcode = '42501';
+  end if;
+
+  legal_state := case when member_exists then 'active' else 'applicant' end;
+  local_date_value := timezone(
+    organization_record.billing_timezone,
+    evaluated_at_value
+  )::date;
+
+  select cs.*
+  into schedule_record
+  from public.contribution_schedules cs
+  where cs.organization_id = p_organization_id
+    and cs.user_id = actor_id
+    and cs.active
+  order by cs.id
+  limit 1;
+
+  if found then
+    select case
+      when cpa.plan_type = 'annual'::public.subscription_plan_type_enum
+        then 'annual'::public.subscription_plan_type_enum
+      else 'monthly'::public.subscription_plan_type_enum
+    end
+    into plan_type_value
+    from public.contribution_plan_assignments cpa
+    where cpa.schedule_id = schedule_record.id
+      and cpa.effective_period_start <= local_date_value
+    order by cpa.effective_period_start desc, cpa.id desc
+    limit 1;
+  end if;
+
+  if plan_type_value is null and application_found then
+    select mar.plan_type
+    into plan_type_value
+    from public.membership_application_revisions mar
+    where mar.application_id = application_record.id
+    order by mar.revision_number desc, mar.id desc
+    limit 1;
+  end if;
+
+  select pc.decision_reason
+  into application_correction_reason
+  from public.payment_claims pc
+  join public.payment_obligations po on po.id = pc.obligation_id
+  where pc.claimant_user_id = actor_id
+    and pc.organization_id = p_organization_id
+    and po.purpose = 'initial_admission'::public.payment_obligation_purpose_enum
+    and pc.status = 'rejected'::public.payment_claim_status_enum
+  order by pc.decided_at desc nulls last, pc.created_at desc, pc.id desc
+  limit 1;
+
+  if exists (
+    select 1
+    from public.payment_obligations po
+    where po.organization_id = p_organization_id
+      and po.user_id = actor_id
+      and po.status not in (
+        'settled'::public.payment_obligation_status_enum,
+        'void'::public.payment_obligation_status_enum
+      )
+      and po.purpose = 'recurring'::public.payment_obligation_purpose_enum
+      and po.due_on < timezone(
+        coalesce(po.billing_timezone, organization_record.billing_timezone),
+        evaluated_at_value
+      )::date
+  ) then
+    financial_state := 'overdue';
+  elsif exists (
+    select 1
+    from public.payment_obligations po
+    where po.organization_id = p_organization_id
+      and po.user_id = actor_id
+      and po.status not in (
+        'settled'::public.payment_obligation_status_enum,
+        'void'::public.payment_obligation_status_enum
+      )
+      and (
+        (
+          po.purpose = 'initial_admission'::public.payment_obligation_purpose_enum
+          and po.available_at <= evaluated_at_value
+        )
+        or (
+          po.purpose = 'recurring'::public.payment_obligation_purpose_enum
+          and po.available_on <= timezone(
+            coalesce(po.billing_timezone, organization_record.billing_timezone),
+            evaluated_at_value
+          )::date
+        )
+      )
+      and not exists (
+        select 1
+        from public.payment_claims pc
+        where pc.obligation_id = po.id
+          and pc.status = 'under_review'::public.payment_claim_status_enum
+      )
+  ) then
+    financial_state := 'payment_available';
+  elsif exists (
+    select 1
+    from public.payment_obligations po
+    join public.payment_claims pc on pc.obligation_id = po.id
+    where po.organization_id = p_organization_id
+      and po.user_id = actor_id
+      and po.status not in (
+        'settled'::public.payment_obligation_status_enum,
+        'void'::public.payment_obligation_status_enum
+      )
+      and pc.status = 'under_review'::public.payment_claim_status_enum
+  ) then
+    financial_state := 'under_review';
+  end if;
+
+  select jsonb_build_object(
+    'obligation_id', po.id,
+    'purpose', po.purpose,
+    'status', state.effective_status,
+    'period_key', po.period_key,
+    'period_start', po.period_start,
+    'period_end', po.period_end,
+    'available_on', po.available_on,
+    'due_on', po.due_on,
+    'amount', po.amount,
+    'currency', po.currency,
+    'action', case state.effective_status
+      when 'under_review' then jsonb_build_object('type', 'open_claim')
+      when 'available' then jsonb_build_object('type', 'open_obligation')
+      when 'overdue' then jsonb_build_object('type', 'open_obligation')
+      else null
+    end,
+    'claims', coalesce((
+      select jsonb_agg(jsonb_build_object(
+        'claim_id', pc.id,
+        'status', pc.status,
+        'payer', pc.payer_type,
+        'payer_name', pc.payer_name,
+        'created_at', pc.created_at,
+        'decided_at', pc.decided_at,
+        'decision_reason', pc.decision_reason
+      ) order by pc.created_at asc, pc.id asc)
+      from public.payment_claims pc
+      where pc.obligation_id = po.id
+    ), '[]'::jsonb)
+  )
+  into attention_obligation
+  from public.payment_obligations po
+  cross join lateral (
+    select case
+      when po.status = 'settled'::public.payment_obligation_status_enum then 'settled'
+      when po.status = 'void'::public.payment_obligation_status_enum then 'void'
+      when exists (
+        select 1
+        from public.payment_claims pc
+        where pc.obligation_id = po.id
+          and pc.status = 'under_review'::public.payment_claim_status_enum
+      ) then 'under_review'
+      when po.purpose = 'initial_admission'::public.payment_obligation_purpose_enum
+        and po.available_at <= evaluated_at_value then 'available'
+      when po.purpose = 'recurring'::public.payment_obligation_purpose_enum
+        and po.due_on < timezone(
+          coalesce(po.billing_timezone, organization_record.billing_timezone),
+          evaluated_at_value
+        )::date then 'overdue'
+      when po.purpose = 'recurring'::public.payment_obligation_purpose_enum
+        and po.available_on <= timezone(
+        coalesce(po.billing_timezone, organization_record.billing_timezone),
+        evaluated_at_value
+      )::date then 'available'
+      else 'scheduled'
+    end as effective_status
+  ) state
+  where po.organization_id = p_organization_id
+    and po.user_id = actor_id
+    and state.effective_status in ('available', 'under_review', 'overdue')
+  order by
+    case state.effective_status
+      when 'overdue' then 0
+      when 'available' then 1
+      when 'under_review' then 2
+      else 3
+    end,
+    po.due_on asc,
+    po.created_at asc,
+    po.id asc
+  limit 1;
+
+  if member_exists and schedule_record.id is not null then
+    select jsonb_build_object(
+      'obligation_id', po.id,
+      'purpose', po.purpose,
+      'status', state.effective_status,
+      'period_key', po.period_key,
+      'period_start', po.period_start,
+      'period_end', po.period_end,
+      'available_on', po.available_on,
+      'due_on', po.due_on,
+      'amount', po.amount,
+      'currency', po.currency,
+      'action', case state.effective_status
+        when 'under_review' then jsonb_build_object('type', 'open_claim')
+        when 'available' then jsonb_build_object('type', 'open_obligation')
+        when 'overdue' then jsonb_build_object('type', 'open_obligation')
+        else null
+      end
+    )
+    into next_obligation
+    from public.payment_obligations po
+    cross join lateral (
+      select case
+        when exists (
+          select 1
+          from public.payment_claims pc
+          where pc.obligation_id = po.id
+            and pc.status = 'under_review'::public.payment_claim_status_enum
+        ) then 'under_review'
+        when po.purpose = 'recurring'::public.payment_obligation_purpose_enum
+          and po.available_on <= timezone(
+          coalesce(po.billing_timezone, schedule_record.billing_timezone),
+          evaluated_at_value
+        )::date then 'available'
+        else 'scheduled'
+      end as effective_status
+    ) state
+    where po.schedule_id = schedule_record.id
+      and po.status not in (
+        'settled'::public.payment_obligation_status_enum,
+        'void'::public.payment_obligation_status_enum
+      )
+      and po.due_on > timezone(
+        coalesce(po.billing_timezone, schedule_record.billing_timezone),
+        evaluated_at_value
+      )::date
+    order by po.due_on asc, po.created_at asc, po.id asc
+    limit 1;
+
+    if next_obligation is null then
+      for next_assignment in
+        select
+          cpa.*,
+          lead(cpa.effective_period_start) over (
+            order by cpa.effective_period_start, cpa.id
+          ) as next_effective_period_start
+        from public.contribution_plan_assignments cpa
+        where cpa.schedule_id = schedule_record.id
+        order by cpa.effective_period_start, cpa.id
+      loop
+        candidate_plan_type := next_assignment.plan_type;
+        candidate_effective_start := greatest(
+          schedule_record.admission_date,
+          next_assignment.effective_period_start
+        );
+        candidate_due_date := public.recurring_due_date_on_or_after(
+          schedule_record.admission_date,
+          case candidate_plan_type
+            when 'annual'::public.subscription_plan_type_enum
+              then 'annual'::public.contribution_cadence_enum
+            else 'monthly'::public.contribution_cadence_enum
+          end,
+          coalesce(next_assignment.due_day, schedule_record.due_day),
+          greatest(
+            candidate_effective_start,
+            timezone(
+              coalesce(next_assignment.billing_timezone, schedule_record.billing_timezone),
+              evaluated_at_value
+            )::date + 1
+          )
+        );
+
+        if next_assignment.next_effective_period_start is not null
+          and candidate_due_date >= next_assignment.next_effective_period_start then
+          continue;
+        end if;
+
+        if not candidate_found or candidate_due_date < selected_candidate_due_date then
+          candidate_found := true;
+          selected_candidate_due_date := candidate_due_date;
+          candidate_next_due_date := public.next_recurring_due_date(
+            candidate_due_date,
+            case candidate_plan_type
+              when 'annual'::public.subscription_plan_type_enum
+                then 'annual'::public.contribution_cadence_enum
+              else 'monthly'::public.contribution_cadence_enum
+            end,
+            coalesce(next_assignment.due_day, schedule_record.due_day)
+          );
+          candidate_available_on := candidate_due_date
+            - coalesce(next_assignment.lead_days, schedule_record.lead_days);
+          candidate_period_start := candidate_due_date;
+          candidate_period_end := candidate_next_due_date - 1;
+          candidate_amount := next_assignment.amount;
+          candidate_currency := next_assignment.currency;
+          next_obligation := jsonb_build_object(
+            'obligation_id', null,
+            'purpose', 'recurring',
+            'status', 'scheduled',
+            'period_key', public.recurring_period_key(
+              case candidate_plan_type
+                when 'annual'::public.subscription_plan_type_enum
+                  then 'annual'::public.contribution_cadence_enum
+                else 'monthly'::public.contribution_cadence_enum
+              end,
+              candidate_due_date
+            ),
+            'period_start', candidate_period_start,
+            'period_end', candidate_period_end,
+            'available_on', candidate_available_on,
+            'due_on', candidate_due_date,
+            'amount', candidate_amount,
+            'currency', candidate_currency,
+            'action', null
+          );
+        end if;
+      end loop;
+    end if;
+  end if;
+
+  select coalesce(jsonb_agg(row_data order by due_on desc, obligation_id desc), '[]'::jsonb),
+    count(*)::integer
+  into history, history_count
+  from (
+    select
+      jsonb_build_object(
+        'obligation_id', po.id,
+        'purpose', po.purpose,
+        'status', state.effective_status,
+        'period_key', po.period_key,
+        'period_start', po.period_start,
+        'period_end', po.period_end,
+        'available_on', po.available_on,
+        'due_on', po.due_on,
+        'amount', po.amount,
+        'currency', po.currency,
+        'settled_at', po.settled_at,
+        'claims', coalesce((
+          select jsonb_agg(jsonb_build_object(
+            'claim_id', pc.id,
+            'status', pc.status,
+            'payer', pc.payer_type,
+            'payer_name', pc.payer_name,
+            'created_at', pc.created_at,
+            'decided_at', pc.decided_at,
+            'decision_reason', pc.decision_reason
+          ) order by pc.created_at asc, pc.id asc)
+          from public.payment_claims pc
+          where pc.obligation_id = po.id
+        ), '[]'::jsonb)
+      ) as row_data,
+      po.due_on,
+      po.created_at,
+      po.id as obligation_id
+    from public.payment_obligations po
+    cross join lateral (
+      select case
+        when po.status = 'settled'::public.payment_obligation_status_enum then 'settled'
+        when po.status = 'void'::public.payment_obligation_status_enum then 'void'
+        when exists (
+          select 1
+          from public.payment_claims pc
+          where pc.obligation_id = po.id
+            and pc.status = 'under_review'::public.payment_claim_status_enum
+        ) then 'under_review'
+        when po.purpose = 'initial_admission'::public.payment_obligation_purpose_enum
+          and po.available_at <= evaluated_at_value then 'available'
+        when po.purpose = 'recurring'::public.payment_obligation_purpose_enum
+          and po.due_on < timezone(
+            coalesce(po.billing_timezone, organization_record.billing_timezone),
+            evaluated_at_value
+          )::date then 'overdue'
+        when po.purpose = 'recurring'::public.payment_obligation_purpose_enum
+          and po.available_on <= timezone(
+          coalesce(po.billing_timezone, organization_record.billing_timezone),
+          evaluated_at_value
+        )::date then 'available'
+        else 'scheduled'
+      end as effective_status
+    ) state
+    where po.organization_id = p_organization_id
+      and po.user_id = actor_id
+      and (
+        cursor_due_on is null
+        or (po.due_on, po.id) < (cursor_due_on, cursor_obligation_id)
+      )
+    order by po.due_on desc, po.id desc
+    limit history_limit_value + 1
+  ) history_rows;
+
+  if history_count > history_limit_value then
+    history_has_more := true;
+    select jsonb_agg(value order by ordinal)
+    into history
+    from jsonb_array_elements(history) with ordinality as items(value, ordinal)
+    where ordinal <= history_limit_value;
+
+    select to_char(po.due_on, 'YYYY-MM-DD') || '|' || po.id::text
+    into history_next_cursor
+    from public.payment_obligations po
+    where po.organization_id = p_organization_id
+      and po.user_id = actor_id
+      and (
+        cursor_due_on is null
+        or (po.due_on, po.id) < (cursor_due_on, cursor_obligation_id)
+      )
+    order by po.due_on desc, po.id desc
+    offset history_limit_value
+    limit 1;
+  end if;
+
+  return jsonb_build_object(
+    'organization_id', organization_record.id,
+    'organization_slug', organization_record.slug,
+    'organization_name', organization_record.name,
+    'legal_membership_state', legal_state,
+    'application_status', case when application_found then application_record.status else null end,
+    'application_correction_reason', application_correction_reason,
+    'financial_standing', financial_state,
+    'evaluated_at', evaluated_at_value,
+    'plan_type', plan_type_value,
+    'attention_obligation', attention_obligation,
+    'next_contribution', next_obligation,
+    'history', coalesce(history, '[]'::jsonb),
+    'history_limit', history_limit_value,
+    'history_has_more', history_has_more,
+    'history_next_cursor', history_next_cursor
+  );
+end;
+$$;
+
+comment on function public.get_membership_billing_ledger(uuid, text, integer) is
+  'Returns the signed-in person''s private Ledger using effective-dated terms and obligation timezone snapshots.';
+
+revoke all on function public.get_membership_billing_ledger(uuid, text, integer)
+  from public, anon;
+grant execute on function public.get_membership_billing_ledger(uuid, text, integer)
+  to authenticated;
+
+drop trigger if exists contribution_plan_assignments_validate_timezone
+  on public.contribution_plan_assignments;
+create trigger contribution_plan_assignments_validate_timezone
+before insert or update of billing_timezone on public.contribution_plan_assignments
+for each row
+when (new.billing_timezone is not null)
+execute function public.validate_billing_policy_timezone();
+
+create or replace function public.reject_contribution_plan_assignment_mutation()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if old.schedule_id is distinct from new.schedule_id
+    or old.effective_period_start is distinct from new.effective_period_start
+    or old.plan_type is distinct from new.plan_type
+    or old.amount is distinct from new.amount
+    or old.currency is distinct from new.currency
+    or old.due_day is distinct from new.due_day
+    or old.lead_days is distinct from new.lead_days
+    or old.billing_timezone is distinct from new.billing_timezone
+    or old.pix_copy_paste is distinct from new.pix_copy_paste then
+    raise exception 'An effective-dated contribution term is immutable; append a new term.'
+      using errcode = '55000';
+  end if;
+
+  return new;
+end;
+$$;
+
+revoke all on function public.reject_contribution_plan_assignment_mutation()
+  from public, anon, authenticated;
+
+drop trigger if exists contribution_plan_assignments_immutable
+  on public.contribution_plan_assignments;
+create trigger contribution_plan_assignments_immutable
+before update on public.contribution_plan_assignments
+for each row
+execute function public.reject_contribution_plan_assignment_mutation();
+
+-- A schedule's admission date is the legal anchor. Future terms are appended
+-- to the assignment history; the anchor and its original policy are never
+-- rewritten by a payment or subscription event.
+create or replace function public.reject_contribution_schedule_anchor_mutation()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if old.admission_date is distinct from new.admission_date then
+    raise exception 'A contribution schedule admission anchor is immutable.'
+      using errcode = '55000';
+  end if;
+
+  if old.cadence is distinct from new.cadence
+    or old.due_day is distinct from new.due_day
+    or old.lead_days is distinct from new.lead_days
+    or old.billing_timezone is distinct from new.billing_timezone
+    or old.currency is distinct from new.currency then
+    raise exception 'Contribution schedule policy is immutable; append an effective-dated term.'
+      using errcode = '55000';
+  end if;
+
+  return new;
+end;
+$$;
+
+revoke all on function public.reject_contribution_schedule_anchor_mutation()
+  from public, anon, authenticated;
+
+drop trigger if exists contribution_schedules_immutable_anchor
+  on public.contribution_schedules;
+create trigger contribution_schedules_immutable_anchor
+before update on public.contribution_schedules
+for each row
+execute function public.reject_contribution_schedule_anchor_mutation();
+
+alter table public.payment_obligations
+  add column if not exists schedule_term_id uuid
+    references public.contribution_plan_assignments(id),
+  add column if not exists billing_timezone text,
+  add column if not exists billing_due_day smallint,
+  add column if not exists billing_lead_days smallint,
+  add column if not exists organization_name_snapshot text,
+  add column if not exists organization_slug_snapshot text;
+
+-- Initial obligations keep schedule_id null, so a full unique constraint is
+-- equivalent for recurring rows and gives the worker a stable conflict target.
+drop index if exists public.payment_obligations_recurring_schedule_period_idx;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'payment_obligations_schedule_period_key'
+      and conrelid = 'public.payment_obligations'::regclass
+  ) then
+    alter table public.payment_obligations
+      add constraint payment_obligations_schedule_period_key
+      unique (schedule_id, period_key);
+  end if;
+end;
+$$;
+
+update public.payment_obligations po
+set
+  billing_timezone = coalesce(po.billing_timezone, o.billing_timezone),
+  billing_due_day = coalesce(po.billing_due_day, o.billing_due_day),
+  billing_lead_days = coalesce(po.billing_lead_days, o.billing_lead_days),
+  organization_name_snapshot = coalesce(po.organization_name_snapshot, o.name),
+  organization_slug_snapshot = coalesce(po.organization_slug_snapshot, o.slug)
+from public.organizations o
+where o.id = po.organization_id;
+
+create or replace function public.snapshot_payment_obligation_context()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  organization_record public.organizations%rowtype;
+  term_record public.contribution_plan_assignments%rowtype;
+begin
+  select o.*
+  into organization_record
+  from public.organizations o
+  where o.id = new.organization_id;
+
+  if not found then
+    raise exception 'Payment obligation organization was not found.'
+      using errcode = '23503';
+  end if;
+
+  if new.schedule_term_id is not null then
+    select cpa.*
+    into term_record
+    from public.contribution_plan_assignments cpa
+    where cpa.id = new.schedule_term_id;
+
+    if not found then
+      raise exception 'Payment obligation billing term was not found.'
+        using errcode = '23503';
+    end if;
+
+    new.billing_timezone := coalesce(new.billing_timezone, term_record.billing_timezone);
+    new.billing_due_day := coalesce(new.billing_due_day, term_record.due_day);
+    new.billing_lead_days := coalesce(new.billing_lead_days, term_record.lead_days);
+  end if;
+
+  new.billing_timezone := coalesce(new.billing_timezone, organization_record.billing_timezone);
+  new.billing_due_day := coalesce(new.billing_due_day, organization_record.billing_due_day);
+  new.billing_lead_days := coalesce(new.billing_lead_days, organization_record.billing_lead_days);
+  new.organization_name_snapshot := coalesce(
+    new.organization_name_snapshot,
+    organization_record.name
+  );
+  new.organization_slug_snapshot := coalesce(
+    new.organization_slug_snapshot,
+    organization_record.slug
+  );
+
+  return new;
+end;
+$$;
+
+revoke all on function public.snapshot_payment_obligation_context()
+  from public, anon, authenticated;
+
+drop trigger if exists payment_obligations_snapshot_context
+  on public.payment_obligations;
+create trigger payment_obligations_snapshot_context
+before insert on public.payment_obligations
+for each row
+execute function public.snapshot_payment_obligation_context();
+
+create index if not exists contribution_plan_assignments_schedule_period_idx
+  on public.contribution_plan_assignments (schedule_id, effective_period_start, id);
+
+create index if not exists payment_obligations_recurring_term_idx
+  on public.payment_obligations (schedule_term_id, due_on, id)
+  where purpose = 'recurring'::public.payment_obligation_purpose_enum;
+
+create or replace function public.recurring_due_date_on_or_after(
+  p_admission_date date,
+  p_cadence public.contribution_cadence_enum,
+  p_due_day integer,
+  p_from_date date
+)
+returns date
+language plpgsql
+immutable
+set search_path = ''
+as $$
+declare
+  due_date_value date;
+  lower_bound date;
+begin
+  if p_admission_date is null
+    or p_cadence is null
+    or p_due_day is null
+    or p_from_date is null then
+    raise exception 'Recurring date inputs are required.' using errcode = '22023';
+  end if;
+
+  if p_due_day < 1 or p_due_day > 31 then
+    raise exception 'Recurring due day must be between 1 and 31.'
+      using errcode = '22023';
+  end if;
+
+  lower_bound := greatest(p_admission_date, p_from_date);
+  due_date_value := public.first_recurring_due_date(
+    p_admission_date,
+    p_cadence,
+    p_due_day
+  );
+
+  while due_date_value < lower_bound loop
+    due_date_value := public.next_recurring_due_date(
+      due_date_value,
+      p_cadence,
+      p_due_day
+    );
+  end loop;
+
+  return due_date_value;
+end;
+$$;
+
+create or replace function public.recurring_period_key(
+  p_cadence public.contribution_cadence_enum,
+  p_due_date date
+)
+returns text
+language sql
+immutable
+set search_path = ''
+as $$
+  select p_cadence::text || ':' || to_char(p_due_date, 'YYYY-MM-DD');
+$$;
+
+revoke all on function public.recurring_due_date_on_or_after(
+  date, public.contribution_cadence_enum, integer, date
+) from public, anon, authenticated;
+revoke all on function public.recurring_period_key(
+  public.contribution_cadence_enum, date
+) from public, anon, authenticated;
+
+-- Convert rows created by the first Ledger migration to the stable period
+-- identity. The old YYYY-MM key and month-start boundary were not sufficient
+-- once cadence changes and late reconciliation were introduced.
+with recurring_terms as (
+  select
+    po.id as obligation_id,
+    po.due_on,
+    term.id as term_id,
+    term.plan_type,
+    term.due_day,
+    term.lead_days,
+    term.billing_timezone
+  from public.payment_obligations po
+  cross join lateral (
+    select cpa.*
+    from public.contribution_plan_assignments cpa
+    where cpa.schedule_id = po.schedule_id
+      and cpa.effective_period_start <= po.due_on
+    order by cpa.effective_period_start desc, cpa.id desc
+    limit 1
+  ) term
+  where po.purpose = 'recurring'::public.payment_obligation_purpose_enum
+    and po.schedule_id is not null
+    and po.due_on is not null
+)
+update public.payment_obligations po
+set
+  schedule_term_id = term.term_id,
+  period_key = public.recurring_period_key(
+    case term.plan_type
+      when 'annual'::public.subscription_plan_type_enum
+        then 'annual'::public.contribution_cadence_enum
+      else 'monthly'::public.contribution_cadence_enum
+    end,
+    term.due_on
+  ),
+  period_start = term.due_on,
+  period_end = public.next_recurring_due_date(
+    term.due_on,
+    case term.plan_type
+      when 'annual'::public.subscription_plan_type_enum
+        then 'annual'::public.contribution_cadence_enum
+      else 'monthly'::public.contribution_cadence_enum
+    end,
+    term.due_day
+  ) - 1,
+  billing_timezone = coalesce(po.billing_timezone, term.billing_timezone),
+  billing_due_day = coalesce(po.billing_due_day, term.due_day),
+  billing_lead_days = coalesce(po.billing_lead_days, term.lead_days)
+from recurring_terms term
+where term.obligation_id = po.id;
+
+-- Existing recurring rows from the first migration were linked to succeeded
+-- legacy payments inside generation. Preserve those links, but all future
+-- reconciliation is explicit and dry-run by default.
+comment on column public.payment_obligations.schedule_term_id is
+  'Immutable effective-dated contribution term that produced this obligation.';
+comment on column public.payment_obligations.billing_timezone is
+  'Timezone snapshot used to evaluate this obligation; never read from live policy for history.';
+comment on column public.payment_obligations.billing_due_day is
+  'Due-day policy snapshot used to produce this obligation.';
+comment on column public.payment_obligations.billing_lead_days is
+  'Lead-day policy snapshot used to produce this obligation.';
+
+create or replace function public.reject_payment_obligation_context_mutation()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if old.organization_id is distinct from new.organization_id
+    or old.user_id is distinct from new.user_id
+    or old.application_revision_id is distinct from new.application_revision_id
+    or old.purpose is distinct from new.purpose
+    or old.plan_type is distinct from new.plan_type
+    or old.amount is distinct from new.amount
+    or old.currency is distinct from new.currency
+    or old.payment_method is distinct from new.payment_method
+    or old.pix_copy_paste is distinct from new.pix_copy_paste
+    or old.available_at is distinct from new.available_at
+    or old.schedule_id is distinct from new.schedule_id
+    or old.schedule_term_id is distinct from new.schedule_term_id
+    or old.period_key is distinct from new.period_key
+    or old.period_start is distinct from new.period_start
+    or old.period_end is distinct from new.period_end
+    or old.available_on is distinct from new.available_on
+    or old.due_on is distinct from new.due_on
+    or old.billing_timezone is distinct from new.billing_timezone
+    or old.billing_due_day is distinct from new.billing_due_day
+    or old.billing_lead_days is distinct from new.billing_lead_days
+    or old.organization_name_snapshot is distinct from new.organization_name_snapshot
+    or old.organization_slug_snapshot is distinct from new.organization_slug_snapshot then
+    raise exception 'Payment obligation billing context is immutable.'
+      using errcode = '55000';
+  end if;
+
+  return new;
+end;
+$$;
+
+revoke all on function public.reject_payment_obligation_context_mutation()
+  from public, anon, authenticated;
+
+drop trigger if exists payment_obligations_immutable_context
+  on public.payment_obligations;
+create trigger payment_obligations_immutable_context
+before update on public.payment_obligations
+for each row
+execute function public.reject_payment_obligation_context_mutation();
+
+-- The public client may read subscriptions for its existing UI, but it must
+-- not mutate the source that drives recurring billing. Plan changes use the
+-- future-effective command below.
+revoke insert, update, delete on table public.subscriptions
+  from anon, authenticated;
+
+create or replace function public.ensure_contribution_schedule(
+  p_organization_id uuid,
+  p_user_id uuid,
+  p_admission_date date default null
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  organization_record public.organizations%rowtype;
+  subscription_record public.subscriptions%rowtype;
+  schedule_record public.contribution_schedules%rowtype;
+  admission_date_value date;
+  cadence_value public.contribution_cadence_enum;
+  amount_value integer;
+  pix_value text;
+begin
+  select o.*
+  into organization_record
+  from public.organizations o
+  where o.id = p_organization_id
+    and o.organization_type = 'association'::public.organization_type_enum
+  for update;
+
+  if not found then
+    return null;
+  end if;
+
+  if not public.is_valid_billing_timezone(organization_record.billing_timezone)
+    or organization_record.billing_due_day not between 1 and 31
+    or organization_record.billing_lead_days not between 0 and 31
+    or organization_record.billing_currency !~ '^[A-Z]{3}$' then
+    raise exception 'The association billing policy is invalid.' using errcode = '23514';
+  end if;
+
+  select s.*
+  into subscription_record
+  from public.subscriptions s
+  where s.organization_id = p_organization_id
+    and s.user_id = p_user_id
+    and s.status = 'active'::public.subscription_status_enum
+  for update;
+
+  if not found then
+    return null;
+  end if;
+
+  cadence_value := case
+    when subscription_record.plan_type = 'annual'::public.subscription_plan_type_enum
+      then 'annual'::public.contribution_cadence_enum
+    else 'monthly'::public.contribution_cadence_enum
+  end;
+  amount_value := case subscription_record.plan_type
+    when 'annual'::public.subscription_plan_type_enum
+      then organization_record.annual_price_amount
+    else organization_record.monthly_price_amount
+  end;
+  pix_value := case subscription_record.plan_type
+    when 'annual'::public.subscription_plan_type_enum
+      then organization_record.annual_pix_copy_paste
+    else organization_record.monthly_pix_copy_paste
+  end;
+
+  if amount_value is null or amount_value <= 0
+    or nullif(btrim(pix_value), '') is null then
+    raise exception 'The association contribution price or PIX configuration is incomplete.'
+      using errcode = '23514';
+  end if;
+
+  admission_date_value := coalesce(
+    p_admission_date,
+    (
+      select timezone(organization_record.billing_timezone, om.joined_at)::date
+      from public.organization_members om
+      where om.organization_id = p_organization_id
+        and om.user_id = p_user_id
+    ),
+    timezone(organization_record.billing_timezone, clock_timestamp())::date
+  );
+
+  insert into public.contribution_schedules (
+    organization_id,
+    user_id,
+    cadence,
+    admission_date,
+    due_day,
+    lead_days,
+    billing_timezone,
+    currency,
+    active
+  )
+  values (
+    p_organization_id,
+    p_user_id,
+    cadence_value,
+    admission_date_value,
+    organization_record.billing_due_day,
+    organization_record.billing_lead_days,
+    organization_record.billing_timezone,
+    organization_record.billing_currency,
+    true
+  )
+  on conflict (organization_id, user_id) do update
+  set active = true
+  returning * into schedule_record;
+
+  if schedule_record.id is null then
+    select cs.*
+    into schedule_record
+    from public.contribution_schedules cs
+    where cs.organization_id = p_organization_id
+      and cs.user_id = p_user_id
+    for update;
+  end if;
+
+  perform 1
+  from public.contribution_plan_assignments cpa
+  where cpa.schedule_id = schedule_record.id
+    and cpa.effective_period_start = schedule_record.admission_date
+  for update;
+
+  if not found then
+    insert into public.contribution_plan_assignments (
+      schedule_id,
+      effective_period_start,
+      plan_type,
+      amount,
+      currency,
+      due_day,
+      lead_days,
+      billing_timezone,
+      pix_copy_paste
+    )
+    values (
+      schedule_record.id,
+      schedule_record.admission_date,
+      subscription_record.plan_type,
+      amount_value,
+      organization_record.billing_currency,
+      schedule_record.due_day,
+      schedule_record.lead_days,
+      schedule_record.billing_timezone,
+      pix_value
+    );
+  end if;
+
+  return schedule_record.id;
+end;
+$$;
+
+revoke all on function public.ensure_contribution_schedule(uuid, uuid, date)
+  from public, anon, authenticated;
+
+create or replace function public.sync_contribution_schedule_on_subscription()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if new.status = 'active'::public.subscription_status_enum then
+    if exists (
+      select 1
+      from public.organization_members om
+      where om.organization_id = new.organization_id
+        and om.user_id = new.user_id
+        and om.role in (
+          'admin'::public.organization_role_enum,
+          'member'::public.organization_role_enum
+        )
+    ) then
+      perform public.ensure_contribution_schedule(new.organization_id, new.user_id, null);
+    end if;
+  else
+    update public.contribution_schedules
+    set active = false
+    where organization_id = new.organization_id
+      and user_id = new.user_id;
+  end if;
+
+  return new;
+end;
+$$;
+
+revoke all on function public.sync_contribution_schedule_on_subscription()
+  from public, anon, authenticated;
+
+drop trigger if exists subscriptions_sync_contribution_schedule
+  on public.subscriptions;
+create trigger subscriptions_sync_contribution_schedule
+after insert or update of status on public.subscriptions
+for each row
+execute function public.sync_contribution_schedule_on_subscription();
+
+create or replace function public.schedule_contribution_plan_change(
+  p_schedule_id uuid,
+  p_effective_period_start date,
+  p_plan_type public.subscription_plan_type_enum
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  actor_id uuid := (select auth.uid());
+  schedule_record public.contribution_schedules%rowtype;
+  organization_record public.organizations%rowtype;
+  latest_assignment public.contribution_plan_assignments%rowtype;
+  existing_assignment public.contribution_plan_assignments%rowtype;
+  amount_value integer;
+  pix_value text;
+  expected_period_start date;
+  local_date_value date;
+begin
+  if actor_id is null and current_user <> 'service_role' then
+    raise exception 'Authentication is required.' using errcode = '42501';
+  end if;
+
+  select cs.*
+  into schedule_record
+  from public.contribution_schedules cs
+  where cs.id = p_schedule_id
+  for update;
+
+  if not found then
+    raise exception 'Contribution schedule was not found.' using errcode = 'P0002';
+  end if;
+
+  if not schedule_record.active then
+    raise exception 'Only an active contribution schedule can receive a plan change.'
+      using errcode = '55000';
+  end if;
+
+  select o.*
+  into organization_record
+  from public.organizations o
+  where o.id = schedule_record.organization_id
+    and o.organization_type = 'association'::public.organization_type_enum
+  for update;
+
+  if not found then
+    raise exception 'Contribution organization was not found.' using errcode = 'P0002';
+  end if;
+
+  if current_user <> 'service_role'
+    and not exists (
+      select 1
+      from public.organization_members om
+      where om.organization_id = schedule_record.organization_id
+        and om.user_id = actor_id
+        and om.role = 'admin'::public.organization_role_enum
+    ) then
+    raise exception 'Association admin access is required.' using errcode = '42501';
+  end if;
+
+  if p_effective_period_start is null or p_plan_type is null then
+    raise exception 'A future effective period and plan are required.'
+      using errcode = '22023';
+  end if;
+
+  local_date_value := timezone(schedule_record.billing_timezone, clock_timestamp())::date;
+  if p_effective_period_start <= local_date_value then
+    raise exception 'A plan change must start in a future billing period.'
+      using errcode = '22023';
+  end if;
+
+  select cpa.*
+  into latest_assignment
+  from public.contribution_plan_assignments cpa
+  where cpa.schedule_id = schedule_record.id
+  order by cpa.effective_period_start desc, cpa.id desc
+  limit 1;
+
+  if not found then
+    raise exception 'Contribution schedule has no billing term.' using errcode = '23514';
+  end if;
+
+  if p_effective_period_start <= latest_assignment.effective_period_start then
+    raise exception 'A plan change must append a later effective billing period.'
+      using errcode = '22023';
+  end if;
+
+  expected_period_start := public.recurring_due_date_on_or_after(
+    schedule_record.admission_date,
+    case latest_assignment.plan_type
+      when 'annual'::public.subscription_plan_type_enum
+        then 'annual'::public.contribution_cadence_enum
+      else 'monthly'::public.contribution_cadence_enum
+    end,
+    coalesce(latest_assignment.due_day, schedule_record.due_day),
+    p_effective_period_start
+  );
+
+  if expected_period_start <> p_effective_period_start then
+    raise exception 'The effective date must be the start of an existing recurring period.'
+      using errcode = '22023';
+  end if;
+
+  amount_value := case p_plan_type
+    when 'annual'::public.subscription_plan_type_enum
+      then organization_record.annual_price_amount
+    else organization_record.monthly_price_amount
+  end;
+  pix_value := case p_plan_type
+    when 'annual'::public.subscription_plan_type_enum
+      then organization_record.annual_pix_copy_paste
+    else organization_record.monthly_pix_copy_paste
+  end;
+
+  if amount_value is null or amount_value <= 0
+    or nullif(btrim(pix_value), '') is null
+    or organization_record.billing_currency !~ '^[A-Z]{3}$' then
+    raise exception 'The future plan price or PIX configuration is incomplete.'
+      using errcode = '23514';
+  end if;
+
+  select cpa.*
+  into existing_assignment
+  from public.contribution_plan_assignments cpa
+  where cpa.schedule_id = schedule_record.id
+    and cpa.effective_period_start = p_effective_period_start
+  for update;
+
+  if found then
+    if existing_assignment.plan_type <> p_plan_type
+      or existing_assignment.amount <> amount_value
+      or existing_assignment.currency <> organization_record.billing_currency
+      or existing_assignment.due_day <> schedule_record.due_day
+      or existing_assignment.lead_days <> schedule_record.lead_days
+      or existing_assignment.billing_timezone <> schedule_record.billing_timezone
+      or existing_assignment.pix_copy_paste <> pix_value then
+      raise exception 'A different plan is already scheduled for this period.'
+        using errcode = '40001';
+    end if;
+
+    return existing_assignment.id;
+  end if;
+
+  insert into public.contribution_plan_assignments (
+    schedule_id,
+    effective_period_start,
+    plan_type,
+    amount,
+    currency,
+    due_day,
+    lead_days,
+    billing_timezone,
+    pix_copy_paste
+  )
+  values (
+    schedule_record.id,
+    p_effective_period_start,
+    p_plan_type,
+    amount_value,
+    organization_record.billing_currency,
+    schedule_record.due_day,
+    schedule_record.lead_days,
+    schedule_record.billing_timezone,
+    pix_value
+  )
+  returning id into existing_assignment.id;
+
+  return existing_assignment.id;
+end;
+$$;
+
+comment on function public.schedule_contribution_plan_change(
+  uuid, date, public.subscription_plan_type_enum
+) is
+  'Appends one idempotent future-effective billing term. Existing periods and schedule anchors are never rewritten.';
+
+revoke all on function public.schedule_contribution_plan_change(
+  uuid, date, public.subscription_plan_type_enum
+) from public, anon;
+grant execute on function public.schedule_contribution_plan_change(
+  uuid, date, public.subscription_plan_type_enum
+) to authenticated, service_role;
+
+-- The timestamp-injected worker is retained only as a private test/migration
+-- seam. Production callers use the no-argument wrapper below, which derives
+-- the database clock and cannot be asked to generate arbitrary history.
+create or replace function public.generate_membership_billing_obligations_at(
+  p_as_of timestamp with time zone
+)
+returns table (
+  schedule_id uuid,
+  period_key text,
+  obligation_id uuid,
+  result text,
+  failure_reason text
+)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  evaluated_at timestamp with time zone := coalesce(p_as_of, clock_timestamp());
+  schedule_record record;
+  assignment_record record;
+  term_count integer;
+  local_date_value date;
+  due_date_value date;
+  next_due_date_value date;
+  period_key_value text;
+  period_start_value date;
+  period_end_value date;
+  available_on_value date;
+  created_obligation public.payment_obligations%rowtype;
+  existing_obligation public.payment_obligations%rowtype;
+  cadence_value public.contribution_cadence_enum;
+begin
+  if evaluated_at is null then
+    raise exception 'The generation clock is required.' using errcode = '22023';
+  end if;
+
+  for schedule_record in
+    select
+      cs.*,
+      o.name as organization_name,
+      o.slug as organization_slug
+    from public.contribution_schedules cs
+    join public.organizations o on o.id = cs.organization_id
+    join public.organization_members om
+      on om.organization_id = cs.organization_id
+      and om.user_id = cs.user_id
+    join public.subscriptions s
+      on s.organization_id = cs.organization_id
+      and s.user_id = cs.user_id
+      and s.status = 'active'::public.subscription_status_enum
+    where cs.active
+      and o.organization_type = 'association'::public.organization_type_enum
+      and om.role in (
+        'admin'::public.organization_role_enum,
+        'member'::public.organization_role_enum
+      )
+    order by cs.organization_id, cs.user_id
+  loop
+    begin
+      if not public.is_valid_billing_timezone(schedule_record.billing_timezone)
+        or schedule_record.due_day not between 1 and 31
+        or schedule_record.lead_days not between 0 and 31
+        or schedule_record.currency !~ '^[A-Z]{3}$' then
+        schedule_id := schedule_record.id;
+        period_key := null;
+        obligation_id := null;
+        result := 'failed';
+        failure_reason := 'The contribution schedule billing policy is invalid.';
+        return next;
+        continue;
+      end if;
+
+      local_date_value := timezone(
+        schedule_record.billing_timezone,
+        evaluated_at
+      )::date;
+      term_count := 0;
+
+      for assignment_record in
+        select
+          cpa.*,
+          lead(cpa.effective_period_start) over (
+            order by cpa.effective_period_start, cpa.id
+          ) as next_effective_period_start
+        from public.contribution_plan_assignments cpa
+        where cpa.schedule_id = schedule_record.id
+        order by cpa.effective_period_start, cpa.id
+      loop
+        term_count := term_count + 1;
+        cadence_value := case
+          when assignment_record.plan_type = 'annual'::public.subscription_plan_type_enum
+            then 'annual'::public.contribution_cadence_enum
+          else 'monthly'::public.contribution_cadence_enum
+        end;
+
+        if assignment_record.due_day is null
+          or assignment_record.due_day not between 1 and 31
+          or assignment_record.lead_days is null
+          or assignment_record.lead_days not between 0 and 31
+          or not public.is_valid_billing_timezone(assignment_record.billing_timezone)
+          or assignment_record.currency !~ '^[A-Z]{3}$'
+          or assignment_record.amount is null
+          or assignment_record.amount <= 0 then
+          schedule_id := schedule_record.id;
+          period_key := null;
+          obligation_id := null;
+          result := 'failed';
+          failure_reason := 'The recurring billing term is invalid or has no positive price.';
+          return next;
+          continue;
+        end if;
+
+        due_date_value := public.recurring_due_date_on_or_after(
+          schedule_record.admission_date,
+          cadence_value,
+          assignment_record.due_day,
+          greatest(
+            schedule_record.admission_date,
+            assignment_record.effective_period_start
+          )
+        );
+
+        while due_date_value - assignment_record.lead_days <= local_date_value loop
+          if assignment_record.next_effective_period_start is not null
+            and due_date_value >= assignment_record.next_effective_period_start then
+            exit;
+          end if;
+
+          next_due_date_value := public.next_recurring_due_date(
+            due_date_value,
+            cadence_value,
+            assignment_record.due_day
+          );
+          period_start_value := due_date_value;
+          period_end_value := next_due_date_value - 1;
+          available_on_value := due_date_value - assignment_record.lead_days;
+          period_key_value := public.recurring_period_key(
+            cadence_value,
+            due_date_value
+          );
+
+          if nullif(btrim(assignment_record.pix_copy_paste), '') is null then
+            schedule_id := schedule_record.id;
+            period_key := period_key_value;
+            obligation_id := null;
+            result := 'failed';
+            failure_reason := 'No PIX snapshot exists for the recurring period.';
+            return next;
+            due_date_value := next_due_date_value;
+            continue;
+          end if;
+
+          created_obligation := null;
+          existing_obligation := null;
+
+          insert into public.payment_obligations (
+            organization_id,
+            user_id,
+            application_revision_id,
+            purpose,
+            status,
+            plan_type,
+            amount,
+            currency,
+            payment_method,
+            pix_copy_paste,
+            available_at,
+            schedule_id,
+            schedule_term_id,
+            period_key,
+            period_start,
+            period_end,
+            available_on,
+            due_on,
+            billing_timezone,
+            billing_due_day,
+            billing_lead_days,
+            organization_name_snapshot,
+            organization_slug_snapshot
+          )
+          values (
+            schedule_record.organization_id,
+            schedule_record.user_id,
+            null,
+            'recurring'::public.payment_obligation_purpose_enum,
+            'available'::public.payment_obligation_status_enum,
+            assignment_record.plan_type,
+            assignment_record.amount,
+            assignment_record.currency,
+            'manual_pix',
+            assignment_record.pix_copy_paste,
+            available_on_value::timestamp at time zone assignment_record.billing_timezone,
+            schedule_record.id,
+            assignment_record.id,
+            period_key_value,
+            period_start_value,
+            period_end_value,
+            available_on_value,
+            due_date_value,
+            assignment_record.billing_timezone,
+            assignment_record.due_day,
+            assignment_record.lead_days,
+            schedule_record.organization_name,
+            schedule_record.organization_slug
+          )
+          on conflict on constraint payment_obligations_schedule_period_key
+          do nothing
+          returning * into created_obligation;
+
+          if created_obligation.id is null then
+            select po.*
+            into existing_obligation
+            from public.payment_obligations po
+            where po.schedule_id = schedule_record.id
+              and po.period_key = period_key_value
+              and po.purpose = 'recurring'::public.payment_obligation_purpose_enum;
+          else
+            existing_obligation := created_obligation;
+          end if;
+
+          schedule_id := schedule_record.id;
+          period_key := period_key_value;
+          obligation_id := existing_obligation.id;
+          result := case
+            when created_obligation.id is null then 'already_exists'
+            else 'created'
+          end;
+          failure_reason := null;
+          return next;
+
+          due_date_value := next_due_date_value;
+        end loop;
+      end loop;
+
+      if term_count = 0 then
+        schedule_id := schedule_record.id;
+        period_key := null;
+        obligation_id := null;
+        result := 'failed';
+        failure_reason := 'No effective-dated billing term exists for the schedule.';
+        return next;
+      end if;
+    exception
+      when others then
+        schedule_id := schedule_record.id;
+        period_key := null;
+        obligation_id := null;
+        result := 'failed';
+        failure_reason := sqlerrm;
+        return next;
+    end;
+  end loop;
+end;
+$$;
+
+revoke all on function public.generate_membership_billing_obligations_at(
+  timestamp with time zone
+) from public, anon, authenticated, service_role;
+
+create or replace function public.generate_membership_billing_obligations(
+  p_as_of timestamp with time zone default null
+)
+returns table (
+  schedule_id uuid,
+  period_key text,
+  obligation_id uuid,
+  result text,
+  failure_reason text
+)
+language sql
+security definer
+set search_path = ''
+as $$
+  select *
+  from public.generate_membership_billing_obligations_at(
+    coalesce(p_as_of, clock_timestamp())
+  );
+$$;
+
+revoke all on function public.generate_membership_billing_obligations(
+  timestamp with time zone
+) from public, anon, authenticated, service_role;
+
+create or replace function public.generate_membership_billing_obligations()
+returns table (
+  schedule_id uuid,
+  period_key text,
+  obligation_id uuid,
+  result text,
+  failure_reason text
+)
+language sql
+security definer
+set search_path = ''
+as $$
+  select *
+  from public.generate_membership_billing_obligations_at(clock_timestamp());
+$$;
+
+comment on function public.generate_membership_billing_obligations() is
+  'Trusted scheduler command. Derives the database clock and materializes every available recurring period exactly once.';
+
+revoke all on function public.generate_membership_billing_obligations()
+  from public, anon, authenticated;
+grant execute on function public.generate_membership_billing_obligations()
+  to service_role;
+
+-- Legacy payment reconciliation is intentionally separate from generation.
+-- The default is a dry run. Only an unambiguous one-to-one match may be
+-- applied, and a succeeded legacy payment never settles an obligation that
+-- already has a claim under review.
+create or replace function public.reconcile_legacy_payment_obligations(
+  p_apply boolean default false
+)
+returns table (
+  payment_id uuid,
+  obligation_id uuid,
+  payment_status public.payment_status_enum,
+  result text,
+  reason text
+)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  payment_record record;
+  candidate_obligation_id uuid;
+  candidate_count integer;
+  matched_obligation public.payment_obligations%rowtype;
+begin
+  for payment_record in
+    select p.*
+    from public.payments p
+    where p.status in (
+      'pending'::public.payment_status_enum,
+      'succeeded'::public.payment_status_enum
+    )
+      and p.payment_provider is null
+      and p.provider_payment_id is null
+      and not exists (
+        select 1
+        from public.payment_obligations linked
+        where linked.legacy_payment_id = p.id
+      )
+    order by coalesce(p.paid_at, p.created_at), p.id
+  loop
+    select count(*)::integer, min(candidates.id::text)::uuid
+    into candidate_count, candidate_obligation_id
+    from public.payment_obligations candidates
+    where candidates.purpose = 'recurring'::public.payment_obligation_purpose_enum
+      and candidates.legacy_payment_id is null
+      and candidates.organization_id = payment_record.organization_id
+      and candidates.user_id = payment_record.user_id
+      and candidates.amount = payment_record.amount
+      and timezone(
+        coalesce(
+          candidates.billing_timezone,
+          (select o.billing_timezone
+           from public.organizations o
+           where o.id = candidates.organization_id)
+        ),
+        coalesce(payment_record.paid_at, payment_record.created_at)
+      )::date between candidates.period_start and candidates.period_end;
+
+    payment_id := payment_record.id;
+    obligation_id := candidate_obligation_id;
+    payment_status := payment_record.status;
+
+    if candidate_count = 0 then
+      result := 'unmatched';
+      reason := 'No stable recurring period matches this legacy payment.';
+      return next;
+      continue;
+    end if;
+
+    if candidate_count > 1 then
+      obligation_id := null;
+      result := 'ambiguous';
+      reason := 'More than one recurring period matches this legacy payment.';
+      return next;
+      continue;
+    end if;
+
+    select po.*
+    into matched_obligation
+    from public.payment_obligations po
+    where po.id = candidate_obligation_id
+    for update;
+
+    if exists (
+      select 1
+      from public.payment_claims pc
+      where pc.obligation_id = matched_obligation.id
+        and pc.status = 'under_review'::public.payment_claim_status_enum
+    ) then
+      result := 'blocked_under_review';
+      reason := 'The period has an active payment claim under review.';
+      return next;
+      continue;
+    end if;
+
+    if not p_apply then
+      result := 'ready';
+      reason := 'One stable period matches; apply only after dry-run review.';
+      return next;
+      continue;
+    end if;
+
+    update public.payment_obligations po
+    set
+      legacy_payment_id = payment_record.id,
+      status = case
+        when payment_record.status = 'succeeded'::public.payment_status_enum
+          then 'settled'::public.payment_obligation_status_enum
+        else po.status
+      end,
+      settled_at = case
+        when payment_record.status = 'succeeded'::public.payment_status_enum
+          then coalesce(payment_record.paid_at, payment_record.created_at)
+        else po.settled_at
+      end
+    where po.id = matched_obligation.id
+      and po.legacy_payment_id is null;
+
+    if found then
+      result := 'linked';
+      reason := 'One stable period was linked to the legacy payment.';
+    else
+      result := 'already_linked';
+      reason := 'The stable period was linked by an earlier reconciliation row.';
+    end if;
+    return next;
+  end loop;
+end;
+$$;
+
+comment on function public.reconcile_legacy_payment_obligations(boolean) is
+  'Returns a dry-run legacy payment mapping by default; only unambiguous reviewed mappings may be applied.';
+
+revoke all on function public.reconcile_legacy_payment_obligations(boolean)
+  from public, anon, authenticated;
+grant execute on function public.reconcile_legacy_payment_obligations(boolean)
+  to service_role;
+
+-- The old daily job ran before São Paulo midnight and the old implementation
+-- also emitted immediate-renewal notifications. Replace it with one frequent,
+-- scheduler-only job; reminders belong to their own workflow.
+do $$
+begin
+  if to_regclass('cron.job') is not null then
+    if exists (select 1 from cron.job where jobname = 'daily-renewal-check') then
+      perform cron.unschedule('daily-renewal-check');
+    end if;
+
+    if not exists (
+      select 1
+      from cron.job
+      where jobname = 'membership-billing-obligation-generator'
+    ) then
+      perform cron.schedule(
+        'membership-billing-obligation-generator',
+        '*/15 * * * *',
+        $cron$
+        select net.http_post(
+          url := (select decrypted_secret from vault.decrypted_secrets where name = 'project_url')
+            || '/functions/v1/generate-renewal-payments',
+          headers := jsonb_build_object(
+            'Content-Type', 'application/json',
+            'Authorization', 'Bearer ' || (
+              select decrypted_secret
+              from vault.decrypted_secrets
+              where name = 'secret_key'
+            )
+          ),
+          body := '{}'::jsonb
+        ) as request_id;
+        $cron$
+      );
+    end if;
+  end if;
+end;
+$$;
+
+create or replace function public.get_payment_obligation_instructions(
+  p_obligation_id uuid
+)
+returns table (
+  obligation_id uuid,
+  organization_id uuid,
+  purpose public.payment_obligation_purpose_enum,
+  status text,
+  plan_type public.subscription_plan_type_enum,
+  amount integer,
+  currency text,
+  payment_method text,
+  pix_copy_paste text,
+  available_at timestamp with time zone,
+  available_on date,
+  due_on date,
+  period_key text,
+  claim_id uuid,
+  claim_status public.payment_claim_status_enum,
+  payer_type public.payment_claim_payer_type_enum,
+  payer_name text,
+  claim_created_at timestamp with time zone,
+  claim_decision_reason text
+)
+language sql
+security definer
+set search_path = ''
+as $$
+  select
+    po.id,
+    po.organization_id,
+    po.purpose,
+    case
+      when po.status = 'settled'::public.payment_obligation_status_enum then 'settled'
+      when po.status = 'void'::public.payment_obligation_status_enum then 'void'
+      when claim.status = 'under_review'::public.payment_claim_status_enum then 'under_review'
+      when po.purpose = 'initial_admission'::public.payment_obligation_purpose_enum
+        and po.available_at <= clock_timestamp() then 'available'
+      when po.purpose = 'recurring'::public.payment_obligation_purpose_enum
+        and po.due_on < timezone(
+          coalesce(po.billing_timezone, o.billing_timezone),
+          clock_timestamp()
+        )::date then 'overdue'
+      when po.purpose = 'recurring'::public.payment_obligation_purpose_enum
+        and po.available_on <= timezone(
+        coalesce(po.billing_timezone, o.billing_timezone),
+        clock_timestamp()
+      )::date then 'available'
+      else 'scheduled'
+    end,
+    po.plan_type,
+    po.amount,
+    po.currency,
+    po.payment_method,
+    po.pix_copy_paste,
+    po.available_at,
+    po.available_on,
+    po.due_on,
+    po.period_key,
+    claim.id,
+    claim.status,
+    claim.payer_type,
+    claim.payer_name,
+    claim.created_at,
+    claim.decision_reason
+  from public.payment_obligations po
+  join public.organizations o on o.id = po.organization_id
+  left join lateral (
+    select
+      pc.id,
+      pc.status,
+      pc.payer_type,
+      pc.payer_name,
+      pc.created_at,
+      pc.decision_reason
+    from public.payment_claims pc
+    where pc.obligation_id = po.id
+      and pc.claimant_user_id = (select auth.uid())
+    order by pc.created_at desc, pc.id desc
+    limit 1
+  ) claim on true
+  where po.id = p_obligation_id
+    and po.user_id = (select auth.uid());
+$$;
+
+comment on function public.get_payment_obligation_instructions(uuid) is
+  'Returns authoritative PIX instructions and evaluates availability using the obligation timezone snapshot.';
+
+revoke all on function public.get_payment_obligation_instructions(uuid)
+  from public, anon;
+grant execute on function public.get_payment_obligation_instructions(uuid)
+  to authenticated;
+
+create or replace function public.claim_recurring_payment(
+  p_obligation_id uuid,
+  p_paid_by_applicant boolean,
+  p_payer_name text default null
+)
+returns table (
+  claim_id uuid,
+  obligation_id uuid,
+  payer_type public.payment_claim_payer_type_enum,
+  payer_name text,
+  claim_status public.payment_claim_status_enum,
+  claim_created_at timestamp with time zone,
+  audit_event_id uuid
+)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  actor_id uuid := (select auth.uid());
+  organization_record public.organizations%rowtype;
+  obligation_record public.payment_obligations%rowtype;
+  existing_claim public.payment_claims%rowtype;
+  audit_record public.payment_claim_audit_events%rowtype;
+  inserted_claim public.payment_claims%rowtype;
+  normalized_payer_name text;
+begin
+  if actor_id is null then
+    raise exception 'Authentication is required.' using errcode = '42501';
+  end if;
+
+  normalized_payer_name := nullif(
+    btrim(regexp_replace(coalesce(p_payer_name, ''), '\\s+', ' ', 'g')),
+    ''
+  );
+
+  if p_paid_by_applicant and normalized_payer_name is not null then
+    raise exception 'Payer name is only allowed when another person paid.'
+      using errcode = '22023';
+  end if;
+
+  if not p_paid_by_applicant and normalized_payer_name is null then
+    raise exception 'Enter the name of the person who made the payment.'
+      using errcode = '22023';
+  end if;
+
+  if normalized_payer_name is not null and char_length(normalized_payer_name) > 120 then
+    raise exception 'Payer name must be 120 characters or fewer.' using errcode = '22023';
+  end if;
+
+  select po.*
+  into obligation_record
+  from public.payment_obligations po
+  where po.id = p_obligation_id
+    and po.user_id = actor_id
+  for update;
+
+  if not found then
+    raise exception 'Payment obligation is unavailable.' using errcode = '42501';
+  end if;
+
+  select o.*
+  into organization_record
+  from public.organizations o
+  where o.id = obligation_record.organization_id
+    and o.organization_type = 'association'::public.organization_type_enum;
+
+  if not found then
+    raise exception 'Payment obligation is unavailable.' using errcode = '42501';
+  end if;
+
+  if obligation_record.purpose <> 'recurring'::public.payment_obligation_purpose_enum
+    or obligation_record.status <> 'available'::public.payment_obligation_status_enum
+    or obligation_record.available_on > timezone(
+      coalesce(obligation_record.billing_timezone, organization_record.billing_timezone),
+      clock_timestamp()
+    )::date
+    or obligation_record.payment_method <> 'manual_pix'
+    or nullif(btrim(obligation_record.pix_copy_paste), '') is null
+    or not exists (
+      select 1
+      from public.organization_members om
+      where om.organization_id = obligation_record.organization_id
+        and om.user_id = actor_id
+        and om.role in (
+          'admin'::public.organization_role_enum,
+          'member'::public.organization_role_enum
+        )
+    ) then
+    raise exception 'This recurring contribution cannot be claimed.' using errcode = '23514';
+  end if;
+
+  select pc.*
+  into existing_claim
+  from public.payment_claims pc
+  where pc.obligation_id = obligation_record.id
+    and pc.status = 'under_review'::public.payment_claim_status_enum
+  for update;
+
+  if found then
+    if existing_claim.payer_type <> (
+      case
+        when p_paid_by_applicant then 'applicant'::public.payment_claim_payer_type_enum
+        else 'other'::public.payment_claim_payer_type_enum
+      end
+    )
+    or existing_claim.payer_name is distinct from (
+      case
+        when p_paid_by_applicant then null
+        else normalized_payer_name
+      end
+    ) then
+      raise exception 'A payment claim is already under review with different payer details.'
+        using errcode = '40001';
+    end if;
+
+    select pcae.*
+    into audit_record
+    from public.payment_claim_audit_events pcae
+    where pcae.claim_id = existing_claim.id
+      and pcae.next_state = 'under_review'
+    order by pcae.created_at asc, pcae.id asc
+    limit 1;
+
+    return query
+    select
+      existing_claim.id,
+      existing_claim.obligation_id,
+      existing_claim.payer_type,
+      existing_claim.payer_name,
+      existing_claim.status,
+      existing_claim.created_at,
+      audit_record.id;
+    return;
+  end if;
+
+  if exists (
+    select 1
+    from public.payment_claims pc
+    where pc.obligation_id = obligation_record.id
+      and pc.status = 'approved'::public.payment_claim_status_enum
+  ) then
+    raise exception 'This payment obligation has already been approved.' using errcode = '23514';
+  end if;
+
+  insert into public.payment_claims (
+    obligation_id,
+    organization_id,
+    claimant_user_id,
+    payer_type,
+    payer_name,
+    status
+  )
+  values (
+    obligation_record.id,
+    obligation_record.organization_id,
+    actor_id,
+    case
+      when p_paid_by_applicant then 'applicant'::public.payment_claim_payer_type_enum
+      else 'other'::public.payment_claim_payer_type_enum
+    end,
+    case when p_paid_by_applicant then null else normalized_payer_name end,
+    'under_review'::public.payment_claim_status_enum
+  )
+  returning * into inserted_claim;
+
+  insert into public.payment_claim_audit_events (
+    organization_id,
+    obligation_id,
+    claim_id,
+    actor_user_id,
+    previous_state,
+    next_state
+  )
+  values (
+    obligation_record.organization_id,
+    obligation_record.id,
+    inserted_claim.id,
+    actor_id,
+    'payment_available',
+    'under_review'
+  )
+  returning * into audit_record;
+
+  return query
+  select
+    inserted_claim.id,
+    inserted_claim.obligation_id,
+    inserted_claim.payer_type,
+    inserted_claim.payer_name,
+    inserted_claim.status,
+    inserted_claim.created_at,
+    audit_record.id;
+end;
+$$;
+
+comment on function public.claim_recurring_payment(uuid, boolean, text) is
+  'Records a recurring payment claim only on or after the obligation''s snapshotted local availability date.';
+
+revoke all on function public.claim_recurring_payment(uuid, boolean, text)
+  from public, anon;
+grant execute on function public.claim_recurring_payment(uuid, boolean, text)
+  to authenticated;
+
+-- The local pgTAP runner uses the privileged postgres role for deterministic
+-- calendar and generation scenarios. These grants do not expose the helpers
+-- to anon/authenticated callers.
+grant execute on function public.clamped_billing_date(integer, integer, integer)
+  to postgres;
+grant execute on function public.first_recurring_due_date(
+  date, public.contribution_cadence_enum, integer
+) to postgres;
+grant execute on function public.next_recurring_due_date(
+  date, public.contribution_cadence_enum, integer
+) to postgres;
+grant execute on function public.recurring_due_date_on_or_after(
+  date, public.contribution_cadence_enum, integer, date
+) to postgres;
+grant execute on function public.recurring_period_key(
+  public.contribution_cadence_enum, date
+) to postgres;
+grant execute on function public.generate_membership_billing_obligations_at(
+  timestamp with time zone
+) to postgres;
+grant execute on function public.reconcile_legacy_payment_obligations(boolean)
+  to postgres;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -6,6 +6,10 @@ INSERT INTO public.organizations (
   id,
   name,
   slug,
+  billing_currency,
+  billing_timezone,
+  billing_due_day,
+  billing_lead_days,
   monthly_price_amount,
   annual_price_amount
 )
@@ -13,6 +17,10 @@ VALUES (
   '2c9c5c8a-4e4d-4322-bb48-adf6231d2bb1'::uuid,
   'SL.A.C',
   'slac',
+  'BRL',
+  'America/Sao_Paulo',
+  10,
+  7,
   3500,
   36000
 )
@@ -20,6 +28,10 @@ ON CONFLICT (id) DO UPDATE
 SET
   name = EXCLUDED.name,
   slug = EXCLUDED.slug,
+  billing_currency = EXCLUDED.billing_currency,
+  billing_timezone = EXCLUDED.billing_timezone,
+  billing_due_day = EXCLUDED.billing_due_day,
+  billing_lead_days = EXCLUDED.billing_lead_days,
   monthly_price_amount = EXCLUDED.monthly_price_amount,
   annual_price_amount = EXCLUDED.annual_price_amount;
 

--- a/supabase/tests/fixed_day_recurring_obligations_test.sql
+++ b/supabase/tests/fixed_day_recurring_obligations_test.sql
@@ -1,0 +1,517 @@
+begin;
+
+select * from no_plan();
+
+select is(
+  public.first_recurring_due_date(
+    '2026-01-09'::date,
+    'monthly'::public.contribution_cadence_enum,
+    10
+  ),
+  '2026-02-10'::date,
+  'monthly admission on January 9 first becomes due on February 10'
+);
+
+select is(
+  public.first_recurring_due_date(
+    '2026-01-10'::date,
+    'monthly'::public.contribution_cadence_enum,
+    10
+  ),
+  '2026-02-10'::date,
+  'monthly admission on January 10 first becomes due on February 10'
+);
+
+select is(
+  public.first_recurring_due_date(
+    '2026-01-11'::date,
+    'monthly'::public.contribution_cadence_enum,
+    10
+  ),
+  '2026-03-10'::date,
+  'monthly admission on January 11 waits for the following fixed-day period'
+);
+
+select is(
+  public.clamped_billing_date(2024, 2, 31),
+  '2024-02-29'::date,
+  'day 31 clamps to leap-day February'
+);
+
+select is(
+  public.clamped_billing_date(2025, 2, 31),
+  '2025-02-28'::date,
+  'day 31 clamps to non-leap February'
+);
+
+select is(
+  public.next_recurring_due_date(
+    '2025-02-28'::date,
+    'monthly'::public.contribution_cadence_enum,
+    31
+  ),
+  '2025-03-31'::date,
+  'a clamped February period returns to day 31 in March'
+);
+
+select is(
+  public.first_recurring_due_date(
+    '2024-02-29'::date,
+    'annual'::public.contribution_cadence_enum,
+    10
+  ),
+  '2025-02-10'::date,
+  'annual admission uses the next anniversary year'
+);
+
+insert into public.organizations (
+  id,
+  name,
+  slug,
+  organization_type,
+  billing_currency,
+  billing_timezone,
+  billing_due_day,
+  billing_lead_days,
+  monthly_price_amount,
+  annual_price_amount,
+  monthly_pix_copy_paste,
+  annual_pix_copy_paste
+)
+values (
+  '82000000-0000-4000-8000-000000000001'::uuid,
+  'Fixed Day Association',
+  'fixed-day-association',
+  'association'::public.organization_type_enum,
+  'BRL',
+  'UTC',
+  31,
+  7,
+  12500,
+  36000,
+  '000201fixed-monthly-pix',
+  '000201fixed-annual-pix'
+);
+
+insert into auth.users (
+  id,
+  aud,
+  role,
+  email,
+  email_confirmed_at,
+  raw_user_meta_data,
+  created_at,
+  updated_at
+)
+values
+  (
+    '82000000-0000-4000-8000-000000000101'::uuid,
+    'authenticated',
+    'authenticated',
+    'fixed-day-member@example.com',
+    timezone('utc'::text, now()),
+    '{"full_name":"Fixed Day Member"}'::jsonb,
+    timezone('utc'::text, now()),
+    timezone('utc'::text, now())
+  ),
+  (
+    '82000000-0000-4000-8000-000000000102'::uuid,
+    'authenticated',
+    'authenticated',
+    'fixed-day-invalid@example.com',
+    timezone('utc'::text, now()),
+    '{"full_name":"Fixed Day Invalid"}'::jsonb,
+    timezone('utc'::text, now()),
+    timezone('utc'::text, now())
+  );
+
+insert into public.profiles (id, name, username)
+values
+  (
+    '82000000-0000-4000-8000-000000000101'::uuid,
+    'Fixed Day Member',
+    '@fixed_day_member'
+  ),
+  (
+    '82000000-0000-4000-8000-000000000102'::uuid,
+    'Fixed Day Invalid',
+    '@fixed_day_invalid'
+  )
+on conflict (id) do update
+set name = excluded.name,
+    username = excluded.username;
+
+insert into public.organization_members (
+  organization_id,
+  user_id,
+  role,
+  joined_at
+)
+values
+  (
+    '82000000-0000-4000-8000-000000000001'::uuid,
+    '82000000-0000-4000-8000-000000000101'::uuid,
+    'member'::public.organization_role_enum,
+    '2026-01-09 12:00:00+00'
+  ),
+  (
+    '82000000-0000-4000-8000-000000000001'::uuid,
+    '82000000-0000-4000-8000-000000000102'::uuid,
+    'member'::public.organization_role_enum,
+    '2026-01-09 12:00:00+00'
+  );
+
+insert into public.subscriptions (
+  organization_id,
+  user_id,
+  plan_type,
+  status,
+  current_period_end
+)
+values
+  (
+    '82000000-0000-4000-8000-000000000001'::uuid,
+    '82000000-0000-4000-8000-000000000101'::uuid,
+    'monthly'::public.subscription_plan_type_enum,
+    'active'::public.subscription_status_enum,
+    '2026-02-09 00:00:00+00'
+  ),
+  (
+    '82000000-0000-4000-8000-000000000001'::uuid,
+    '82000000-0000-4000-8000-000000000102'::uuid,
+    'monthly'::public.subscription_plan_type_enum,
+    'active'::public.subscription_status_enum,
+    '2026-02-09 00:00:00+00'
+  );
+
+select is(
+  (select admission_date from public.contribution_schedules
+   where organization_id = '82000000-0000-4000-8000-000000000001'::uuid
+     and user_id = '82000000-0000-4000-8000-000000000101'::uuid),
+  '2026-01-09'::date,
+  'the schedule keeps the verified admission anchor'
+);
+
+insert into public.contribution_plan_assignments (
+  schedule_id,
+  effective_period_start,
+  plan_type,
+  amount,
+  currency,
+  due_day,
+  lead_days,
+  billing_timezone,
+  pix_copy_paste
+)
+select
+  cs.id,
+  '2026-03-31'::date,
+  'annual'::public.subscription_plan_type_enum,
+  36000,
+  'BRL',
+  31,
+  7,
+  'UTC',
+  '000201fixed-annual-pix'
+from public.contribution_schedules cs
+where cs.organization_id = '82000000-0000-4000-8000-000000000001'::uuid
+  and cs.user_id = '82000000-0000-4000-8000-000000000101'::uuid;
+
+select is(
+  (select count(*)::integer
+   from public.contribution_plan_assignments cpa
+   join public.contribution_schedules cs on cs.id = cpa.schedule_id
+   where cs.organization_id = '82000000-0000-4000-8000-000000000001'::uuid
+     and cs.user_id = '82000000-0000-4000-8000-000000000101'::uuid),
+  2,
+  'the member has an immutable initial term and one future term'
+);
+
+select is(
+  (select count(*)::integer
+   from public.generate_membership_billing_obligations_at(
+     '2026-02-22 12:00:00+00'::timestamp with time zone
+   )
+   where schedule_id = (
+     select cs.id
+     from public.contribution_schedules cs
+     where cs.organization_id = '82000000-0000-4000-8000-000000000001'::uuid
+       and cs.user_id = '82000000-0000-4000-8000-000000000101'::uuid
+   )
+     and result = 'created'),
+  1,
+  'the generator materializes the first available fixed-day period'
+);
+
+select is(
+  (select count(*)::integer
+   from public.payment_obligations
+   where organization_id = '82000000-0000-4000-8000-000000000001'::uuid
+     and user_id = '82000000-0000-4000-8000-000000000101'::uuid
+     and purpose = 'recurring'::public.payment_obligation_purpose_enum),
+  1,
+  'one recurring obligation exists after the first generation'
+);
+
+select is(
+  (select period_key
+   from public.payment_obligations
+   where organization_id = '82000000-0000-4000-8000-000000000001'::uuid
+     and user_id = '82000000-0000-4000-8000-000000000101'::uuid
+     and purpose = 'recurring'::public.payment_obligation_purpose_enum),
+  'monthly:2026-02-28',
+  'the recurring period identity includes cadence and due date'
+);
+
+select is(
+  (select period_start
+   from public.payment_obligations
+   where organization_id = '82000000-0000-4000-8000-000000000001'::uuid
+     and user_id = '82000000-0000-4000-8000-000000000101'::uuid
+     and purpose = 'recurring'::public.payment_obligation_purpose_enum),
+  '2026-02-28'::date,
+  'period start is the due-date boundary and does not overlap the next period'
+);
+
+select is(
+  (select period_end
+   from public.payment_obligations
+   where organization_id = '82000000-0000-4000-8000-000000000001'::uuid
+     and user_id = '82000000-0000-4000-8000-000000000101'::uuid
+     and purpose = 'recurring'::public.payment_obligation_purpose_enum),
+  '2026-03-30'::date,
+  'period end is the day before the next fixed-day boundary'
+);
+
+select is(
+  (select available_on
+   from public.payment_obligations
+   where organization_id = '82000000-0000-4000-8000-000000000001'::uuid
+     and user_id = '82000000-0000-4000-8000-000000000101'::uuid
+     and purpose = 'recurring'::public.payment_obligation_purpose_enum),
+  '2026-02-21'::date,
+  'availability is exactly the configured lead days before due'
+);
+
+select is(
+  (select count(*)::integer
+   from public.generate_membership_billing_obligations_at(
+     '2026-02-22 12:00:00+00'::timestamp with time zone
+   )
+   where schedule_id = (
+     select cs.id
+     from public.contribution_schedules cs
+     where cs.organization_id = '82000000-0000-4000-8000-000000000001'::uuid
+       and cs.user_id = '82000000-0000-4000-8000-000000000101'::uuid
+   )
+     and result = 'already_exists'),
+  1,
+  'repeating generation is idempotent'
+);
+
+select is(
+  (select count(*)::integer
+   from public.generate_membership_billing_obligations_at(
+     '2027-01-25 12:00:00+00'::timestamp with time zone
+   )
+   where schedule_id = (
+     select cs.id
+     from public.contribution_schedules cs
+     where cs.organization_id = '82000000-0000-4000-8000-000000000001'::uuid
+       and cs.user_id = '82000000-0000-4000-8000-000000000101'::uuid
+   )
+     and result = 'created'),
+  1,
+  'a future annual term eventually materializes its anniversary period'
+);
+
+select is(
+  (select period_key
+   from public.payment_obligations
+   where organization_id = '82000000-0000-4000-8000-000000000001'::uuid
+     and user_id = '82000000-0000-4000-8000-000000000101'::uuid
+     and plan_type = 'annual'::public.subscription_plan_type_enum),
+  'annual:2027-01-31',
+  'annual periods remain anniversary anchored after a future plan change'
+);
+
+select throws_ok(
+  $$update public.contribution_schedules
+    set due_day = 10
+    where organization_id = '82000000-0000-4000-8000-000000000001'::uuid
+      and user_id = '82000000-0000-4000-8000-000000000101'::uuid$$,
+  '55000',
+  'Contribution schedule policy is immutable; append an effective-dated term.',
+  'the original schedule policy cannot drift after admission'
+);
+
+select throws_ok(
+  $$update public.contribution_plan_assignments
+    set amount = 1
+    where schedule_id = (
+      select cs.id
+      from public.contribution_schedules cs
+      where cs.organization_id = '82000000-0000-4000-8000-000000000001'::uuid
+        and cs.user_id = '82000000-0000-4000-8000-000000000101'::uuid
+    )
+      and effective_period_start = '2026-01-09'::date$$,
+  '55000',
+  'An effective-dated contribution term is immutable; append a new term.',
+  'effective-dated plan snapshots cannot be rewritten'
+);
+
+update public.organizations
+set
+  billing_timezone = 'America/Sao_Paulo',
+  billing_due_day = 10,
+  billing_lead_days = 3,
+  monthly_price_amount = 1,
+  monthly_pix_copy_paste = '000201changed-policy-pix'
+where id = '82000000-0000-4000-8000-000000000001'::uuid;
+
+select is(
+  (select billing_timezone
+   from public.payment_obligations
+   where organization_id = '82000000-0000-4000-8000-000000000001'::uuid
+     and user_id = '82000000-0000-4000-8000-000000000101'::uuid
+     and period_key = 'monthly:2026-02-28'),
+  'UTC',
+  'existing obligations keep their original timezone snapshot'
+);
+
+select is(
+  (select amount
+   from public.payment_obligations
+   where organization_id = '82000000-0000-4000-8000-000000000001'::uuid
+     and user_id = '82000000-0000-4000-8000-000000000101'::uuid
+     and period_key = 'monthly:2026-02-28'),
+  12500,
+  'existing obligations keep their original price snapshot'
+);
+
+select throws_ok(
+  $$update public.payment_obligations
+    set amount = 1
+    where organization_id = '82000000-0000-4000-8000-000000000001'::uuid
+      and user_id = '82000000-0000-4000-8000-000000000101'::uuid
+      and period_key = 'monthly:2026-02-28'$$,
+  '55000',
+  'Payment obligation billing context is immutable.',
+  'materialized obligation context cannot be rewritten'
+);
+
+insert into public.contribution_plan_assignments (
+  schedule_id,
+  effective_period_start,
+  plan_type,
+  amount,
+  currency,
+  due_day,
+  lead_days,
+  billing_timezone,
+  pix_copy_paste
+)
+select
+  cs.id,
+  '2026-02-28'::date,
+  'annual'::public.subscription_plan_type_enum,
+  36000,
+  'BRL',
+  31,
+  7,
+  'UTC',
+  null
+from public.contribution_schedules cs
+where cs.organization_id = '82000000-0000-4000-8000-000000000001'::uuid
+  and cs.user_id = '82000000-0000-4000-8000-000000000102'::uuid;
+
+select is(
+  (select count(*)::integer
+   from public.generate_membership_billing_obligations_at(
+     '2027-02-22 12:00:00+00'::timestamp with time zone
+   )
+   where schedule_id = (
+     select cs.id
+     from public.contribution_schedules cs
+     where cs.organization_id = '82000000-0000-4000-8000-000000000001'::uuid
+       and cs.user_id = '82000000-0000-4000-8000-000000000102'::uuid
+   )
+     and result = 'failed'),
+  1,
+  'an invalid member term is an operational failure and does not abort valid schedules'
+);
+
+select throws_ok(
+  $$update public.organizations
+    set billing_timezone = 'Mars/Olympus'
+    where id = '82000000-0000-4000-8000-000000000001'::uuid$$,
+  '22023',
+  'Billing timezone must be a valid IANA timezone name.',
+  'invalid IANA timezones are rejected by the database policy boundary'
+);
+
+insert into public.payments (
+  id,
+  organization_id,
+  user_id,
+  subscription_id,
+  amount,
+  status,
+  created_at
+)
+select
+  '82000000-0000-4000-8000-000000000401'::uuid,
+  '82000000-0000-4000-8000-000000000001'::uuid,
+  '82000000-0000-4000-8000-000000000101'::uuid,
+  s.id,
+  36000,
+  'pending'::public.payment_status_enum,
+  '2027-01-31 12:00:00+00'
+from public.subscriptions s
+where s.organization_id = '82000000-0000-4000-8000-000000000001'::uuid
+  and s.user_id = '82000000-0000-4000-8000-000000000101'::uuid;
+
+select is(
+  (select result
+   from public.reconcile_legacy_payment_obligations(false)
+   where payment_id = '82000000-0000-4000-8000-000000000401'::uuid),
+  'ready',
+  'legacy pending payments produce a reviewed dry-run mapping'
+);
+
+select is(
+  (select result
+   from public.reconcile_legacy_payment_obligations(true)
+   where payment_id = '82000000-0000-4000-8000-000000000401'::uuid),
+  'linked',
+  'only an unambiguous legacy mapping is applied'
+);
+
+select is(
+  (select status
+   from public.payment_obligations
+   where legacy_payment_id = '82000000-0000-4000-8000-000000000401'::uuid),
+  'available'::public.payment_obligation_status_enum,
+  'a pending legacy payment is linked without being falsely settled'
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.role', 'authenticated', true);
+select set_config(
+  'request.jwt.claim.sub',
+  '82000000-0000-4000-8000-000000000101',
+  true
+);
+
+select throws_ok(
+  $$update public.subscriptions
+    set plan_type = 'annual'::public.subscription_plan_type_enum
+    where organization_id = '82000000-0000-4000-8000-000000000001'::uuid
+      and user_id = '82000000-0000-4000-8000-000000000101'::uuid$$,
+  '42501',
+  'permission denied for table subscriptions',
+  'authenticated members cannot mutate the recurring billing source'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/membership_billing_ledger_test.sql
+++ b/supabase/tests/membership_billing_ledger_test.sql
@@ -436,6 +436,7 @@ select set_config(
   '81000000-0000-4000-8000-000000000104',
   true
 );
+set local role postgres;
 
 select is(
   public.get_membership_billing_ledger(
@@ -525,18 +526,57 @@ where id = '81000000-0000-4000-8000-000000000001'::uuid;
 
 update public.subscriptions
 set
-  plan_type = 'annual'::public.subscription_plan_type_enum,
   status = 'active'::public.subscription_status_enum
 where organization_id = '81000000-0000-4000-8000-000000000001'::uuid
   and user_id = '81000000-0000-4000-8000-000000000104'::uuid;
 
+set local role authenticated;
+select set_config(
+  'request.jwt.claim.sub',
+  '81000000-0000-4000-8000-000000000104',
+  true
+);
+
 select is(
-  (select cadence
-   from public.contribution_schedules
+  (
+    public.schedule_contribution_plan_change(
+      (
+        select cs.id
+        from public.contribution_schedules cs
+        where cs.organization_id = '81000000-0000-4000-8000-000000000001'::uuid
+          and cs.user_id = '81000000-0000-4000-8000-000000000104'::uuid
+      ),
+      (
+        select case
+          when candidate_due >= minimum_due then candidate_due
+          else (candidate_due + interval '1 month')::date
+        end
+        from (
+          select
+            (cs.admission_date + interval '1 month')::date as minimum_due,
+            (
+              date_trunc('month', cs.admission_date + interval '1 month')
+              + interval '9 days'
+            )::date as candidate_due
+          from public.contribution_schedules cs
+          where cs.organization_id = '81000000-0000-4000-8000-000000000001'::uuid
+            and cs.user_id = '81000000-0000-4000-8000-000000000104'::uuid
+        ) first_period
+      ),
+      'annual'::public.subscription_plan_type_enum
+    ) is not null
+  ),
+  true,
+  'a future plan change is appended through the effective-dated command'
+);
+
+select is(
+   (select cadence
+    from public.contribution_schedules
    where organization_id = '81000000-0000-4000-8000-000000000001'::uuid
      and user_id = '81000000-0000-4000-8000-000000000104'::uuid),
-  'annual'::public.contribution_cadence_enum,
-  'reactivating a plan synchronizes its Ledger cadence'
+  'monthly'::public.contribution_cadence_enum,
+  'the admission schedule cadence remains an immutable anchor'
 );
 
 select is(
@@ -548,7 +588,7 @@ select is(
    order by cpa.effective_period_start desc
    limit 1),
   'annual'::public.subscription_plan_type_enum,
-  'a plan change updates the effective price snapshot'
+  'a plan change appends the effective price snapshot'
 );
 
 select * from finish();


### PR DESCRIPTION
## Summary

- add server-owned fixed-day monthly and annual obligation generation with organization-local calendar semantics
- preserve immutable admission anchors, effective-dated plan terms, period uniqueness, policy snapshots, and conflict-safe backfill
- keep the production RPC database-clock/service-role only and reduce the Edge Function to a scheduler adapter with no reminder side effects
- add dry-run/apply legacy reconciliation, cron cutover, Ledger/read/claim snapshot behavior, and client write protections
- seed SL.A.C with BRL, America/Sao_Paulo, due day 10, and seven lead days

## Verification

- `supabase test db` — 118 tests passed
- `deno check --no-lock --config supabase/functions/generate-renewal-payments/deno.json supabase/functions/generate-renewal-payments/index.ts`
- `pnpm build` — passed
- `pnpm lint` remains blocked by the repository's existing ESLint 9 config gap in `@chooselife/ui`

Reviewed against the issue contract with a fresh GPT-5.6 Sol/high advisor, including a grilling pass on admission anchors, cadence changes, policy snapshots, reconciliation, and scheduler authority.

Closes #209