### PR TITLE
feat: review recurring contribution payments individually

### DIFF
--- a/next/app/[locale]/admin/_components/billing-workspace-claim-review.tsx
+++ b/next/app/[locale]/admin/_components/billing-workspace-claim-review.tsx
@@ -1,0 +1,354 @@
+"use client";
+
+import {
+  AlertTriangle,
+  CalendarDays,
+  Check,
+  CheckCircle2,
+  Clock3,
+  Loader2,
+  X,
+  XCircle,
+} from "lucide-react";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import type { BillingWorkspaceClaimDetail } from "@/lib/billing-workspace";
+import {
+  formatBillingAmount,
+  formatBillingDate,
+  formatBillingDateTime,
+  jsonArray,
+  planLabel,
+  purposeLabel,
+} from "@/lib/billing-workspace";
+
+import type { ReviewAction } from "../claims/_components/initial-payment-claim-review";
+
+export default function BillingWorkspaceClaimReview({
+  action,
+  actionError,
+  detail,
+  detailLoading,
+  onApprove,
+  onClose,
+  onReject,
+  rejectionReason,
+  onRejectionReasonChange,
+}: {
+  action: ReviewAction;
+  actionError: string | null;
+  detail: BillingWorkspaceClaimDetail | null;
+  detailLoading: boolean;
+  onApprove: () => Promise<void>;
+  onClose: () => void;
+  onReject: () => Promise<void>;
+  rejectionReason: string;
+  onRejectionReasonChange: (value: string) => void;
+}) {
+  const claimHistory = jsonArray(detail?.claim_history);
+  const auditHistory = jsonArray(detail?.audit_history);
+
+  return (
+    <div className="flex max-h-[96vh] flex-col overflow-hidden">
+      <header className="flex items-center justify-between gap-4 border-b px-5 py-5 md:px-7">
+        <div className="min-w-0">
+          <p className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
+            Recurring claim review
+          </p>
+          <h2 className="mt-1 truncate text-xl font-semibold">
+            {detail?.member_name || "Loading member"}
+          </h2>
+          <p className="truncate text-sm text-muted-foreground">
+            {detail?.member_handle || detail?.organization_name || ""}
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={onClose}
+          disabled={action !== null}
+          aria-label="Close review"
+          className="shrink-0 rounded-xl"
+        >
+          <X className="size-5" aria-hidden="true" />
+        </Button>
+      </header>
+
+      <div className="scrollbar overflow-y-auto px-5 py-5 md:px-7 md:py-6">
+        {detailLoading ? (
+          <div className="flex min-h-72 items-center justify-center">
+            <Loader2
+              className="size-7 animate-spin text-muted-foreground"
+              aria-label="Loading claim details"
+            />
+          </div>
+        ) : !detail ? (
+          <div className="flex min-h-72 items-center justify-center">
+            <Alert variant="destructive" className="max-w-lg">
+              <AlertTriangle className="size-4" aria-hidden="true" />
+              <AlertTitle>Review unavailable</AlertTitle>
+              <AlertDescription>
+                {actionError || "Refresh the workspace and try again."}
+              </AlertDescription>
+            </Alert>
+          </div>
+        ) : (
+          <div className="space-y-6">
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge variant="outline">
+                <Clock3 className="mr-1.5 size-3.5" aria-hidden="true" />
+                {detail.claim_status === "under_review"
+                  ? "Awaiting review"
+                  : detail.claim_status}
+              </Badge>
+              <Badge variant="secondary">{purposeLabel(detail.purpose)}</Badge>
+              <Badge variant="secondary">{detail.organization_name}</Badge>
+            </div>
+
+            {actionError ? (
+              <Alert variant="destructive" aria-live="assertive">
+                <AlertTriangle className="size-4" aria-hidden="true" />
+                <AlertTitle>Decision not completed</AlertTitle>
+                <AlertDescription>{actionError}</AlertDescription>
+              </Alert>
+            ) : null}
+
+            <div className="grid gap-3 sm:grid-cols-3">
+              <SummaryCard
+                label="Contribution"
+                value={formatBillingAmount(detail.amount, detail.currency)}
+              />
+              <SummaryCard label="Plan" value={planLabel(detail.plan_type)} />
+              <SummaryCard label="Submitted" value={formatBillingDateTime(detail.claim_created_at)} />
+            </div>
+
+            <section aria-labelledby="recurring-obligation-title">
+              <SectionHeading
+                id="recurring-obligation-title"
+                icon={<CalendarDays className="size-4" aria-hidden="true" />}
+                title="Recurring obligation"
+              />
+              <div className="mt-3 grid gap-x-6 gap-y-4 rounded-2xl border bg-muted/20 p-4 sm:grid-cols-2">
+                <DetailField label="Period">{detail.period_key}</DetailField>
+                <DetailField label="Payer">
+                  {detail.payer_type === "applicant"
+                    ? "Member"
+                    : detail.payer_name || "Other payer"}
+                </DetailField>
+                <DetailField label="Period start">
+                  {formatBillingDate(detail.period_start)}
+                </DetailField>
+                <DetailField label="Period end">
+                  {formatBillingDate(detail.period_end)}
+                </DetailField>
+                <DetailField label="Available on">
+                  {formatBillingDate(detail.available_on)}
+                </DetailField>
+                <DetailField label="Due on">
+                  {formatBillingDate(detail.due_on)}
+                </DetailField>
+                <DetailField label="Claim attempts">
+                  {detail.attempt_count}
+                </DetailField>
+                <DetailField label="Claim submitted">
+                  {formatBillingDateTime(detail.claim_created_at)}
+                </DetailField>
+              </div>
+            </section>
+
+            <section aria-labelledby="recurring-safety-title" className="rounded-2xl border border-primary/20 bg-primary/5 p-4">
+              <h3 id="recurring-safety-title" className="font-semibold">
+                Decision scope
+              </h3>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Approval settles this one obligation and records the reviewer.
+                It never changes legal membership, role, schedule anchors, due
+                dates, plan assignments, or any other obligation.
+              </p>
+            </section>
+
+            {claimHistory.length > 0 || auditHistory.length > 0 ? (
+              <section aria-labelledby="recurring-history-title">
+                <SectionHeading
+                  id="recurring-history-title"
+                  icon={<CalendarDays className="size-4" aria-hidden="true" />}
+                  title="Immutable history"
+                />
+                <div className="mt-3 grid gap-3 rounded-2xl border bg-muted/20 p-4 lg:grid-cols-2">
+                  <HistoryColumn title="Claim states">
+                    {claimHistory.map((history) => (
+                      <div
+                        key={String(history.claim_id)}
+                        className="flex flex-wrap items-center justify-between gap-2 text-sm"
+                      >
+                        <span className="font-medium">{String(history.status)}</span>
+                        <span className="text-muted-foreground">
+                          {formatBillingDateTime(history.created_at)}
+                          {history.decision_reason
+                            ? ` · ${String(history.decision_reason)}`
+                            : ""}
+                        </span>
+                      </div>
+                    ))}
+                  </HistoryColumn>
+                  <HistoryColumn title="Audit events">
+                    {auditHistory.map((history) => (
+                      <div
+                        key={String(history.id)}
+                        className="flex flex-wrap items-center justify-between gap-2 text-sm"
+                      >
+                        <span className="font-medium">
+                          {String(history.previous_state)} → {String(history.next_state)}
+                        </span>
+                        <span className="text-muted-foreground">
+                          {history.actor_name ? `${String(history.actor_name)} · ` : ""}
+                          {formatBillingDateTime(history.created_at)}
+                          {history.reason ? ` · ${String(history.reason)}` : ""}
+                        </span>
+                      </div>
+                    ))}
+                  </HistoryColumn>
+                </div>
+              </section>
+            ) : null}
+          </div>
+        )}
+      </div>
+
+      {detail ? (
+        detail.claim_status !== "under_review" ? (
+          <div className="border-t bg-muted/20 px-5 py-4 md:px-7">
+            <div className="flex items-start gap-3 text-sm text-muted-foreground">
+              {detail.claim_status === "approved" ? (
+                <CheckCircle2
+                  className="mt-0.5 size-5 shrink-0 text-emerald-600"
+                  aria-hidden="true"
+                />
+              ) : (
+                <XCircle
+                  className="mt-0.5 size-5 shrink-0 text-destructive"
+                  aria-hidden="true"
+                />
+              )}
+              <p>
+                This claim is {detail.claim_status}. Its obligation and full
+                chronology remain authoritative.
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="border-t bg-card px-5 py-4 md:px-7">
+            <label htmlFor="recurring-rejection-reason" className="text-sm font-medium">
+              Rejection reason
+              <span className="ml-1 text-destructive" aria-hidden="true">
+                *
+              </span>
+            </label>
+            <Textarea
+              id="recurring-rejection-reason"
+              value={rejectionReason}
+              onChange={(event) => onRejectionReasonChange(event.target.value)}
+              maxLength={500}
+              placeholder="Explain what needs to be corrected."
+              className="mt-2 min-h-20 rounded-xl"
+              disabled={action !== null}
+            />
+            <div className="mt-3 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+              <Button
+                type="button"
+                variant="destructive"
+                onClick={() => void onReject()}
+                disabled={action !== null}
+                className="h-11 rounded-xl px-5 active:scale-[0.96]"
+              >
+                {action === "reject" ? (
+                  <Loader2 className="mr-2 size-4 animate-spin" aria-hidden="true" />
+                ) : (
+                  <XCircle className="mr-2 size-4" aria-hidden="true" />
+                )}
+                Reject recurring claim
+              </Button>
+              <Button
+                type="button"
+                onClick={() => void onApprove()}
+                disabled={action !== null}
+                className="h-11 rounded-xl px-5 active:scale-[0.96]"
+              >
+                {action === "approve" ? (
+                  <Loader2 className="mr-2 size-4 animate-spin" aria-hidden="true" />
+                ) : (
+                  <Check className="mr-2 size-4" aria-hidden="true" />
+                )}
+                Approve recurring contribution
+              </Button>
+            </div>
+          </div>
+        )
+      ) : null}
+    </div>
+  );
+}
+
+function SummaryCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-2xl border bg-card p-4 shadow-sm">
+      <p className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
+        {label}
+      </p>
+      <p className="mt-2 truncate font-semibold tabular-nums">{value}</p>
+    </div>
+  );
+}
+
+function DetailField({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <dt className="text-xs font-medium uppercase tracking-[0.08em] text-muted-foreground">
+        {label}
+      </dt>
+      <dd className="mt-1 font-medium">{children || "—"}</dd>
+    </div>
+  );
+}
+
+function SectionHeading({
+  icon,
+  id,
+  title,
+}: {
+  icon: React.ReactNode;
+  id: string;
+  title: string;
+}) {
+  return (
+    <h3 id={id} className="flex items-center gap-2 font-semibold">
+      {icon}
+      {title}
+    </h3>
+  );
+}
+
+function HistoryColumn({
+  children,
+  title,
+}: {
+  children: React.ReactNode;
+  title: string;
+}) {
+  return (
+    <div className="space-y-2 rounded-xl border bg-background p-3">
+      <h4 className="text-sm font-semibold">{title}</h4>
+      {children}
+    </div>
+  );
+}

--- a/next/app/[locale]/admin/_components/billing-workspace-layout.tsx
+++ b/next/app/[locale]/admin/_components/billing-workspace-layout.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import { AlertTriangle, CheckCircle2, Loader2, RefreshCw } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import type {
+  BillingWorkspaceMemberRow,
+  BillingWorkspaceOrganization,
+  BillingWorkspacePaymentRow,
+  BillingWorkspaceQueueRow,
+  BillingWorkspaceView,
+} from "@/lib/billing-workspace";
+
+import BillingWorkspaceMembers from "./billing-workspace-members";
+import BillingWorkspacePayments from "./billing-workspace-payments";
+import BillingWorkspaceQueue, {
+  WorkspaceHeading,
+} from "./billing-workspace-queue";
+
+type BillingWorkspaceLayoutProps = {
+  organizations: BillingWorkspaceOrganization[];
+  activeOrganizationId: string;
+  view: BillingWorkspaceView;
+  queue: BillingWorkspaceQueueRow[];
+  payments: BillingWorkspacePaymentRow[];
+  members: BillingWorkspaceMemberRow[];
+  workspaceIsPending: boolean;
+  workspaceIsFetching: boolean;
+  workspaceErrorMessage: string | null;
+  workspaceHasLoadedQueue: boolean;
+  reviewOpen: boolean;
+  reviewSurface: ReactNode;
+  onOrganizationChange: (organizationId: string) => void;
+  onViewChange: (view: BillingWorkspaceView) => void;
+  onRefresh: () => void;
+  onOpenClaim: (claim: BillingWorkspaceQueueRow) => void;
+  onCloseReview: () => void;
+};
+
+export default function BillingWorkspaceLayout({
+  organizations,
+  activeOrganizationId,
+  view,
+  queue,
+  payments,
+  members,
+  workspaceIsPending,
+  workspaceIsFetching,
+  workspaceErrorMessage,
+  workspaceHasLoadedQueue,
+  reviewOpen,
+  reviewSurface,
+  onOrganizationChange,
+  onViewChange,
+  onRefresh,
+  onOpenClaim,
+  onCloseReview,
+}: BillingWorkspaceLayoutProps) {
+  const selectedOrganization =
+    organizations.find(
+      (organization) => organization.organization_id === activeOrganizationId,
+    ) ?? organizations[0];
+
+  if (organizations.length === 0) {
+    return (
+      <section className="mx-auto flex min-h-[60vh] max-w-3xl items-center px-4 py-12 md:px-6">
+        <div className="w-full rounded-3xl border bg-card p-8 shadow-sm">
+          <p className="text-sm font-medium uppercase tracking-[0.18em] text-muted-foreground">
+            Association administration
+          </p>
+          <h1 className="mt-3 text-3xl font-semibold tracking-tight">
+            No billing workspace access
+          </h1>
+          <p className="mt-3 text-muted-foreground">
+            An authorized association admin can review payment claims and member
+            financial standing here.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="min-h-[calc(100vh-5rem)] bg-muted/20 px-4 py-8 md:px-6 md:py-12">
+      <div className="mx-auto max-w-7xl">
+        <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <label className="flex items-center gap-3">
+            <span className="text-sm font-medium text-muted-foreground">
+              Association
+            </span>
+            <select
+              value={activeOrganizationId}
+              onChange={(event) => onOrganizationChange(event.target.value)}
+              className="h-11 min-w-64 rounded-xl border border-input bg-background px-3 text-sm shadow-sm outline-none focus:ring-1 focus:ring-ring"
+            >
+              {organizations.map((organization) => (
+                <option
+                  key={organization.organization_id}
+                  value={organization.organization_id}
+                >
+                  {organization.organization_name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <div className="flex items-center gap-3">
+            <Badge variant="outline">
+              {view === "queue"
+                ? `${queue.filter((claim) => claim.claim_status === "under_review").length} awaiting review`
+                : view === "payments"
+                  ? `${payments.length} obligations`
+                  : `${members.length} active members`}
+            </Badge>
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              onClick={onRefresh}
+              disabled={workspaceIsFetching}
+              aria-label="Refresh workspace"
+            >
+              <RefreshCw
+                className={
+                  workspaceIsFetching ? "size-4 animate-spin" : "size-4"
+                }
+                aria-hidden="true"
+              />
+            </Button>
+          </div>
+        </div>
+
+        <div
+          className="mb-6 flex flex-wrap gap-2 rounded-2xl border bg-card p-2"
+          role="tablist"
+          aria-label="Billing workspace views"
+        >
+          {(
+            [
+              ["queue", "Queue"],
+              ["payments", "Payments"],
+              ["members", "Members"],
+            ] as const
+          ).map(([value, label]) => (
+            <button
+              key={value}
+              type="button"
+              role="tab"
+              aria-selected={view === value}
+              onClick={() => onViewChange(value)}
+              className={`rounded-xl px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+                view === value
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:bg-muted hover:text-foreground"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        <WorkspaceHeading
+          view={view}
+          organizationName={
+            selectedOrganization?.organization_name ?? "Association"
+          }
+        />
+
+        {workspaceIsPending ? (
+          <div className="mt-8 flex min-h-72 items-center justify-center rounded-3xl border bg-card">
+            <Loader2
+              className="size-7 animate-spin text-muted-foreground"
+              aria-label="Loading workspace"
+            />
+          </div>
+        ) : workspaceErrorMessage ? (
+          <Alert variant="destructive" className="mt-8">
+            <AlertTriangle className="size-4" aria-hidden="true" />
+            <AlertTitle>Workspace unavailable</AlertTitle>
+            <AlertDescription>
+              {workspaceErrorMessage} Try refreshing the workspace.
+            </AlertDescription>
+          </Alert>
+        ) : (
+          <div className="mt-8">
+            {view === "queue" ? (
+              <BillingWorkspaceQueue
+                key={activeOrganizationId}
+                claims={queue}
+                onOpenClaim={onOpenClaim}
+              />
+            ) : view === "payments" ? (
+              <BillingWorkspacePayments
+                key={activeOrganizationId}
+                payments={payments}
+              />
+            ) : (
+              <BillingWorkspaceMembers
+                key={activeOrganizationId}
+                members={members}
+              />
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="hidden md:block">
+        <Dialog
+          open={reviewOpen}
+          onOpenChange={(open) => {
+            if (!open) onCloseReview();
+          }}
+        >
+          <DialogContent className="max-h-[90vh] max-w-3xl overflow-hidden rounded-3xl p-0">
+            <DialogHeader className="sr-only">
+              <DialogTitle>Review payment claim</DialogTitle>
+              <DialogDescription>
+                Inspect the authoritative obligation and decide this claim.
+              </DialogDescription>
+            </DialogHeader>
+            {reviewSurface}
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      <div className="md:hidden">
+        <Drawer
+          open={reviewOpen}
+          onOpenChange={(open) => {
+            if (!open) onCloseReview();
+          }}
+        >
+          <DrawerContent className="max-h-[96vh] overflow-hidden rounded-t-3xl p-0">
+            <DrawerHeader className="sr-only">
+              <DrawerTitle>Review payment claim</DrawerTitle>
+              <DrawerDescription>
+                Inspect the authoritative obligation and decide this claim.
+              </DrawerDescription>
+            </DrawerHeader>
+            {reviewSurface}
+          </DrawerContent>
+        </Drawer>
+      </div>
+
+      {workspaceHasLoadedQueue ? (
+        <div className="sr-only" aria-live="polite">
+          <CheckCircle2 aria-hidden="true" />
+          Workspace loaded with {queue.length} claims.
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/next/app/[locale]/admin/_components/billing-workspace-members.tsx
+++ b/next/app/[locale]/admin/_components/billing-workspace-members.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { Search } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import type { BillingWorkspaceMemberRow } from "@/lib/billing-workspace";
+import {
+  formatBillingDate,
+  formatBillingDateTime,
+  paymentStateLabel,
+  planLabel,
+} from "@/lib/billing-workspace";
+
+import { ApplicantAvatar } from "../claims/_components/initial-payment-claim-review";
+
+type MemberStateFilter =
+  | "all"
+  | "overdue"
+  | "payment_available"
+  | "under_review"
+  | "up_to_date";
+
+function stateVariant(state: string) {
+  if (state === "overdue") return "destructive" as const;
+  if (state === "up_to_date") return "secondary" as const;
+  return "outline" as const;
+}
+
+export default function BillingWorkspaceMembers({
+  members,
+}: {
+  members: BillingWorkspaceMemberRow[];
+}) {
+  const [search, setSearch] = useState("");
+  const [stateFilter, setStateFilter] = useState<MemberStateFilter>("all");
+
+  const visibleMembers = useMemo(() => {
+    const normalizedSearch = search.trim().toLowerCase();
+
+    return members.filter((member) => {
+      if (
+        stateFilter !== "all" &&
+        member.financial_standing !== stateFilter
+      ) {
+        return false;
+      }
+
+      if (!normalizedSearch) return true;
+
+      return [member.member_name, member.member_handle, member.plan_type]
+        .filter(Boolean)
+        .some((value) => value!.toLowerCase().includes(normalizedSearch));
+    });
+  }, [members, search, stateFilter]);
+
+  return (
+    <Card className="overflow-hidden rounded-3xl border-0 shadow-[0_20px_70px_-40px_hsl(var(--foreground)/0.45)]">
+      <CardHeader className="border-b bg-card/80 pb-5">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <CardTitle>Members</CardTitle>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Active legal roster with financial standing derived from the billing ledger.
+            </p>
+          </div>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <label className="relative block min-w-0 sm:w-64">
+              <span className="sr-only">Search members</span>
+              <Search
+                className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+                aria-hidden="true"
+              />
+              <Input
+                type="search"
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                placeholder="Search members"
+                className="h-11 rounded-xl pl-9"
+              />
+            </label>
+            <label>
+              <span className="sr-only">Filter member financial standing</span>
+              <select
+                value={stateFilter}
+                onChange={(event) =>
+                  setStateFilter(event.target.value as MemberStateFilter)
+                }
+                className="h-11 min-w-44 rounded-xl border border-input bg-background px-3 text-sm shadow-sm outline-none focus:ring-1 focus:ring-ring"
+              >
+                <option value="all">All standings</option>
+                <option value="overdue">Overdue</option>
+                <option value="payment_available">Payment available</option>
+                <option value="under_review">Under review</option>
+                <option value="up_to_date">Up to date</option>
+              </select>
+            </label>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="p-4 md:p-6">
+        {visibleMembers.length === 0 ? (
+          <div className="flex min-h-64 items-center justify-center rounded-2xl border border-dashed px-6 text-center text-sm text-muted-foreground">
+            {members.length === 0
+              ? "No active members are available for this association."
+              : "No members match these filters."}
+          </div>
+        ) : (
+          <div className="grid gap-3 xl:grid-cols-2">
+            {visibleMembers.map((member) => (
+              <article
+                key={member.member_user_id}
+                className="rounded-2xl border bg-card p-4 md:p-5"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex min-w-0 items-center gap-3">
+                    <ApplicantAvatar
+                      name={member.member_name}
+                      handle={member.member_handle}
+                      picture={member.member_profile_picture}
+                      size="sm"
+                    />
+                    <div className="min-w-0">
+                      <h2 className="truncate font-semibold">
+                        {member.member_name || "Unnamed member"}
+                      </h2>
+                      <p className="truncate text-sm text-muted-foreground">
+                        {member.member_handle || "No handle"} · {member.member_role}
+                      </p>
+                    </div>
+                  </div>
+                  <Badge variant={stateVariant(member.financial_standing)}>
+                    {paymentStateLabel(member.financial_standing)}
+                  </Badge>
+                </div>
+
+                <dl className="mt-5 grid gap-x-4 gap-y-4 text-sm sm:grid-cols-2">
+                  <div>
+                    <dt className="text-muted-foreground">Plan</dt>
+                    <dd className="mt-1 font-medium">{planLabel(member.plan_type)}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-muted-foreground">Overdue obligations</dt>
+                    <dd className="mt-1 font-medium tabular-nums">
+                      {member.overdue_count}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-muted-foreground">Oldest attention</dt>
+                    <dd className="mt-1 font-medium">
+                      {formatBillingDate(member.oldest_attention_due_on)}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-muted-foreground">Next due</dt>
+                    <dd className="mt-1 font-medium">
+                      {formatBillingDate(member.next_due_on)}
+                    </dd>
+                  </div>
+                  <div className="sm:col-span-2">
+                    <dt className="text-muted-foreground">Last verified contribution</dt>
+                    <dd className="mt-1 font-medium">
+                      {formatBillingDateTime(member.last_verified_contribution_at)}
+                    </dd>
+                  </div>
+                </dl>
+              </article>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/next/app/[locale]/admin/_components/billing-workspace-payments.tsx
+++ b/next/app/[locale]/admin/_components/billing-workspace-payments.tsx
@@ -34,6 +34,25 @@ function stateVariant(state: string) {
   return "outline" as const;
 }
 
+function historyEntryKey(
+  title: string,
+  entry: ReturnType<typeof jsonArray>[number],
+) {
+  return (
+    entry.id ??
+    entry.claim_id ??
+    [
+      title,
+      entry.created_at,
+      entry.status,
+      entry.previous_state,
+      entry.next_state,
+      entry.reason,
+      entry.decision_reason,
+    ].join("|")
+  );
+}
+
 export default function BillingWorkspacePayments({
   payments,
 }: {
@@ -41,9 +60,8 @@ export default function BillingWorkspacePayments({
 }) {
   const [search, setSearch] = useState("");
   const [stateFilter, setStateFilter] = useState<PaymentStateFilter>("all");
-  const [purposeFilter, setPurposeFilter] = useState<PaymentPurposeFilter>(
-    "all",
-  );
+  const [purposeFilter, setPurposeFilter] =
+    useState<PaymentPurposeFilter>("all");
 
   const visiblePayments = useMemo(() => {
     const normalizedSearch = search.trim().toLowerCase();
@@ -153,10 +171,14 @@ export default function BillingWorkspacePayments({
                 <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
                   <div className="min-w-0">
                     <div className="flex flex-wrap items-center gap-2">
-                      <Badge variant={stateVariant(payment.effective_payment_state)}>
+                      <Badge
+                        variant={stateVariant(payment.effective_payment_state)}
+                      >
                         {paymentStateLabel(payment.effective_payment_state)}
                       </Badge>
-                      <Badge variant="outline">{purposeLabel(payment.purpose)}</Badge>
+                      <Badge variant="outline">
+                        {purposeLabel(payment.purpose)}
+                      </Badge>
                       <span className="text-xs text-muted-foreground">
                         {payment.period_key}
                       </span>
@@ -165,7 +187,8 @@ export default function BillingWorkspacePayments({
                       {payment.member_name || "Unnamed member"}
                     </h2>
                     <p className="text-sm text-muted-foreground">
-                      {payment.member_handle || "No handle"} · {planLabel(payment.plan_type)}
+                      {payment.member_handle || "No handle"} ·{" "}
+                      {planLabel(payment.plan_type)}
                     </p>
                   </div>
                   <div className="text-left lg:text-right">
@@ -182,7 +205,8 @@ export default function BillingWorkspacePayments({
                   <div>
                     <dt className="text-muted-foreground">Period</dt>
                     <dd className="mt-1 font-medium">
-                      {formatBillingDate(payment.period_start)} — {formatBillingDate(payment.period_end)}
+                      {formatBillingDate(payment.period_start)} —{" "}
+                      {formatBillingDate(payment.period_end)}
                     </dd>
                   </div>
                   <div>
@@ -194,7 +218,9 @@ export default function BillingWorkspacePayments({
                     </dd>
                   </div>
                   <div>
-                    <dt className="text-muted-foreground">Last decision actor</dt>
+                    <dt className="text-muted-foreground">
+                      Last decision actor
+                    </dt>
                     <dd className="mt-1 font-medium">
                       {payment.last_decision_actor_name || "—"}
                     </dd>
@@ -216,7 +242,8 @@ export default function BillingWorkspacePayments({
                 <details className="mt-4 rounded-xl border bg-muted/20 px-3 py-2 text-sm">
                   <summary className="cursor-pointer font-medium">
                     View claim and decision history ({claims.length} claim
-                    {claims.length === 1 ? "" : "s"}, {audits.length} audit event
+                    {claims.length === 1 ? "" : "s"}, {audits.length} audit
+                    event
                     {audits.length === 1 ? "" : "s"})
                   </summary>
                   <div className="mt-3 grid gap-4 lg:grid-cols-2">
@@ -247,8 +274,11 @@ function HistoryList({
         <p className="mt-2 text-muted-foreground">No history yet.</p>
       ) : (
         <ol className="mt-2 space-y-2">
-          {entries.map((entry, index) => (
-            <li key={entry.id || entry.claim_id || index} className="rounded-lg border bg-background p-3">
+          {entries.map((entry) => (
+            <li
+              key={historyEntryKey(title, entry)}
+              className="rounded-lg border bg-background p-3"
+            >
               <div className="flex flex-wrap items-center justify-between gap-2">
                 <span className="font-medium">
                   {entry.status ||

--- a/next/app/[locale]/admin/_components/billing-workspace-payments.tsx
+++ b/next/app/[locale]/admin/_components/billing-workspace-payments.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import { Search } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import type { BillingWorkspacePaymentRow } from "@/lib/billing-workspace";
+import {
+  formatBillingAmount,
+  formatBillingDate,
+  formatBillingDateTime,
+  jsonArray,
+  paymentStateLabel,
+  planLabel,
+  purposeLabel,
+} from "@/lib/billing-workspace";
+
+type PaymentStateFilter =
+  | "all"
+  | "scheduled"
+  | "available"
+  | "under_review"
+  | "overdue"
+  | "settled"
+  | "void";
+type PaymentPurposeFilter = "all" | BillingWorkspacePaymentRow["purpose"];
+
+function stateVariant(state: string) {
+  if (state === "overdue") return "destructive" as const;
+  if (state === "settled") return "secondary" as const;
+  if (state === "under_review") return "default" as const;
+  return "outline" as const;
+}
+
+export default function BillingWorkspacePayments({
+  payments,
+}: {
+  payments: BillingWorkspacePaymentRow[];
+}) {
+  const [search, setSearch] = useState("");
+  const [stateFilter, setStateFilter] = useState<PaymentStateFilter>("all");
+  const [purposeFilter, setPurposeFilter] = useState<PaymentPurposeFilter>(
+    "all",
+  );
+
+  const visiblePayments = useMemo(() => {
+    const normalizedSearch = search.trim().toLowerCase();
+
+    return payments.filter((payment) => {
+      if (
+        stateFilter !== "all" &&
+        payment.effective_payment_state !== stateFilter
+      ) {
+        return false;
+      }
+
+      if (purposeFilter !== "all" && payment.purpose !== purposeFilter) {
+        return false;
+      }
+
+      if (!normalizedSearch) return true;
+
+      return [
+        payment.member_name,
+        payment.member_handle,
+        payment.period_key,
+        payment.latest_claim_decision_reason,
+      ]
+        .filter(Boolean)
+        .some((value) => value!.toLowerCase().includes(normalizedSearch));
+    });
+  }, [payments, purposeFilter, search, stateFilter]);
+
+  return (
+    <Card className="overflow-hidden rounded-3xl border-0 shadow-[0_20px_70px_-40px_hsl(var(--foreground)/0.45)]">
+      <CardHeader className="border-b bg-card/80 pb-5">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <CardTitle>Payments</CardTitle>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Private obligation history scoped to this association.
+            </p>
+          </div>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <label className="relative block min-w-0 sm:w-64">
+              <span className="sr-only">Search payments</span>
+              <Search
+                className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+                aria-hidden="true"
+              />
+              <Input
+                type="search"
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                placeholder="Search member or period"
+                className="h-11 rounded-xl pl-9"
+              />
+            </label>
+            <label>
+              <span className="sr-only">Filter payment state</span>
+              <select
+                value={stateFilter}
+                onChange={(event) =>
+                  setStateFilter(event.target.value as PaymentStateFilter)
+                }
+                className="h-11 min-w-40 rounded-xl border border-input bg-background px-3 text-sm shadow-sm outline-none focus:ring-1 focus:ring-ring"
+              >
+                <option value="all">All payment states</option>
+                <option value="under_review">Under review</option>
+                <option value="available">Available</option>
+                <option value="overdue">Overdue</option>
+                <option value="scheduled">Scheduled</option>
+                <option value="settled">Settled</option>
+                <option value="void">Void</option>
+              </select>
+            </label>
+            <label>
+              <span className="sr-only">Filter payment purpose</span>
+              <select
+                value={purposeFilter}
+                onChange={(event) =>
+                  setPurposeFilter(event.target.value as PaymentPurposeFilter)
+                }
+                className="h-11 min-w-44 rounded-xl border border-input bg-background px-3 text-sm shadow-sm outline-none focus:ring-1 focus:ring-ring"
+              >
+                <option value="all">All purposes</option>
+                <option value="initial_admission">Initial admission</option>
+                <option value="recurring">Recurring contribution</option>
+              </select>
+            </label>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3 p-4 md:p-6">
+        {visiblePayments.length === 0 ? (
+          <div className="flex min-h-64 items-center justify-center rounded-2xl border border-dashed px-6 text-center text-sm text-muted-foreground">
+            {payments.length === 0
+              ? "No payment obligations are available for this association."
+              : "No payment obligations match these filters."}
+          </div>
+        ) : (
+          visiblePayments.map((payment) => {
+            const claims = jsonArray(payment.claim_history);
+            const audits = jsonArray(payment.audit_history);
+
+            return (
+              <article
+                key={payment.obligation_id}
+                className="rounded-2xl border bg-card p-4 md:p-5"
+              >
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge variant={stateVariant(payment.effective_payment_state)}>
+                        {paymentStateLabel(payment.effective_payment_state)}
+                      </Badge>
+                      <Badge variant="outline">{purposeLabel(payment.purpose)}</Badge>
+                      <span className="text-xs text-muted-foreground">
+                        {payment.period_key}
+                      </span>
+                    </div>
+                    <h2 className="mt-3 truncate text-lg font-semibold">
+                      {payment.member_name || "Unnamed member"}
+                    </h2>
+                    <p className="text-sm text-muted-foreground">
+                      {payment.member_handle || "No handle"} · {planLabel(payment.plan_type)}
+                    </p>
+                  </div>
+                  <div className="text-left lg:text-right">
+                    <p className="text-xl font-semibold tabular-nums">
+                      {formatBillingAmount(payment.amount, payment.currency)}
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      Due {formatBillingDate(payment.due_on)}
+                    </p>
+                  </div>
+                </div>
+
+                <dl className="mt-5 grid gap-4 text-sm sm:grid-cols-2 lg:grid-cols-4">
+                  <div>
+                    <dt className="text-muted-foreground">Period</dt>
+                    <dd className="mt-1 font-medium">
+                      {formatBillingDate(payment.period_start)} — {formatBillingDate(payment.period_end)}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-muted-foreground">Latest claim</dt>
+                    <dd className="mt-1 font-medium">
+                      {payment.latest_claim_status
+                        ? paymentStateLabel(payment.latest_claim_status)
+                        : "No claim"}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-muted-foreground">Last decision actor</dt>
+                    <dd className="mt-1 font-medium">
+                      {payment.last_decision_actor_name || "—"}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-muted-foreground">Last decision</dt>
+                    <dd className="mt-1 font-medium">
+                      {formatBillingDateTime(payment.last_decision_at)}
+                    </dd>
+                  </div>
+                </dl>
+
+                {payment.latest_claim_decision_reason ? (
+                  <p className="mt-4 rounded-xl bg-muted/50 px-3 py-2 text-sm text-muted-foreground">
+                    Reason: {payment.latest_claim_decision_reason}
+                  </p>
+                ) : null}
+
+                <details className="mt-4 rounded-xl border bg-muted/20 px-3 py-2 text-sm">
+                  <summary className="cursor-pointer font-medium">
+                    View claim and decision history ({claims.length} claim
+                    {claims.length === 1 ? "" : "s"}, {audits.length} audit event
+                    {audits.length === 1 ? "" : "s"})
+                  </summary>
+                  <div className="mt-3 grid gap-4 lg:grid-cols-2">
+                    <HistoryList title="Claims" entries={claims} />
+                    <HistoryList title="Decisions" entries={audits} />
+                  </div>
+                </details>
+              </article>
+            );
+          })
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function HistoryList({
+  title,
+  entries,
+}: {
+  title: string;
+  entries: ReturnType<typeof jsonArray>;
+}) {
+  return (
+    <div>
+      <h3 className="font-medium">{title}</h3>
+      {entries.length === 0 ? (
+        <p className="mt-2 text-muted-foreground">No history yet.</p>
+      ) : (
+        <ol className="mt-2 space-y-2">
+          {entries.map((entry, index) => (
+            <li key={entry.id || entry.claim_id || index} className="rounded-lg border bg-background p-3">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <span className="font-medium">
+                  {entry.status ||
+                    `${entry.previous_state || ""} → ${entry.next_state || ""}`}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {formatBillingDateTime(entry.created_at)}
+                </span>
+              </div>
+              {entry.actor_name ? (
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Actor: {entry.actor_name}
+                </p>
+              ) : null}
+              {entry.reason || entry.decision_reason ? (
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {entry.reason || entry.decision_reason}
+                </p>
+              ) : null}
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}

--- a/next/app/[locale]/admin/_components/billing-workspace-queue.tsx
+++ b/next/app/[locale]/admin/_components/billing-workspace-queue.tsx
@@ -1,0 +1,302 @@
+"use client";
+
+import { CheckCircle2, ChevronRight, Search, ShieldCheck } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import type {
+  BillingWorkspaceQueueRow,
+  BillingWorkspaceView,
+} from "@/lib/billing-workspace";
+import {
+  formatBillingAmount,
+  formatBillingDate,
+  formatBillingDateTime,
+  planLabel,
+  purposeLabel,
+} from "@/lib/billing-workspace";
+
+import { ApplicantAvatar } from "../claims/_components/initial-payment-claim-review";
+
+type QueueStatusFilter = "all" | "under_review" | "approved" | "rejected";
+type QueuePurposeFilter = "all" | BillingWorkspaceQueueRow["purpose"];
+type QueueSort = "oldest" | "newest" | "amount" | "member";
+
+function statusLabel(status: QueueStatusFilter) {
+  if (status === "all") return "All claim states";
+  if (status === "under_review") return "Awaiting review";
+  return status.charAt(0).toUpperCase() + status.slice(1);
+}
+
+function statusVariant(status: BillingWorkspaceQueueRow["claim_status"]) {
+  if (status === "under_review") return "default" as const;
+  if (status === "approved") return "secondary" as const;
+  return "outline" as const;
+}
+
+function ClaimStatusBadge({
+  status,
+}: {
+  status: BillingWorkspaceQueueRow["claim_status"];
+}) {
+  return <Badge variant={statusVariant(status)}>{statusLabel(status)}</Badge>;
+}
+
+export default function BillingWorkspaceQueue({
+  claims,
+  onOpenClaim,
+}: {
+  claims: BillingWorkspaceQueueRow[];
+  onOpenClaim: (claim: BillingWorkspaceQueueRow) => void;
+}) {
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState<QueueStatusFilter>(
+    "under_review",
+  );
+  const [purposeFilter, setPurposeFilter] = useState<QueuePurposeFilter>(
+    "all",
+  );
+  const [sort, setSort] = useState<QueueSort>("oldest");
+
+  const visibleClaims = useMemo(() => {
+    const normalizedSearch = search.trim().toLowerCase();
+    const filteredClaims = claims.filter((claim) => {
+      if (
+        statusFilter !== "all" &&
+        claim.claim_status !== statusFilter
+      ) {
+        return false;
+      }
+
+      if (purposeFilter !== "all" && claim.purpose !== purposeFilter) {
+        return false;
+      }
+
+      if (!normalizedSearch) return true;
+
+      return [
+        claim.member_name,
+        claim.member_handle,
+        claim.payer_name,
+        claim.period_key,
+      ]
+        .filter(Boolean)
+        .some((value) => value!.toLowerCase().includes(normalizedSearch));
+    });
+
+    return [...filteredClaims].sort((left, right) => {
+      if (sort === "amount") return right.amount - left.amount;
+      if (sort === "member") {
+        return (left.member_name || left.member_handle || "").localeCompare(
+          right.member_name || right.member_handle || "",
+        );
+      }
+
+      const leftDate = new Date(left.claim_created_at).getTime();
+      const rightDate = new Date(right.claim_created_at).getTime();
+      return sort === "newest" ? rightDate - leftDate : leftDate - rightDate;
+    });
+  }, [claims, purposeFilter, search, sort, statusFilter]);
+
+  return (
+    <Card className="overflow-hidden rounded-3xl border-0 shadow-[0_20px_70px_-40px_hsl(var(--foreground)/0.45)]">
+      <CardHeader className="border-b bg-card/80 pb-5">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <CardTitle>Review queue</CardTitle>
+            <CardDescription className="mt-1">
+              Initial and recurring claims from this association. Terminal
+              history stays available in the filter; only under-review claims
+              expose a decision action.
+            </CardDescription>
+          </div>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <label className="relative block min-w-0 sm:w-64">
+              <span className="sr-only">Search claims</span>
+              <Search
+                className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+                aria-hidden="true"
+              />
+              <Input
+                type="search"
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                placeholder="Search member or payer"
+                className="h-11 rounded-xl pl-9"
+              />
+            </label>
+            <label>
+              <span className="sr-only">Filter claim state</span>
+              <select
+                value={statusFilter}
+                onChange={(event) =>
+                  setStatusFilter(event.target.value as QueueStatusFilter)
+                }
+                className="h-11 min-w-40 rounded-xl border border-input bg-background px-3 text-sm shadow-sm outline-none focus:ring-1 focus:ring-ring"
+              >
+                <option value="under_review">{statusLabel("under_review")}</option>
+                <option value="all">{statusLabel("all")}</option>
+                <option value="approved">{statusLabel("approved")}</option>
+                <option value="rejected">{statusLabel("rejected")}</option>
+              </select>
+            </label>
+            <label>
+              <span className="sr-only">Filter claim purpose</span>
+              <select
+                value={purposeFilter}
+                onChange={(event) =>
+                  setPurposeFilter(event.target.value as QueuePurposeFilter)
+                }
+                className="h-11 min-w-44 rounded-xl border border-input bg-background px-3 text-sm shadow-sm outline-none focus:ring-1 focus:ring-ring"
+              >
+                <option value="all">All purposes</option>
+                <option value="initial_admission">Initial admission</option>
+                <option value="recurring">Recurring contribution</option>
+              </select>
+            </label>
+            <label>
+              <span className="sr-only">Sort claims</span>
+              <select
+                value={sort}
+                onChange={(event) => setSort(event.target.value as QueueSort)}
+                className="h-11 min-w-36 rounded-xl border border-input bg-background px-3 text-sm shadow-sm outline-none focus:ring-1 focus:ring-ring"
+              >
+                <option value="oldest">Oldest first</option>
+                <option value="newest">Newest first</option>
+                <option value="amount">Highest amount</option>
+                <option value="member">Member name</option>
+              </select>
+            </label>
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent className="p-0">
+        {visibleClaims.length === 0 ? (
+          <div className="flex min-h-72 flex-col items-center justify-center px-6 py-16 text-center">
+            <span className="flex size-14 items-center justify-center rounded-full bg-emerald-500/10 text-emerald-600 dark:text-emerald-400">
+              <CheckCircle2 className="size-7" aria-hidden="true" />
+            </span>
+            <h2 className="mt-5 text-xl font-semibold">
+              {claims.length === 0 ? "The queue is clear" : "No claims match these filters"}
+            </h2>
+            <p className="mt-2 max-w-md text-sm text-muted-foreground">
+              {claims.length === 0
+                ? "New member claims will appear here when an association member submits one."
+                : "Try clearing the search or changing the claim state and purpose filters."}
+            </p>
+          </div>
+        ) : (
+          <ul aria-label="Billing claim queue" className="list-none p-0">
+            {visibleClaims.map((claim) => (
+              <li key={claim.claim_id}>
+                <button
+                  type="button"
+                  onClick={() => onOpenClaim(claim)}
+                  className="group grid w-full grid-cols-[auto_1fr_auto] items-center gap-4 px-5 py-4 text-left transition-[background-color,transform] duration-200 hover:bg-muted/40 focus-visible:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring active:scale-[0.996] md:grid-cols-[minmax(14rem,1.7fr)_minmax(11rem,1fr)_minmax(8rem,0.8fr)_minmax(8rem,0.7fr)_auto] md:px-6"
+                >
+                  <div className="flex min-w-0 items-center gap-3">
+                    <ApplicantAvatar
+                      name={claim.member_name}
+                      handle={claim.member_handle}
+                      picture={claim.member_profile_picture}
+                      size="sm"
+                    />
+                    <div className="min-w-0">
+                      <p className="truncate font-semibold">
+                        {claim.member_name || "Unnamed member"}
+                      </p>
+                      <p className="truncate text-sm text-muted-foreground">
+                        {claim.member_handle || "No handle"}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="hidden min-w-0 md:block">
+                    <p className="truncate text-sm font-medium">
+                      {purposeLabel(claim.purpose)}
+                    </p>
+                    <p className="truncate text-xs text-muted-foreground">
+                      {claim.period_key || planLabel(claim.plan_type)}
+                    </p>
+                  </div>
+                  <div className="hidden md:block">
+                    <p className="font-semibold tabular-nums">
+                      {formatBillingAmount(claim.amount, claim.currency)}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {formatBillingDate(claim.due_on)} due
+                    </p>
+                  </div>
+                  <div className="hidden md:block">
+                    <p className="text-sm font-medium">
+                      {claim.payer_type === "applicant"
+                        ? "Member"
+                        : claim.payer_name || "Other payer"}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {formatBillingDateTime(claim.claim_created_at)}
+                    </p>
+                  </div>
+                  <div className="flex items-center justify-end gap-3">
+                    <ClaimStatusBadge status={claim.claim_status} />
+                    <ChevronRight
+                      className="size-5 text-muted-foreground transition-transform duration-200 group-hover:translate-x-0.5"
+                      aria-hidden="true"
+                    />
+                  </div>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function WorkspaceHeading({
+  view,
+  organizationName,
+}: {
+  view: BillingWorkspaceView;
+  organizationName: string;
+}) {
+  const copy = {
+    queue: {
+      title: "Review payments one at a time",
+      description:
+        "Keep each payment decision tied to one immutable obligation and its complete claim history.",
+    },
+    payments: {
+      title: "Payment history",
+      description:
+        "See the obligation, period, claim, decision, actor, and audit chronology for this association.",
+    },
+    members: {
+      title: "Member financial standing",
+      description:
+        "Legal membership stays active while financial standing is derived from each obligation.",
+    },
+  }[view];
+
+  return (
+    <div className="flex flex-col gap-5 md:flex-row md:items-end md:justify-between">
+      <div>
+        <div className="flex items-center gap-2 text-sm font-medium uppercase tracking-[0.18em] text-muted-foreground">
+          <ShieldCheck className="size-4" aria-hidden="true" />
+          {organizationName}
+        </div>
+        <h1 className="mt-3 text-4xl font-semibold tracking-tight">{copy.title}</h1>
+        <p className="mt-3 max-w-2xl text-muted-foreground">{copy.description}</p>
+      </div>
+    </div>
+  );
+}

--- a/next/app/[locale]/admin/_components/billing-workspace.tsx
+++ b/next/app/[locale]/admin/_components/billing-workspace.tsx
@@ -1,30 +1,8 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { AlertTriangle, CheckCircle2, Loader2, RefreshCw } from "lucide-react";
 import { useState } from "react";
 
-import {
-  Alert,
-  AlertDescription,
-  AlertTitle,
-} from "@/components/ui/alert";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import {
-  Drawer,
-  DrawerContent,
-  DrawerDescription,
-  DrawerHeader,
-  DrawerTitle,
-} from "@/components/ui/drawer";
 import { useRouter } from "@/i18n/navigation";
 import type {
   BillingWorkspaceClaimDetail,
@@ -42,11 +20,7 @@ import {
   type ReviewAction,
 } from "../claims/_components/initial-payment-claim-review";
 import BillingWorkspaceClaimReview from "./billing-workspace-claim-review";
-import BillingWorkspaceMembers from "./billing-workspace-members";
-import BillingWorkspacePayments from "./billing-workspace-payments";
-import BillingWorkspaceQueue, {
-  WorkspaceHeading,
-} from "./billing-workspace-queue";
+import BillingWorkspaceLayout from "./billing-workspace-layout";
 
 type RpcError = {
   code?: string;
@@ -99,9 +73,12 @@ async function fetchWorkspaceData(
   }
 
   if (view === "payments") {
-    const { data, error } = await supabase.rpc("get_billing_workspace_payments", {
-      p_organization_id: organizationId,
-    });
+    const { data, error } = await supabase.rpc(
+      "get_billing_workspace_payments",
+      {
+        p_organization_id: organizationId,
+      },
+    );
     if (error) throw error;
     return data ?? [];
   }
@@ -130,8 +107,9 @@ export default function BillingWorkspace({
   const [actionError, setActionError] = useState<string | null>(null);
 
   const selectedOrganization =
-    organizations.find((organization) => organization.organization_id === organizationId) ??
-    organizations[0];
+    organizations.find(
+      (organization) => organization.organization_id === organizationId,
+    ) ?? organizations[0];
   const activeOrganizationId = selectedOrganization?.organization_id ?? "";
 
   const workspaceQuery = useQuery<WorkspaceData, RpcError>({
@@ -151,9 +129,7 @@ export default function BillingWorkspace({
           { p_claim_id: selectedClaim.claim_id },
         );
         if (error) throw error;
-        return data?.[0]
-          ? { kind: "initial", detail: data[0] }
-          : null;
+        return data?.[0] ? { kind: "initial", detail: data[0] } : null;
       }
 
       const { data, error } = await supabase.rpc(
@@ -161,9 +137,7 @@ export default function BillingWorkspace({
         { p_claim_id: selectedClaim.claim_id },
       );
       if (error) throw error;
-      return data?.[0]
-        ? { kind: "recurring", detail: data[0] }
-        : null;
+      return data?.[0] ? { kind: "recurring", detail: data[0] } : null;
     },
     enabled: selectedClaim !== null,
   });
@@ -176,7 +150,8 @@ export default function BillingWorkspace({
       if (!rpcName) {
         throw {
           code: "40001",
-          message: "This claim is no longer actionable. Refresh before deciding.",
+          message:
+            "This claim is no longer actionable. Refresh before deciding.",
         } satisfies RpcError;
       }
 
@@ -235,28 +210,12 @@ export default function BillingWorkspace({
     },
   });
 
-  if (organizations.length === 0) {
-    return (
-      <section className="mx-auto flex min-h-[60vh] max-w-3xl items-center px-4 py-12 md:px-6">
-        <div className="w-full rounded-3xl border bg-card p-8 shadow-sm">
-          <p className="text-sm font-medium uppercase tracking-[0.18em] text-muted-foreground">
-            Association administration
-          </p>
-          <h1 className="mt-3 text-3xl font-semibold tracking-tight">
-            No billing workspace access
-          </h1>
-          <p className="mt-3 text-muted-foreground">
-            An authorized association admin can review payment claims and member financial standing here.
-          </p>
-        </div>
-      </section>
-    );
-  }
-
   const data = workspaceQuery.data ?? [];
   const queue = view === "queue" ? (data as BillingWorkspaceQueueRow[]) : [];
-  const payments = view === "payments" ? (data as BillingWorkspacePaymentRow[]) : [];
-  const members = view === "members" ? (data as BillingWorkspaceMemberRow[]) : [];
+  const payments =
+    view === "payments" ? (data as BillingWorkspacePaymentRow[]) : [];
+  const members =
+    view === "members" ? (data as BillingWorkspaceMemberRow[]) : [];
 
   const openClaim = (claim: BillingWorkspaceQueueRow) => {
     setActionError(null);
@@ -269,6 +228,18 @@ export default function BillingWorkspace({
     setSelectedClaim(null);
     setActionError(null);
     setRejectionReason("");
+  };
+
+  const handleOrganizationChange = (nextOrganizationId: string) => {
+    setOrganizationId(nextOrganizationId);
+    setSelectedClaim(null);
+    setActionError(null);
+  };
+
+  const handleViewChange = (nextView: BillingWorkspaceView) => {
+    setView(nextView);
+    setSelectedClaim(null);
+    setActionError(null);
   };
 
   const handleApprove = async () => {
@@ -292,11 +263,18 @@ export default function BillingWorkspace({
   const reviewSurface =
     selectedClaim?.purpose === "initial_admission" ? (
       <InitialPaymentClaimReview
-        action={decisionMutation.isPending ? decisionMutation.variables?.action ?? null : null}
-        actionError={
-          actionError || (detailQuery.error ? getRpcErrorMessage(detailQuery.error) : null)
+        action={
+          decisionMutation.isPending
+            ? (decisionMutation.variables?.action ?? null)
+            : null
         }
-        detail={detailQuery.data?.kind === "initial" ? detailQuery.data.detail : null}
+        actionError={
+          actionError ||
+          (detailQuery.error ? getRpcErrorMessage(detailQuery.error) : null)
+        }
+        detail={
+          detailQuery.data?.kind === "initial" ? detailQuery.data.detail : null
+        }
         detailLoading={detailQuery.isPending}
         onApprove={handleApprove}
         onClose={closeClaim}
@@ -306,11 +284,20 @@ export default function BillingWorkspace({
       />
     ) : (
       <BillingWorkspaceClaimReview
-        action={decisionMutation.isPending ? decisionMutation.variables?.action ?? null : null}
-        actionError={
-          actionError || (detailQuery.error ? getRpcErrorMessage(detailQuery.error) : null)
+        action={
+          decisionMutation.isPending
+            ? (decisionMutation.variables?.action ?? null)
+            : null
         }
-        detail={detailQuery.data?.kind === "recurring" ? detailQuery.data.detail : null}
+        actionError={
+          actionError ||
+          (detailQuery.error ? getRpcErrorMessage(detailQuery.error) : null)
+        }
+        detail={
+          detailQuery.data?.kind === "recurring"
+            ? detailQuery.data.detail
+            : null
+        }
         detailLoading={detailQuery.isPending}
         onApprove={handleApprove}
         onClose={closeClaim}
@@ -321,165 +308,26 @@ export default function BillingWorkspace({
     );
 
   return (
-    <section className="min-h-[calc(100vh-5rem)] bg-muted/20 px-4 py-8 md:px-6 md:py-12">
-      <div className="mx-auto max-w-7xl">
-        <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-          <label className="flex items-center gap-3">
-            <span className="text-sm font-medium text-muted-foreground">Association</span>
-            <select
-              value={activeOrganizationId}
-              onChange={(event) => {
-                setOrganizationId(event.target.value);
-                setSelectedClaim(null);
-                setActionError(null);
-              }}
-              className="h-11 min-w-64 rounded-xl border border-input bg-background px-3 text-sm shadow-sm outline-none focus:ring-1 focus:ring-ring"
-            >
-              {organizations.map((organization) => (
-                <option
-                  key={organization.organization_id}
-                  value={organization.organization_id}
-                >
-                  {organization.organization_name}
-                </option>
-              ))}
-            </select>
-          </label>
-          <div className="flex items-center gap-3">
-            <Badge variant="outline">
-              {view === "queue"
-                ? `${queue.filter((claim) => claim.claim_status === "under_review").length} awaiting review`
-                : view === "payments"
-                  ? `${payments.length} obligations`
-                  : `${members.length} active members`}
-            </Badge>
-            <Button
-              type="button"
-              variant="outline"
-              size="icon"
-              onClick={() => void workspaceQuery.refetch()}
-              disabled={workspaceQuery.isFetching}
-              aria-label="Refresh workspace"
-            >
-              <RefreshCw
-                className={workspaceQuery.isFetching ? "size-4 animate-spin" : "size-4"}
-                aria-hidden="true"
-              />
-            </Button>
-          </div>
-        </div>
-
-        <div className="mb-6 flex flex-wrap gap-2 rounded-2xl border bg-card p-2" role="tablist" aria-label="Billing workspace views">
-          {([
-            ["queue", "Queue"],
-            ["payments", "Payments"],
-            ["members", "Members"],
-          ] as const).map(([value, label]) => (
-            <button
-              key={value}
-              type="button"
-              role="tab"
-              aria-selected={view === value}
-              onClick={() => {
-                setView(value);
-                setSelectedClaim(null);
-                setActionError(null);
-              }}
-              className={`rounded-xl px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
-                view === value
-                  ? "bg-primary text-primary-foreground"
-                  : "text-muted-foreground hover:bg-muted hover:text-foreground"
-              }`}
-            >
-              {label}
-            </button>
-          ))}
-        </div>
-
-        <WorkspaceHeading
-          view={view}
-          organizationName={selectedOrganization?.organization_name ?? "Association"}
-        />
-
-        {workspaceQuery.isPending ? (
-          <div className="mt-8 flex min-h-72 items-center justify-center rounded-3xl border bg-card">
-            <Loader2 className="size-7 animate-spin text-muted-foreground" aria-label="Loading workspace" />
-          </div>
-        ) : workspaceQuery.error ? (
-          <Alert variant="destructive" className="mt-8">
-            <AlertTriangle className="size-4" aria-hidden="true" />
-            <AlertTitle>Workspace unavailable</AlertTitle>
-            <AlertDescription>
-              {getRpcErrorMessage(workspaceQuery.error)} Try refreshing the workspace.
-            </AlertDescription>
-          </Alert>
-        ) : (
-          <div className="mt-8">
-            {view === "queue" ? (
-              <BillingWorkspaceQueue
-                key={activeOrganizationId}
-                claims={queue}
-                onOpenClaim={openClaim}
-              />
-            ) : view === "payments" ? (
-              <BillingWorkspacePayments
-                key={activeOrganizationId}
-                payments={payments}
-              />
-            ) : (
-              <BillingWorkspaceMembers
-                key={activeOrganizationId}
-                members={members}
-              />
-            )}
-          </div>
-        )}
-      </div>
-
-      <div className="hidden md:block">
-        <Dialog
-          open={selectedClaim !== null}
-          onOpenChange={(open) => {
-            if (!open) closeClaim();
-          }}
-        >
-          <DialogContent className="max-h-[90vh] max-w-3xl overflow-hidden rounded-3xl p-0">
-            <DialogHeader className="sr-only">
-              <DialogTitle>Review payment claim</DialogTitle>
-              <DialogDescription>
-                Inspect the authoritative obligation and decide this claim.
-              </DialogDescription>
-            </DialogHeader>
-            {reviewSurface}
-          </DialogContent>
-        </Dialog>
-      </div>
-
-      <div className="md:hidden">
-        <Drawer
-          open={selectedClaim !== null}
-          onOpenChange={(open) => {
-            if (!open) closeClaim();
-          }}
-        >
-          <DrawerContent className="max-h-[96vh] overflow-hidden rounded-t-3xl p-0">
-            <DrawerHeader className="sr-only">
-              <DrawerTitle>Review payment claim</DrawerTitle>
-              <DrawerDescription>
-                Inspect the authoritative obligation and decide this claim.
-              </DrawerDescription>
-            </DrawerHeader>
-            {reviewSurface}
-          </DrawerContent>
-        </Drawer>
-      </div>
-
-      {workspaceQuery.data && view === "queue" && queue.length > 0 ? (
-        <div className="sr-only" aria-live="polite">
-          <CheckCircle2 aria-hidden="true" />
-          Workspace loaded with {queue.length} claims.
-        </div>
-      ) : null}
-    </section>
+    <BillingWorkspaceLayout
+      organizations={organizations}
+      activeOrganizationId={activeOrganizationId}
+      view={view}
+      queue={queue}
+      payments={payments}
+      members={members}
+      workspaceIsPending={workspaceQuery.isPending}
+      workspaceIsFetching={workspaceQuery.isFetching}
+      workspaceErrorMessage={
+        workspaceQuery.error ? getRpcErrorMessage(workspaceQuery.error) : null
+      }
+      workspaceHasLoadedQueue={Boolean(workspaceQuery.data) && queue.length > 0}
+      reviewOpen={selectedClaim !== null}
+      reviewSurface={reviewSurface}
+      onOrganizationChange={handleOrganizationChange}
+      onViewChange={handleViewChange}
+      onRefresh={() => void workspaceQuery.refetch()}
+      onOpenClaim={openClaim}
+      onCloseReview={closeClaim}
+    />
   );
 }

--- a/next/app/[locale]/admin/_components/billing-workspace.tsx
+++ b/next/app/[locale]/admin/_components/billing-workspace.tsx
@@ -1,0 +1,485 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { AlertTriangle, CheckCircle2, Loader2, RefreshCw } from "lucide-react";
+import { useState } from "react";
+
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import { useRouter } from "@/i18n/navigation";
+import type {
+  BillingWorkspaceClaimDetail,
+  BillingWorkspaceMemberRow,
+  BillingWorkspaceOrganization,
+  BillingWorkspacePaymentRow,
+  BillingWorkspaceQueueRow,
+  BillingWorkspaceView,
+  InitialPaymentClaimDetail,
+} from "@/lib/billing-workspace";
+import { supabaseBrowser } from "@/utils/supabase/client";
+
+import {
+  InitialPaymentClaimReview,
+  type ReviewAction,
+} from "../claims/_components/initial-payment-claim-review";
+import BillingWorkspaceClaimReview from "./billing-workspace-claim-review";
+import BillingWorkspaceMembers from "./billing-workspace-members";
+import BillingWorkspacePayments from "./billing-workspace-payments";
+import BillingWorkspaceQueue, {
+  WorkspaceHeading,
+} from "./billing-workspace-queue";
+
+type RpcError = {
+  code?: string;
+  message?: string;
+};
+
+type WorkspaceData =
+  | BillingWorkspaceQueueRow[]
+  | BillingWorkspacePaymentRow[]
+  | BillingWorkspaceMemberRow[];
+
+type ClaimDetailEnvelope =
+  | { kind: "initial"; detail: InitialPaymentClaimDetail }
+  | { kind: "recurring"; detail: BillingWorkspaceClaimDetail };
+
+type DecisionVariables = {
+  action: Exclude<ReviewAction, null>;
+  claim: BillingWorkspaceQueueRow;
+  reason?: string;
+};
+
+const supabase = supabaseBrowser();
+
+function getRpcErrorMessage(error: RpcError) {
+  if (error.code === "40001") {
+    return "Another reviewer may have acted on this claim. The review stays open while we refresh the authoritative state.";
+  }
+
+  if (error.code === "42501") {
+    return "You are not authorized to inspect or decide this claim.";
+  }
+
+  if (error.code === "22023") {
+    return error.message || "Check the information and try again.";
+  }
+
+  return "The decision could not be completed. Nothing was changed; try again.";
+}
+
+async function fetchWorkspaceData(
+  organizationId: string,
+  view: BillingWorkspaceView,
+): Promise<WorkspaceData> {
+  if (view === "queue") {
+    const { data, error } = await supabase.rpc("get_billing_workspace_queue", {
+      p_organization_id: organizationId,
+    });
+    if (error) throw error;
+    return data ?? [];
+  }
+
+  if (view === "payments") {
+    const { data, error } = await supabase.rpc("get_billing_workspace_payments", {
+      p_organization_id: organizationId,
+    });
+    if (error) throw error;
+    return data ?? [];
+  }
+
+  const { data, error } = await supabase.rpc("get_billing_workspace_members", {
+    p_organization_id: organizationId,
+  });
+  if (error) throw error;
+  return data ?? [];
+}
+
+export default function BillingWorkspace({
+  organizations,
+}: {
+  organizations: BillingWorkspaceOrganization[];
+}) {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const [organizationId, setOrganizationId] = useState(
+    organizations[0]?.organization_id ?? "",
+  );
+  const [view, setView] = useState<BillingWorkspaceView>("queue");
+  const [selectedClaim, setSelectedClaim] =
+    useState<BillingWorkspaceQueueRow | null>(null);
+  const [rejectionReason, setRejectionReason] = useState("");
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const selectedOrganization =
+    organizations.find((organization) => organization.organization_id === organizationId) ??
+    organizations[0];
+  const activeOrganizationId = selectedOrganization?.organization_id ?? "";
+
+  const workspaceQuery = useQuery<WorkspaceData, RpcError>({
+    queryKey: ["billing-workspace", activeOrganizationId, view],
+    queryFn: () => fetchWorkspaceData(activeOrganizationId, view),
+    enabled: activeOrganizationId.length > 0,
+  });
+
+  const detailQuery = useQuery<ClaimDetailEnvelope | null, RpcError>({
+    queryKey: ["billing-workspace-claim", selectedClaim?.claim_id],
+    queryFn: async () => {
+      if (!selectedClaim) return null;
+
+      if (selectedClaim.purpose === "initial_admission") {
+        const { data, error } = await supabase.rpc(
+          "get_initial_payment_claim_detail",
+          { p_claim_id: selectedClaim.claim_id },
+        );
+        if (error) throw error;
+        return data?.[0]
+          ? { kind: "initial", detail: data[0] }
+          : null;
+      }
+
+      const { data, error } = await supabase.rpc(
+        "get_billing_workspace_claim_detail",
+        { p_claim_id: selectedClaim.claim_id },
+      );
+      if (error) throw error;
+      return data?.[0]
+        ? { kind: "recurring", detail: data[0] }
+        : null;
+    },
+    enabled: selectedClaim !== null,
+  });
+
+  const decisionMutation = useMutation<void, RpcError, DecisionVariables>({
+    mutationFn: async ({ action, claim, reason }) => {
+      const rpcName =
+        action === "approve" ? claim.approve_command : claim.reject_command;
+
+      if (!rpcName) {
+        throw {
+          code: "40001",
+          message: "This claim is no longer actionable. Refresh before deciding.",
+        } satisfies RpcError;
+      }
+
+      if (action === "approve") {
+        const { error } = await (claim.purpose === "initial_admission"
+          ? supabase.rpc("approve_initial_claim", {
+              p_claim_id: claim.claim_id,
+            })
+          : supabase.rpc("approve_recurring_payment_claim", {
+              p_claim_id: claim.claim_id,
+            }));
+        if (error) throw error;
+        return;
+      }
+
+      const normalizedReason = reason?.trim().replace(/\s+/g, " ");
+      if (!normalizedReason) {
+        throw {
+          code: "22023",
+          message: "A rejection reason is required.",
+        } satisfies RpcError;
+      }
+
+      const { error } = await (claim.purpose === "initial_admission"
+        ? supabase.rpc("reject_initial_claim", {
+            p_claim_id: claim.claim_id,
+            p_reason: normalizedReason,
+          })
+        : supabase.rpc("reject_recurring_payment_claim", {
+            p_claim_id: claim.claim_id,
+            p_reason: normalizedReason,
+          }));
+      if (error) throw error;
+    },
+    onSuccess: async (_, variables) => {
+      await queryClient.invalidateQueries({
+        queryKey: ["billing-workspace", activeOrganizationId],
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ["billing-workspace-claim", variables.claim.claim_id],
+      });
+      setSelectedClaim(null);
+      setRejectionReason("");
+      setActionError(null);
+      router.refresh();
+    },
+    onError: async (error, variables) => {
+      setActionError(getRpcErrorMessage(error));
+      if (error.code === "40001") {
+        await queryClient.invalidateQueries({
+          queryKey: ["billing-workspace", activeOrganizationId],
+        });
+        await detailQuery.refetch();
+      }
+      void variables;
+    },
+  });
+
+  if (organizations.length === 0) {
+    return (
+      <section className="mx-auto flex min-h-[60vh] max-w-3xl items-center px-4 py-12 md:px-6">
+        <div className="w-full rounded-3xl border bg-card p-8 shadow-sm">
+          <p className="text-sm font-medium uppercase tracking-[0.18em] text-muted-foreground">
+            Association administration
+          </p>
+          <h1 className="mt-3 text-3xl font-semibold tracking-tight">
+            No billing workspace access
+          </h1>
+          <p className="mt-3 text-muted-foreground">
+            An authorized association admin can review payment claims and member financial standing here.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  const data = workspaceQuery.data ?? [];
+  const queue = view === "queue" ? (data as BillingWorkspaceQueueRow[]) : [];
+  const payments = view === "payments" ? (data as BillingWorkspacePaymentRow[]) : [];
+  const members = view === "members" ? (data as BillingWorkspaceMemberRow[]) : [];
+
+  const openClaim = (claim: BillingWorkspaceQueueRow) => {
+    setActionError(null);
+    setRejectionReason("");
+    setSelectedClaim(claim);
+  };
+
+  const closeClaim = () => {
+    if (decisionMutation.isPending) return;
+    setSelectedClaim(null);
+    setActionError(null);
+    setRejectionReason("");
+  };
+
+  const handleApprove = async () => {
+    if (!selectedClaim || decisionMutation.isPending) return;
+    setActionError(null);
+    await decisionMutation.mutateAsync({
+      action: "approve",
+      claim: selectedClaim,
+    });
+  };
+
+  const handleReject = async () => {
+    if (!selectedClaim || decisionMutation.isPending) return;
+    await decisionMutation.mutateAsync({
+      action: "reject",
+      claim: selectedClaim,
+      reason: rejectionReason,
+    });
+  };
+
+  const reviewSurface =
+    selectedClaim?.purpose === "initial_admission" ? (
+      <InitialPaymentClaimReview
+        action={decisionMutation.isPending ? decisionMutation.variables?.action ?? null : null}
+        actionError={
+          actionError || (detailQuery.error ? getRpcErrorMessage(detailQuery.error) : null)
+        }
+        detail={detailQuery.data?.kind === "initial" ? detailQuery.data.detail : null}
+        detailLoading={detailQuery.isPending}
+        onApprove={handleApprove}
+        onClose={closeClaim}
+        onReject={handleReject}
+        rejectionReason={rejectionReason}
+        onRejectionReasonChange={setRejectionReason}
+      />
+    ) : (
+      <BillingWorkspaceClaimReview
+        action={decisionMutation.isPending ? decisionMutation.variables?.action ?? null : null}
+        actionError={
+          actionError || (detailQuery.error ? getRpcErrorMessage(detailQuery.error) : null)
+        }
+        detail={detailQuery.data?.kind === "recurring" ? detailQuery.data.detail : null}
+        detailLoading={detailQuery.isPending}
+        onApprove={handleApprove}
+        onClose={closeClaim}
+        onReject={handleReject}
+        rejectionReason={rejectionReason}
+        onRejectionReasonChange={setRejectionReason}
+      />
+    );
+
+  return (
+    <section className="min-h-[calc(100vh-5rem)] bg-muted/20 px-4 py-8 md:px-6 md:py-12">
+      <div className="mx-auto max-w-7xl">
+        <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <label className="flex items-center gap-3">
+            <span className="text-sm font-medium text-muted-foreground">Association</span>
+            <select
+              value={activeOrganizationId}
+              onChange={(event) => {
+                setOrganizationId(event.target.value);
+                setSelectedClaim(null);
+                setActionError(null);
+              }}
+              className="h-11 min-w-64 rounded-xl border border-input bg-background px-3 text-sm shadow-sm outline-none focus:ring-1 focus:ring-ring"
+            >
+              {organizations.map((organization) => (
+                <option
+                  key={organization.organization_id}
+                  value={organization.organization_id}
+                >
+                  {organization.organization_name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <div className="flex items-center gap-3">
+            <Badge variant="outline">
+              {view === "queue"
+                ? `${queue.filter((claim) => claim.claim_status === "under_review").length} awaiting review`
+                : view === "payments"
+                  ? `${payments.length} obligations`
+                  : `${members.length} active members`}
+            </Badge>
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              onClick={() => void workspaceQuery.refetch()}
+              disabled={workspaceQuery.isFetching}
+              aria-label="Refresh workspace"
+            >
+              <RefreshCw
+                className={workspaceQuery.isFetching ? "size-4 animate-spin" : "size-4"}
+                aria-hidden="true"
+              />
+            </Button>
+          </div>
+        </div>
+
+        <div className="mb-6 flex flex-wrap gap-2 rounded-2xl border bg-card p-2" role="tablist" aria-label="Billing workspace views">
+          {([
+            ["queue", "Queue"],
+            ["payments", "Payments"],
+            ["members", "Members"],
+          ] as const).map(([value, label]) => (
+            <button
+              key={value}
+              type="button"
+              role="tab"
+              aria-selected={view === value}
+              onClick={() => {
+                setView(value);
+                setSelectedClaim(null);
+                setActionError(null);
+              }}
+              className={`rounded-xl px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+                view === value
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:bg-muted hover:text-foreground"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        <WorkspaceHeading
+          view={view}
+          organizationName={selectedOrganization?.organization_name ?? "Association"}
+        />
+
+        {workspaceQuery.isPending ? (
+          <div className="mt-8 flex min-h-72 items-center justify-center rounded-3xl border bg-card">
+            <Loader2 className="size-7 animate-spin text-muted-foreground" aria-label="Loading workspace" />
+          </div>
+        ) : workspaceQuery.error ? (
+          <Alert variant="destructive" className="mt-8">
+            <AlertTriangle className="size-4" aria-hidden="true" />
+            <AlertTitle>Workspace unavailable</AlertTitle>
+            <AlertDescription>
+              {getRpcErrorMessage(workspaceQuery.error)} Try refreshing the workspace.
+            </AlertDescription>
+          </Alert>
+        ) : (
+          <div className="mt-8">
+            {view === "queue" ? (
+              <BillingWorkspaceQueue
+                key={activeOrganizationId}
+                claims={queue}
+                onOpenClaim={openClaim}
+              />
+            ) : view === "payments" ? (
+              <BillingWorkspacePayments
+                key={activeOrganizationId}
+                payments={payments}
+              />
+            ) : (
+              <BillingWorkspaceMembers
+                key={activeOrganizationId}
+                members={members}
+              />
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="hidden md:block">
+        <Dialog
+          open={selectedClaim !== null}
+          onOpenChange={(open) => {
+            if (!open) closeClaim();
+          }}
+        >
+          <DialogContent className="max-h-[90vh] max-w-3xl overflow-hidden rounded-3xl p-0">
+            <DialogHeader className="sr-only">
+              <DialogTitle>Review payment claim</DialogTitle>
+              <DialogDescription>
+                Inspect the authoritative obligation and decide this claim.
+              </DialogDescription>
+            </DialogHeader>
+            {reviewSurface}
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      <div className="md:hidden">
+        <Drawer
+          open={selectedClaim !== null}
+          onOpenChange={(open) => {
+            if (!open) closeClaim();
+          }}
+        >
+          <DrawerContent className="max-h-[96vh] overflow-hidden rounded-t-3xl p-0">
+            <DrawerHeader className="sr-only">
+              <DrawerTitle>Review payment claim</DrawerTitle>
+              <DrawerDescription>
+                Inspect the authoritative obligation and decide this claim.
+              </DrawerDescription>
+            </DrawerHeader>
+            {reviewSurface}
+          </DrawerContent>
+        </Drawer>
+      </div>
+
+      {workspaceQuery.data && view === "queue" && queue.length > 0 ? (
+        <div className="sr-only" aria-live="polite">
+          <CheckCircle2 aria-hidden="true" />
+          Workspace loaded with {queue.length} claims.
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/next/app/[locale]/admin/claims/page.tsx
+++ b/next/app/[locale]/admin/claims/page.tsx
@@ -1,52 +1,5 @@
-import { createSupabaseClient } from "@/utils/supabase/server";
+import { redirect } from "next/navigation";
 
-import InitialPaymentClaimsQueue from "./_components/initial-payment-claims-queue";
-
-export default async function InitialPaymentClaimsPage() {
-  const supabase = await createSupabaseClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return (
-      <section className="mx-auto flex min-h-[60vh] max-w-3xl items-center px-4 py-12 md:px-6">
-        <div className="w-full rounded-3xl border bg-card p-8 shadow-sm">
-          <p className="text-sm font-medium uppercase tracking-[0.18em] text-muted-foreground">
-            Association administration
-          </p>
-          <h1 className="mt-3 text-3xl font-semibold tracking-tight">
-            Sign in to open the review queue
-          </h1>
-          <p className="mt-3 max-w-xl text-muted-foreground">
-            Only an authorized association admin can inspect or decide an
-            initial payment claim.
-          </p>
-        </div>
-      </section>
-    );
-  }
-
-  const { data, error } = await supabase.rpc("get_initial_payment_claim_queue");
-
-  if (error) {
-    return (
-      <section className="mx-auto flex min-h-[60vh] max-w-3xl items-center px-4 py-12 md:px-6">
-        <div className="w-full rounded-3xl border border-destructive/40 bg-card p-8 shadow-sm">
-          <p className="text-sm font-medium uppercase tracking-[0.18em] text-destructive">
-            Review queue unavailable
-          </p>
-          <h1 className="mt-3 text-3xl font-semibold tracking-tight">
-            We could not load this queue
-          </h1>
-          <p className="mt-3 text-muted-foreground">
-            Refresh the page and try again. Your account and the association
-            authorization are checked by the database for every request.
-          </p>
-        </div>
-      </section>
-    );
-  }
-
-  return <InitialPaymentClaimsQueue initialClaims={data ?? []} />;
+export default function InitialPaymentClaimsPage() {
+  redirect("/admin?view=queue");
 }

--- a/next/app/[locale]/admin/page.tsx
+++ b/next/app/[locale]/admin/page.tsx
@@ -1,0 +1,54 @@
+import { createSupabaseClient } from "@/utils/supabase/server";
+
+import BillingWorkspace from "./_components/billing-workspace";
+
+export const dynamic = "force-dynamic";
+
+export default async function BillingWorkspacePage() {
+  const supabase = await createSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return (
+      <section className="mx-auto flex min-h-[60vh] max-w-3xl items-center px-4 py-12 md:px-6">
+        <div className="w-full rounded-3xl border bg-card p-8 shadow-sm">
+          <p className="text-sm font-medium uppercase tracking-[0.18em] text-muted-foreground">
+            Association administration
+          </p>
+          <h1 className="mt-3 text-3xl font-semibold tracking-tight">
+            Sign in to open the billing workspace
+          </h1>
+          <p className="mt-3 text-muted-foreground">
+            Only an authorized association admin can inspect or decide payment claims.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  const { data: organizations, error } = await supabase.rpc(
+    "get_billing_workspace_organizations",
+  );
+
+  if (error) {
+    return (
+      <section className="mx-auto flex min-h-[60vh] max-w-3xl items-center px-4 py-12 md:px-6">
+        <div className="w-full rounded-3xl border border-destructive/40 bg-card p-8 shadow-sm">
+          <p className="text-sm font-medium uppercase tracking-[0.18em] text-destructive">
+            Billing workspace unavailable
+          </p>
+          <h1 className="mt-3 text-3xl font-semibold tracking-tight">
+            We could not load your associations
+          </h1>
+          <p className="mt-3 text-muted-foreground">
+            Refresh the page and try again. Association authorization is checked by the database for every request.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  return <BillingWorkspace organizations={organizations ?? []} />;
+}

--- a/next/components/layout/navbar/ProfileMenu.tsx
+++ b/next/components/layout/navbar/ProfileMenu.tsx
@@ -54,9 +54,9 @@ export default function ProfileMenu({ user }: { user: User }) {
             </Link>
           </DropdownMenuItem>
           <DropdownMenuItem asChild>
-            <Link href="/admin/claims">
+            <Link href="/admin">
               <ShieldCheck className="mr-2 size-4" aria-hidden="true" />
-              Review payment claims
+              Billing workspace
             </Link>
           </DropdownMenuItem>
           <DropdownMenuItem onClick={signOut}>

--- a/next/lib/billing-workspace.ts
+++ b/next/lib/billing-workspace.ts
@@ -1,0 +1,92 @@
+import type { Database, Json } from "@chooselife/database";
+
+export type BillingWorkspaceOrganization =
+  Database["public"]["Functions"]["get_billing_workspace_organizations"]["Returns"][number];
+
+export type BillingWorkspaceQueueRow =
+  Database["public"]["Functions"]["get_billing_workspace_queue"]["Returns"][number];
+
+export type BillingWorkspaceClaimDetail =
+  Database["public"]["Functions"]["get_billing_workspace_claim_detail"]["Returns"][number];
+
+export type BillingWorkspacePaymentRow =
+  Database["public"]["Functions"]["get_billing_workspace_payments"]["Returns"][number];
+
+export type BillingWorkspaceMemberRow =
+  Database["public"]["Functions"]["get_billing_workspace_members"]["Returns"][number];
+
+export type InitialPaymentClaimDetail =
+  Database["public"]["Functions"]["get_initial_payment_claim_detail"]["Returns"][number];
+
+export type BillingWorkspaceView = "queue" | "payments" | "members";
+
+export type BillingWorkspaceClaimDetailResult =
+  | BillingWorkspaceClaimDetail
+  | InitialPaymentClaimDetail;
+
+export type BillingHistoryEntry = {
+  actor_handle?: string | null;
+  actor_name?: string | null;
+  actor_user_id?: string | null;
+  claim_id?: string | null;
+  created_at?: string | null;
+  decided_at?: string | null;
+  decision_reason?: string | null;
+  id?: string | null;
+  next_state?: string | null;
+  payer_name?: string | null;
+  payer_type?: string | null;
+  previous_state?: string | null;
+  reason?: string | null;
+  status?: string | null;
+};
+
+export function jsonArray(value: Json | null | undefined): BillingHistoryEntry[] {
+  return Array.isArray(value) ? (value as BillingHistoryEntry[]) : [];
+}
+
+export function formatBillingDate(value: string | null | undefined) {
+  if (!value) return "—";
+
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeZone: "America/Sao_Paulo",
+  }).format(new Date(`${value}T00:00:00`));
+}
+
+export function formatBillingDateTime(value: string | null | undefined) {
+  if (!value) return "—";
+
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "America/Sao_Paulo",
+  }).format(new Date(value));
+}
+
+export function formatBillingAmount(amount: number, currency: string) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+  }).format(amount / 100);
+}
+
+export function purposeLabel(
+  purpose: Database["public"]["Enums"]["payment_obligation_purpose_enum"],
+) {
+  return purpose === "recurring" ? "Recurring contribution" : "Initial admission";
+}
+
+export function planLabel(
+  plan: Database["public"]["Enums"]["subscription_plan_type_enum"] | null,
+) {
+  if (!plan) return "No active plan";
+  return plan === "annual" ? "Annual" : "Monthly";
+}
+
+export function paymentStateLabel(state: string) {
+  return state
+    .split("_")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}

--- a/next/lib/billing-workspace.ts
+++ b/next/lib/billing-workspace.ts
@@ -21,8 +21,7 @@ export type InitialPaymentClaimDetail =
 export type BillingWorkspaceView = "queue" | "payments" | "members";
 
 export type BillingWorkspaceClaimDetailResult =
-  | BillingWorkspaceClaimDetail
-  | InitialPaymentClaimDetail;
+  BillingWorkspaceClaimDetail | InitialPaymentClaimDetail;
 
 export type BillingHistoryEntry = {
   actor_handle?: string | null;
@@ -41,27 +40,33 @@ export type BillingHistoryEntry = {
   status?: string | null;
 };
 
-export function jsonArray(value: Json | null | undefined): BillingHistoryEntry[] {
+const BILLING_DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  dateStyle: "medium",
+  timeZone: "America/Sao_Paulo",
+});
+
+const BILLING_DATE_TIME_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  dateStyle: "medium",
+  timeStyle: "short",
+  timeZone: "America/Sao_Paulo",
+});
+
+export function jsonArray(
+  value: Json | null | undefined,
+): BillingHistoryEntry[] {
   return Array.isArray(value) ? (value as BillingHistoryEntry[]) : [];
 }
 
 export function formatBillingDate(value: string | null | undefined) {
   if (!value) return "—";
 
-  return new Intl.DateTimeFormat("en-US", {
-    dateStyle: "medium",
-    timeZone: "America/Sao_Paulo",
-  }).format(new Date(`${value}T00:00:00`));
+  return BILLING_DATE_FORMATTER.format(new Date(`${value}T00:00:00`));
 }
 
 export function formatBillingDateTime(value: string | null | undefined) {
   if (!value) return "—";
 
-  return new Intl.DateTimeFormat("en-US", {
-    dateStyle: "medium",
-    timeStyle: "short",
-    timeZone: "America/Sao_Paulo",
-  }).format(new Date(value));
+  return BILLING_DATE_TIME_FORMATTER.format(new Date(value));
 }
 
 export function formatBillingAmount(amount: number, currency: string) {
@@ -74,7 +79,9 @@ export function formatBillingAmount(amount: number, currency: string) {
 export function purposeLabel(
   purpose: Database["public"]["Enums"]["payment_obligation_purpose_enum"],
 ) {
-  return purpose === "recurring" ? "Recurring contribution" : "Initial admission";
+  return purpose === "recurring"
+    ? "Recurring contribution"
+    : "Initial admission";
 }
 
 export function planLabel(

--- a/packages/database/database-generated.types.ts
+++ b/packages/database/database-generated.types.ts
@@ -2007,6 +2007,127 @@ export type Database = {
           schedule_id: string
         }[]
       }
+      get_billing_workspace_claim_detail: {
+        Args: { p_claim_id: string }
+        Returns: {
+          amount: number
+          approve_command: string | null
+          attempt_count: number
+          audit_history: Json
+          available_on: string
+          claim_created_at: string
+          claim_decided_at: string | null
+          claim_decision_reason: string | null
+          claim_history: Json
+          claim_id: string
+          claim_status: Database["public"]["Enums"]["payment_claim_status_enum"]
+          currency: string
+          due_on: string
+          member_handle: string | null
+          member_name: string | null
+          member_profile_picture: string | null
+          member_user_id: string
+          obligation_id: string
+          organization_id: string
+          organization_name: string
+          organization_slug: string
+          payer_name: string | null
+          payer_type: Database["public"]["Enums"]["payment_claim_payer_type_enum"]
+          period_end: string
+          period_key: string
+          period_start: string
+          plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"]
+          purpose: Database["public"]["Enums"]["payment_obligation_purpose_enum"]
+          reject_command: string | null
+        }[]
+      }
+      get_billing_workspace_members: {
+        Args: { p_organization_id: string }
+        Returns: {
+          financial_standing: string
+          joined_at: string
+          last_verified_contribution_at: string | null
+          member_handle: string | null
+          member_name: string | null
+          member_profile_picture: string | null
+          member_role: Database["public"]["Enums"]["organization_role_enum"]
+          member_user_id: string
+          next_due_on: string | null
+          oldest_attention_due_on: string | null
+          overdue_count: number
+          plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"] | null
+        }[]
+      }
+      get_billing_workspace_organizations: {
+        Args: never
+        Returns: {
+          organization_id: string
+          organization_name: string
+          organization_slug: string
+        }[]
+      }
+      get_billing_workspace_payments: {
+        Args: { p_organization_id: string }
+        Returns: {
+          amount: number
+          audit_history: Json
+          available_on: string
+          claim_history: Json
+          currency: string
+          due_on: string
+          effective_payment_state: string
+          last_decision_actor_name: string | null
+          last_decision_actor_user_id: string | null
+          last_decision_at: string | null
+          latest_claim_created_at: string | null
+          latest_claim_decided_at: string | null
+          latest_claim_decision_reason: string | null
+          latest_claim_id: string | null
+          latest_claim_status: Database["public"]["Enums"]["payment_claim_status_enum"] | null
+          member_handle: string | null
+          member_name: string | null
+          member_user_id: string
+          obligation_id: string
+          obligation_status: Database["public"]["Enums"]["payment_obligation_status_enum"]
+          organization_id: string
+          period_end: string
+          period_key: string
+          period_start: string
+          plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"]
+          purpose: Database["public"]["Enums"]["payment_obligation_purpose_enum"]
+          settled_at: string | null
+        }[]
+      }
+      get_billing_workspace_queue: {
+        Args: { p_organization_id: string }
+        Returns: {
+          amount: number
+          approve_command: string | null
+          attempt_count: number
+          available_on: string
+          claim_created_at: string
+          claim_decided_at: string | null
+          claim_decision_reason: string | null
+          claim_id: string
+          claim_status: Database["public"]["Enums"]["payment_claim_status_enum"]
+          currency: string
+          due_on: string
+          member_handle: string | null
+          member_name: string | null
+          member_profile_picture: string | null
+          member_user_id: string
+          obligation_id: string
+          organization_id: string
+          payer_name: string | null
+          payer_type: Database["public"]["Enums"]["payment_claim_payer_type_enum"]
+          period_end: string
+          period_key: string
+          period_start: string
+          plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"]
+          purpose: Database["public"]["Enums"]["payment_obligation_purpose_enum"]
+          reject_command: string | null
+        }[]
+      }
       get_crossing_time: {
         Args: { highline_id: string; page_number: number; page_size: number }
         Returns: {

--- a/supabase/migrations/20260826000000_billing_workspace.sql
+++ b/supabase/migrations/20260826000000_billing_workspace.sql
@@ -1,0 +1,737 @@
+-- Issue #210: expose one organization-scoped billing workspace for
+-- recurring and initial payment review without exposing raw member data.
+
+create index if not exists payment_claims_billing_workspace_queue_idx
+  on public.payment_claims (organization_id, created_at, id, obligation_id)
+  where status = 'under_review'::public.payment_claim_status_enum;
+
+create index if not exists payment_obligations_billing_workspace_idx
+  on public.payment_obligations (
+    organization_id,
+    purpose,
+    status,
+    due_on,
+    available_on,
+    created_at,
+    id
+  );
+
+create index if not exists payment_claim_audit_events_claim_history_idx
+  on public.payment_claim_audit_events (claim_id, created_at, id);
+
+create index if not exists organization_members_billing_workspace_idx
+  on public.organization_members (organization_id, role, user_id);
+
+create or replace function public.get_billing_workspace_organizations()
+returns table (
+  organization_id uuid,
+  organization_name text,
+  organization_slug text
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select
+    o.id,
+    o.name,
+    o.slug
+  from public.organizations o
+  where o.organization_type = 'association'::public.organization_type_enum
+    and exists (
+      select 1
+      from public.organization_members om
+      where om.organization_id = o.id
+        and om.user_id = (select auth.uid())
+        and om.role = 'admin'::public.organization_role_enum
+    )
+  order by o.name, o.id;
+$$;
+
+comment on function public.get_billing_workspace_organizations() is
+  'Returns the associations where the signed-in person may open the billing workspace.';
+
+revoke all on function public.get_billing_workspace_organizations()
+  from public, anon;
+grant execute on function public.get_billing_workspace_organizations()
+  to authenticated;
+
+create or replace function public.get_billing_workspace_queue(
+  p_organization_id uuid
+)
+returns table (
+  claim_id uuid,
+  obligation_id uuid,
+  organization_id uuid,
+  purpose public.payment_obligation_purpose_enum,
+  member_user_id uuid,
+  member_name text,
+  member_handle text,
+  member_profile_picture text,
+  payer_type public.payment_claim_payer_type_enum,
+  payer_name text,
+  plan_type public.subscription_plan_type_enum,
+  amount integer,
+  currency text,
+  period_key text,
+  period_start date,
+  period_end date,
+  available_on date,
+  due_on date,
+  claim_created_at timestamp with time zone,
+  claim_decided_at timestamp with time zone,
+  claim_decision_reason text,
+  claim_status public.payment_claim_status_enum,
+  attempt_count bigint,
+  approve_command text,
+  reject_command text
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select
+    pc.id,
+    po.id,
+    pc.organization_id,
+    po.purpose,
+    pc.claimant_user_id,
+    member_profile.name,
+    member_profile.username,
+    member_profile.profile_picture,
+    pc.payer_type,
+    pc.payer_name,
+    po.plan_type,
+    po.amount,
+    po.currency,
+    po.period_key,
+    po.period_start,
+    po.period_end,
+    po.available_on,
+    po.due_on,
+    pc.created_at,
+    pc.decided_at,
+    pc.decision_reason,
+    pc.status,
+    (
+      select count(*)
+      from public.payment_claims attempts
+      where attempts.obligation_id = po.id
+    ),
+    case
+      when pc.status = 'under_review'::public.payment_claim_status_enum
+        and po.status = 'available'::public.payment_obligation_status_enum
+        and (
+          (
+            po.purpose = 'initial_admission'::public.payment_obligation_purpose_enum
+            and po.available_at <= clock_timestamp()
+          )
+          or (
+            po.purpose = 'recurring'::public.payment_obligation_purpose_enum
+            and po.available_on <= timezone(
+              coalesce(po.billing_timezone, o.billing_timezone),
+              clock_timestamp()
+            )::date
+          )
+        )
+        then case po.purpose
+          when 'initial_admission'::public.payment_obligation_purpose_enum
+            then 'approve_initial_claim'
+          else 'approve_recurring_payment_claim'
+        end
+      else null
+    end,
+    case
+      when pc.status = 'under_review'::public.payment_claim_status_enum
+        and po.status = 'available'::public.payment_obligation_status_enum
+        and (
+          (
+            po.purpose = 'initial_admission'::public.payment_obligation_purpose_enum
+            and po.available_at <= clock_timestamp()
+          )
+          or (
+            po.purpose = 'recurring'::public.payment_obligation_purpose_enum
+            and po.available_on <= timezone(
+              coalesce(po.billing_timezone, o.billing_timezone),
+              clock_timestamp()
+            )::date
+          )
+        )
+        then case po.purpose
+          when 'initial_admission'::public.payment_obligation_purpose_enum
+            then 'reject_initial_claim'
+          else 'reject_recurring_payment_claim'
+        end
+      else null
+    end
+  from public.payment_claims pc
+  join public.payment_obligations po on po.id = pc.obligation_id
+  join public.organizations o on o.id = pc.organization_id
+  join public.profiles member_profile on member_profile.id = pc.claimant_user_id
+  left join public.membership_application_revisions mar
+    on mar.id = po.application_revision_id
+  left join public.membership_applications ma
+    on ma.id = mar.application_id
+  where p_organization_id is not null
+    and pc.organization_id = p_organization_id
+    and po.organization_id = pc.organization_id
+    and o.organization_type = 'association'::public.organization_type_enum
+    and pc.claimant_user_id <> (select auth.uid())
+    and exists (
+      select 1
+      from public.organization_members reviewer_membership
+      where reviewer_membership.organization_id = pc.organization_id
+        and reviewer_membership.user_id = (select auth.uid())
+        and reviewer_membership.role = 'admin'::public.organization_role_enum
+    )
+    and (
+      (
+        po.purpose = 'initial_admission'::public.payment_obligation_purpose_enum
+        and po.application_revision_id = mar.id
+        and mar.organization_id = pc.organization_id
+        and mar.user_id = pc.claimant_user_id
+        and ma.organization_id = pc.organization_id
+        and ma.user_id = pc.claimant_user_id
+        and ma.status = 'submitted'::public.membership_application_status_enum
+      )
+      or (
+        po.purpose = 'recurring'::public.payment_obligation_purpose_enum
+        and po.schedule_id is not null
+        and po.application_revision_id is null
+        and po.user_id = pc.claimant_user_id
+      )
+    )
+  order by pc.created_at asc, pc.id asc;
+$$;
+
+comment on function public.get_billing_workspace_queue(uuid) is
+  'Returns organization-scoped claim history with safe member summaries and purpose-specific decision commands.';
+
+revoke all on function public.get_billing_workspace_queue(uuid)
+  from public, anon;
+grant execute on function public.get_billing_workspace_queue(uuid)
+  to authenticated;
+
+create or replace function public.get_billing_workspace_claim_detail(
+  p_claim_id uuid
+)
+returns table (
+  claim_id uuid,
+  obligation_id uuid,
+  organization_id uuid,
+  organization_name text,
+  organization_slug text,
+  purpose public.payment_obligation_purpose_enum,
+  member_user_id uuid,
+  member_name text,
+  member_handle text,
+  member_profile_picture text,
+  claim_status public.payment_claim_status_enum,
+  payer_type public.payment_claim_payer_type_enum,
+  payer_name text,
+  claim_created_at timestamp with time zone,
+  claim_decided_at timestamp with time zone,
+  claim_decision_reason text,
+  plan_type public.subscription_plan_type_enum,
+  amount integer,
+  currency text,
+  period_key text,
+  period_start date,
+  period_end date,
+  available_on date,
+  due_on date,
+  attempt_count bigint,
+  claim_history jsonb,
+  audit_history jsonb,
+  approve_command text,
+  reject_command text
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select
+    pc.id,
+    po.id,
+    pc.organization_id,
+    o.name,
+    o.slug,
+    po.purpose,
+    pc.claimant_user_id,
+    member_profile.name,
+    member_profile.username,
+    member_profile.profile_picture,
+    pc.status,
+    pc.payer_type,
+    pc.payer_name,
+    pc.created_at,
+    pc.decided_at,
+    pc.decision_reason,
+    po.plan_type,
+    po.amount,
+    po.currency,
+    po.period_key,
+    po.period_start,
+    po.period_end,
+    po.available_on,
+    po.due_on,
+    (
+      select count(*)
+      from public.payment_claims attempts
+      where attempts.obligation_id = po.id
+    ),
+    coalesce(
+      (
+        select jsonb_agg(
+          jsonb_build_object(
+            'claim_id', history.id,
+            'status', history.status,
+            'payer_type', history.payer_type,
+            'payer_name', history.payer_name,
+            'created_at', history.created_at,
+            'decided_at', history.decided_at,
+            'decision_reason', history.decision_reason
+          )
+          order by history.created_at asc, history.id asc
+        )
+        from public.payment_claims history
+        where history.obligation_id = po.id
+      ),
+      '[]'::jsonb
+    ),
+    coalesce(
+      (
+        select jsonb_agg(
+          jsonb_build_object(
+            'id', audit.id,
+            'claim_id', audit.claim_id,
+            'actor_user_id', audit.actor_user_id,
+            'actor_name', actor_profile.name,
+            'actor_handle', actor_profile.username,
+            'previous_state', audit.previous_state,
+            'next_state', audit.next_state,
+            'reason', audit.reason,
+            'created_at', audit.created_at
+          )
+          order by audit.created_at asc, audit.id asc
+        )
+        from public.payment_claim_audit_events audit
+        left join public.profiles actor_profile on actor_profile.id = audit.actor_user_id
+        where audit.obligation_id = po.id
+      ),
+      '[]'::jsonb
+    ),
+    case
+      when pc.status = 'under_review'::public.payment_claim_status_enum
+        and po.status = 'available'::public.payment_obligation_status_enum
+        then case po.purpose
+          when 'initial_admission'::public.payment_obligation_purpose_enum
+            then 'approve_initial_claim'
+          else 'approve_recurring_payment_claim'
+        end
+      else null
+    end,
+    case
+      when pc.status = 'under_review'::public.payment_claim_status_enum
+        and po.status = 'available'::public.payment_obligation_status_enum
+        then case po.purpose
+          when 'initial_admission'::public.payment_obligation_purpose_enum
+            then 'reject_initial_claim'
+          else 'reject_recurring_payment_claim'
+        end
+      else null
+    end
+  from public.payment_claims pc
+  join public.payment_obligations po on po.id = pc.obligation_id
+  join public.organizations o on o.id = pc.organization_id
+  join public.profiles member_profile on member_profile.id = pc.claimant_user_id
+  left join public.membership_application_revisions mar
+    on mar.id = po.application_revision_id
+  left join public.membership_applications ma
+    on ma.id = mar.application_id
+  where pc.id = p_claim_id
+    and pc.organization_id = po.organization_id
+    and o.organization_type = 'association'::public.organization_type_enum
+    and pc.claimant_user_id <> (select auth.uid())
+    and exists (
+      select 1
+      from public.organization_members reviewer_membership
+      where reviewer_membership.organization_id = pc.organization_id
+        and reviewer_membership.user_id = (select auth.uid())
+        and reviewer_membership.role = 'admin'::public.organization_role_enum
+    )
+    and (
+      po.purpose = 'recurring'::public.payment_obligation_purpose_enum
+      or (
+        po.purpose = 'initial_admission'::public.payment_obligation_purpose_enum
+        and po.application_revision_id = mar.id
+        and mar.organization_id = pc.organization_id
+        and mar.user_id = pc.claimant_user_id
+        and ma.organization_id = pc.organization_id
+        and ma.user_id = pc.claimant_user_id
+        and ma.status = 'submitted'::public.membership_application_status_enum
+      )
+    );
+$$;
+
+comment on function public.get_billing_workspace_claim_detail(uuid) is
+  'Returns authorized common claim detail and immutable chronology for either payment purpose without application-private fields.';
+
+revoke all on function public.get_billing_workspace_claim_detail(uuid)
+  from public, anon;
+grant execute on function public.get_billing_workspace_claim_detail(uuid)
+  to authenticated;
+
+create or replace function public.get_billing_workspace_payments(
+  p_organization_id uuid
+)
+returns table (
+  obligation_id uuid,
+  organization_id uuid,
+  purpose public.payment_obligation_purpose_enum,
+  member_user_id uuid,
+  member_name text,
+  member_handle text,
+  plan_type public.subscription_plan_type_enum,
+  amount integer,
+  currency text,
+  period_key text,
+  period_start date,
+  period_end date,
+  available_on date,
+  due_on date,
+  obligation_status public.payment_obligation_status_enum,
+  effective_payment_state text,
+  settled_at timestamp with time zone,
+  latest_claim_id uuid,
+  latest_claim_status public.payment_claim_status_enum,
+  latest_claim_created_at timestamp with time zone,
+  latest_claim_decided_at timestamp with time zone,
+  latest_claim_decision_reason text,
+  last_decision_actor_user_id uuid,
+  last_decision_actor_name text,
+  last_decision_at timestamp with time zone,
+  claim_history jsonb,
+  audit_history jsonb
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select
+    po.id,
+    po.organization_id,
+    po.purpose,
+    po.user_id,
+    member_profile.name,
+    member_profile.username,
+    po.plan_type,
+    po.amount,
+    po.currency,
+    po.period_key,
+    po.period_start,
+    po.period_end,
+    po.available_on,
+    po.due_on,
+    po.status,
+    case
+      when po.status = 'settled'::public.payment_obligation_status_enum then 'settled'
+      when po.status = 'void'::public.payment_obligation_status_enum then 'void'
+      when exists (
+        select 1
+        from public.payment_claims under_review
+        where under_review.obligation_id = po.id
+          and under_review.status = 'under_review'::public.payment_claim_status_enum
+      ) then 'under_review'
+      when po.purpose = 'initial_admission'::public.payment_obligation_purpose_enum
+        and po.available_at <= clock_timestamp() then 'available'
+      when po.purpose = 'recurring'::public.payment_obligation_purpose_enum
+        and po.due_on < timezone(
+          coalesce(po.billing_timezone, o.billing_timezone),
+          clock_timestamp()
+        )::date then 'overdue'
+      when po.purpose = 'recurring'::public.payment_obligation_purpose_enum
+        and po.available_on <= timezone(
+          coalesce(po.billing_timezone, o.billing_timezone),
+          clock_timestamp()
+        )::date then 'available'
+      else 'scheduled'
+    end,
+    po.settled_at,
+    latest_claim.id,
+    latest_claim.status,
+    latest_claim.created_at,
+    latest_claim.decided_at,
+    latest_claim.decision_reason,
+    last_decision.actor_user_id,
+    last_decision.actor_name,
+    last_decision.created_at,
+    coalesce(
+      (
+        select jsonb_agg(
+          jsonb_build_object(
+            'claim_id', history.id,
+            'status', history.status,
+            'payer_type', history.payer_type,
+            'payer_name', history.payer_name,
+            'created_at', history.created_at,
+            'decided_at', history.decided_at,
+            'decision_reason', history.decision_reason
+          )
+          order by history.created_at asc, history.id asc
+        )
+        from public.payment_claims history
+        where history.obligation_id = po.id
+      ),
+      '[]'::jsonb
+    ),
+    coalesce(
+      (
+        select jsonb_agg(
+          jsonb_build_object(
+            'id', audit.id,
+            'claim_id', audit.claim_id,
+            'actor_user_id', audit.actor_user_id,
+            'actor_name', actor_profile.name,
+            'actor_handle', actor_profile.username,
+            'previous_state', audit.previous_state,
+            'next_state', audit.next_state,
+            'reason', audit.reason,
+            'created_at', audit.created_at
+          )
+          order by audit.created_at asc, audit.id asc
+        )
+        from public.payment_claim_audit_events audit
+        left join public.profiles actor_profile on actor_profile.id = audit.actor_user_id
+        where audit.obligation_id = po.id
+      ),
+      '[]'::jsonb
+    )
+  from public.payment_obligations po
+  join public.organizations o on o.id = po.organization_id
+  join public.profiles member_profile on member_profile.id = po.user_id
+  left join lateral (
+    select pc.*
+    from public.payment_claims pc
+    where pc.obligation_id = po.id
+    order by pc.created_at desc, pc.id desc
+    limit 1
+  ) latest_claim on true
+  left join lateral (
+    select
+      audit.actor_user_id,
+      actor_profile.name as actor_name,
+      audit.created_at
+    from public.payment_claim_audit_events audit
+    left join public.profiles actor_profile on actor_profile.id = audit.actor_user_id
+    where audit.obligation_id = po.id
+      and audit.next_state in ('payment_available', 'payment_settled')
+    order by audit.created_at desc, audit.id desc
+    limit 1
+  ) last_decision on true
+  where p_organization_id is not null
+    and po.organization_id = p_organization_id
+    and o.organization_type = 'association'::public.organization_type_enum
+    and exists (
+      select 1
+      from public.organization_members reviewer_membership
+      where reviewer_membership.organization_id = po.organization_id
+        and reviewer_membership.user_id = (select auth.uid())
+        and reviewer_membership.role = 'admin'::public.organization_role_enum
+    )
+  order by po.due_on desc, po.created_at desc, po.id desc;
+$$;
+
+comment on function public.get_billing_workspace_payments(uuid) is
+  'Returns private organization-scoped obligation history with immutable claim decisions and server-derived actors.';
+
+revoke all on function public.get_billing_workspace_payments(uuid)
+  from public, anon;
+grant execute on function public.get_billing_workspace_payments(uuid)
+  to authenticated;
+
+create or replace function public.get_billing_workspace_members(
+  p_organization_id uuid
+)
+returns table (
+  member_user_id uuid,
+  member_name text,
+  member_handle text,
+  member_profile_picture text,
+  member_role public.organization_role_enum,
+  joined_at timestamp with time zone,
+  financial_standing text,
+  overdue_count bigint,
+  oldest_attention_due_on date,
+  plan_type public.subscription_plan_type_enum,
+  last_verified_contribution_at timestamp with time zone,
+  next_due_on date
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select
+    om.user_id,
+    member_profile.name,
+    member_profile.username,
+    member_profile.profile_picture,
+    om.role,
+    om.joined_at,
+    case
+      when coalesce(financial.overdue_count, 0) > 0 then 'overdue'
+      when coalesce(financial.payment_available_count, 0) > 0 then 'payment_available'
+      when coalesce(financial.under_review_count, 0) > 0 then 'under_review'
+      else 'up_to_date'
+    end,
+    coalesce(financial.overdue_count, 0),
+    financial.oldest_attention_due_on,
+    coalesce(current_term.plan_type, active_subscription.plan_type),
+    financial.last_verified_contribution_at,
+    financial.next_due_on
+  from public.organization_members om
+  join public.organizations o on o.id = om.organization_id
+  join public.profiles member_profile on member_profile.id = om.user_id
+  left join public.subscriptions active_subscription
+    on active_subscription.organization_id = om.organization_id
+    and active_subscription.user_id = om.user_id
+    and active_subscription.status = 'active'::public.subscription_status_enum
+  left join lateral (
+    select cpa.plan_type
+    from public.contribution_plan_assignments cpa
+    join public.contribution_schedules cs on cs.id = cpa.schedule_id
+    where cs.organization_id = om.organization_id
+      and cs.user_id = om.user_id
+      and cs.active
+      and cpa.effective_period_start <= timezone(o.billing_timezone, clock_timestamp())::date
+    order by cpa.effective_period_start desc, cpa.id desc
+    limit 1
+  ) current_term on true
+  left join lateral (
+    select
+      count(*) filter (
+        where po.purpose = 'recurring'::public.payment_obligation_purpose_enum
+          and po.status not in (
+            'settled'::public.payment_obligation_status_enum,
+            'void'::public.payment_obligation_status_enum
+          )
+          and po.due_on < timezone(
+            coalesce(po.billing_timezone, o.billing_timezone),
+            clock_timestamp()
+          )::date
+      ) as overdue_count,
+      count(*) filter (
+        where po.status not in (
+            'settled'::public.payment_obligation_status_enum,
+            'void'::public.payment_obligation_status_enum
+          )
+          and not exists (
+            select 1
+            from public.payment_claims pc
+            where pc.obligation_id = po.id
+              and pc.status = 'under_review'::public.payment_claim_status_enum
+          )
+          and (
+            (
+              po.purpose = 'initial_admission'::public.payment_obligation_purpose_enum
+              and po.available_at <= clock_timestamp()
+            )
+            or (
+              po.purpose = 'recurring'::public.payment_obligation_purpose_enum
+              and po.available_on <= timezone(
+                coalesce(po.billing_timezone, o.billing_timezone),
+                clock_timestamp()
+              )::date
+            )
+          )
+      ) as payment_available_count,
+      count(*) filter (
+        where po.status not in (
+          'settled'::public.payment_obligation_status_enum,
+          'void'::public.payment_obligation_status_enum
+        )
+        and exists (
+          select 1
+          from public.payment_claims pc
+          where pc.obligation_id = po.id
+            and pc.status = 'under_review'::public.payment_claim_status_enum
+        )
+      ) as under_review_count,
+      min(
+        case
+          when po.status not in (
+            'settled'::public.payment_obligation_status_enum,
+            'void'::public.payment_obligation_status_enum
+          )
+          and (
+            po.due_on < timezone(
+              coalesce(po.billing_timezone, o.billing_timezone),
+              clock_timestamp()
+            )::date
+            or po.available_at <= clock_timestamp()
+            or po.available_on <= timezone(
+              coalesce(po.billing_timezone, o.billing_timezone),
+              clock_timestamp()
+            )::date
+            or exists (
+              select 1
+              from public.payment_claims pc
+              where pc.obligation_id = po.id
+                and pc.status = 'under_review'::public.payment_claim_status_enum
+            )
+          ) then po.due_on
+        end
+      ) as oldest_attention_due_on,
+      max(
+        case
+          when po.status = 'settled'::public.payment_obligation_status_enum
+            then po.settled_at
+        end
+      ) as last_verified_contribution_at,
+      min(
+        case
+          when po.purpose = 'recurring'::public.payment_obligation_purpose_enum
+            and po.status not in (
+              'settled'::public.payment_obligation_status_enum,
+              'void'::public.payment_obligation_status_enum
+            )
+            and po.due_on >= timezone(
+              coalesce(po.billing_timezone, o.billing_timezone),
+              clock_timestamp()
+            )::date
+            then po.due_on
+        end
+      ) as next_due_on
+    from public.payment_obligations po
+    where po.organization_id = om.organization_id
+      and po.user_id = om.user_id
+  ) financial on true
+  where p_organization_id is not null
+    and om.organization_id = p_organization_id
+    and o.organization_type = 'association'::public.organization_type_enum
+    and om.role in (
+      'admin'::public.organization_role_enum,
+      'member'::public.organization_role_enum
+    )
+    and exists (
+      select 1
+      from public.organization_members reviewer_membership
+      where reviewer_membership.organization_id = om.organization_id
+        and reviewer_membership.user_id = (select auth.uid())
+        and reviewer_membership.role = 'admin'::public.organization_role_enum
+    )
+  order by member_profile.name, member_profile.username, om.user_id;
+$$;
+
+comment on function public.get_billing_workspace_members(uuid) is
+  'Returns the active association roster with server-derived financial standing and obligation attention.';
+
+revoke all on function public.get_billing_workspace_members(uuid)
+  from public, anon;
+grant execute on function public.get_billing_workspace_members(uuid)
+  to authenticated;

--- a/supabase/tests/billing_workspace_test.sql
+++ b/supabase/tests/billing_workspace_test.sql
@@ -1,0 +1,433 @@
+begin;
+
+select * from no_plan();
+
+set local role postgres;
+
+insert into public.organizations (
+  id,
+  name,
+  slug,
+  organization_type,
+  billing_currency,
+  billing_timezone,
+  billing_due_day,
+  billing_lead_days,
+  monthly_price_amount,
+  annual_price_amount,
+  monthly_pix_copy_paste,
+  annual_pix_copy_paste
+)
+values
+  (
+    '82000000-0000-4000-8000-000000000001'::uuid,
+    'Workspace Association',
+    'workspace-association',
+    'association',
+    'BRL',
+    'America/Sao_Paulo',
+    10,
+    7,
+    12500,
+    120000,
+    '000201workspace-monthly',
+    '000201workspace-annual'
+  ),
+  (
+    '82000000-0000-4000-8000-000000000002'::uuid,
+    'Workspace Group',
+    'workspace-group',
+    'group',
+    'BRL',
+    'America/Sao_Paulo',
+    10,
+    7,
+    12500,
+    120000,
+    '000201group-monthly',
+    '000201group-annual'
+  );
+
+insert into auth.users (
+  id,
+  aud,
+  role,
+  email,
+  email_confirmed_at,
+  raw_user_meta_data,
+  created_at,
+  updated_at
+)
+values
+  (
+    '82000000-0000-4000-8000-000000000101'::uuid,
+    'authenticated',
+    'authenticated',
+    'workspace-admin@example.com',
+    timezone('utc'::text, now()),
+    '{"full_name":"Workspace Admin"}'::jsonb,
+    timezone('utc'::text, now()),
+    timezone('utc'::text, now())
+  ),
+  (
+    '82000000-0000-4000-8000-000000000102'::uuid,
+    'authenticated',
+    'authenticated',
+    'workspace-member@example.com',
+    timezone('utc'::text, now()),
+    '{"full_name":"Workspace Member"}'::jsonb,
+    timezone('utc'::text, now()),
+    timezone('utc'::text, now())
+  ),
+  (
+    '82000000-0000-4000-8000-000000000103'::uuid,
+    'authenticated',
+    'authenticated',
+    'workspace-group-admin@example.com',
+    timezone('utc'::text, now()),
+    '{"full_name":"Workspace Group Admin"}'::jsonb,
+    timezone('utc'::text, now()),
+    timezone('utc'::text, now())
+  );
+
+insert into public.profiles (id, name, username)
+values
+  (
+    '82000000-0000-4000-8000-000000000101'::uuid,
+    'Workspace Admin',
+    '@workspace_admin'
+  ),
+  (
+    '82000000-0000-4000-8000-000000000102'::uuid,
+    'Workspace Member',
+    '@workspace_member'
+  ),
+  (
+    '82000000-0000-4000-8000-000000000103'::uuid,
+    'Workspace Group Admin',
+    '@workspace_group_admin'
+  )
+on conflict (id) do update
+set name = excluded.name,
+    username = excluded.username;
+
+insert into public.organization_members (organization_id, user_id, role)
+values
+  (
+    '82000000-0000-4000-8000-000000000001'::uuid,
+    '82000000-0000-4000-8000-000000000101'::uuid,
+    'admin'
+  ),
+  (
+    '82000000-0000-4000-8000-000000000001'::uuid,
+    '82000000-0000-4000-8000-000000000102'::uuid,
+    'member'
+  ),
+  (
+    '82000000-0000-4000-8000-000000000002'::uuid,
+    '82000000-0000-4000-8000-000000000103'::uuid,
+    'admin'
+  );
+
+insert into public.subscriptions (
+  organization_id,
+  user_id,
+  plan_type,
+  status,
+  current_period_end
+)
+values (
+  '82000000-0000-4000-8000-000000000001'::uuid,
+  '82000000-0000-4000-8000-000000000102'::uuid,
+  'monthly',
+  'active',
+  timezone('utc'::text, now()) + interval '1 month'
+);
+
+insert into public.payment_obligations (
+  id,
+  organization_id,
+  user_id,
+  application_revision_id,
+  purpose,
+  status,
+  plan_type,
+  amount,
+  currency,
+  payment_method,
+  pix_copy_paste,
+  available_at,
+  schedule_id,
+  period_key,
+  period_start,
+  period_end,
+  available_on,
+  due_on
+)
+select
+  obligation.id,
+  '82000000-0000-4000-8000-000000000001'::uuid,
+  '82000000-0000-4000-8000-000000000102'::uuid,
+  null,
+  'recurring',
+  'available',
+  'monthly',
+  12500,
+  'BRL',
+  'manual_pix',
+  '000201workspace-monthly',
+  timezone('utc'::text, now()),
+  cs.id,
+  obligation.period_key,
+  current_date,
+  obligation.due_on,
+  current_date - 1,
+  obligation.due_on
+from (
+  values
+    (
+      '82000000-0000-4000-8000-000000000201'::uuid,
+      'workspace:current',
+      (current_date + 7)::date
+    ),
+    (
+      '82000000-0000-4000-8000-000000000202'::uuid,
+      'workspace:retry',
+      (current_date + 14)::date
+    )
+) as obligation(id, period_key, due_on)
+join public.contribution_schedules cs
+  on cs.organization_id = '82000000-0000-4000-8000-000000000001'::uuid
+  and cs.user_id = '82000000-0000-4000-8000-000000000102'::uuid;
+
+insert into public.payment_claims (
+  id,
+  obligation_id,
+  organization_id,
+  claimant_user_id,
+  payer_type,
+  payer_name,
+  status
+)
+values
+  (
+    '82000000-0000-4000-8000-000000000301'::uuid,
+    '82000000-0000-4000-8000-000000000201'::uuid,
+    '82000000-0000-4000-8000-000000000001'::uuid,
+    '82000000-0000-4000-8000-000000000102'::uuid,
+    'applicant',
+    null,
+    'under_review'
+  ),
+  (
+    '82000000-0000-4000-8000-000000000302'::uuid,
+    '82000000-0000-4000-8000-000000000202'::uuid,
+    '82000000-0000-4000-8000-000000000001'::uuid,
+    '82000000-0000-4000-8000-000000000102'::uuid,
+    'other',
+    'Workspace Payer',
+    'under_review'
+  );
+
+insert into public.payment_claim_audit_events (
+  organization_id,
+  obligation_id,
+  claim_id,
+  actor_user_id,
+  previous_state,
+  next_state
+)
+values
+  (
+    '82000000-0000-4000-8000-000000000001'::uuid,
+    '82000000-0000-4000-8000-000000000201'::uuid,
+    '82000000-0000-4000-8000-000000000301'::uuid,
+    '82000000-0000-4000-8000-000000000102'::uuid,
+    'payment_available',
+    'under_review'
+  ),
+  (
+    '82000000-0000-4000-8000-000000000001'::uuid,
+    '82000000-0000-4000-8000-000000000202'::uuid,
+    '82000000-0000-4000-8000-000000000302'::uuid,
+    '82000000-0000-4000-8000-000000000102'::uuid,
+    'payment_available',
+    'under_review'
+  );
+
+set local role authenticated;
+select set_config('request.jwt.claim.role', 'authenticated', true);
+select set_config(
+  'request.jwt.claim.sub',
+  '82000000-0000-4000-8000-000000000101',
+  true
+);
+
+select is(
+  (select count(*)::integer from public.get_billing_workspace_organizations()),
+  1,
+  'the workspace lists only association admin scopes'
+);
+
+select is(
+  (select count(*)::integer
+   from public.get_billing_workspace_queue(
+     '82000000-0000-4000-8000-000000000001'::uuid
+   )),
+  2,
+  'the queue combines the association''s recurring claims'
+);
+
+select is(
+  (select approve_command
+   from public.get_billing_workspace_queue(
+     '82000000-0000-4000-8000-000000000001'::uuid
+   )
+   where claim_id = '82000000-0000-4000-8000-000000000301'::uuid),
+  'approve_recurring_payment_claim',
+  'recurring queue rows expose the purpose-specific approval command'
+);
+
+select is(
+  (select count(*)::integer
+   from public.get_billing_workspace_claim_detail(
+     '82000000-0000-4000-8000-000000000301'::uuid
+   )),
+  1,
+  'an association admin can inspect an authorized recurring claim'
+);
+
+select is(
+  (select audit_history->0->>'actor_name'
+   from public.get_billing_workspace_claim_detail(
+     '82000000-0000-4000-8000-000000000301'::uuid
+   )),
+  'Workspace Member',
+  'claim detail keeps the server-derived audit actor'
+);
+
+select is(
+  (select effective_payment_state
+   from public.get_billing_workspace_payments(
+     '82000000-0000-4000-8000-000000000001'::uuid
+   )
+   where obligation_id = '82000000-0000-4000-8000-000000000201'::uuid),
+  'under_review',
+  'payments expose the current effective obligation state'
+);
+
+select is(
+  (select financial_standing
+   from public.get_billing_workspace_members(
+     '82000000-0000-4000-8000-000000000001'::uuid
+   )
+   where member_user_id = '82000000-0000-4000-8000-000000000102'::uuid),
+  'under_review',
+  'members derive standing from the active claim'
+);
+
+select is(
+  (select decision_applied_now
+   from public.approve_recurring_payment_claim(
+     '82000000-0000-4000-8000-000000000301'::uuid
+   )),
+  true,
+  'approval settles one recurring obligation'
+);
+
+select is(
+  (select role::text
+   from public.organization_members
+   where organization_id = '82000000-0000-4000-8000-000000000001'::uuid
+     and user_id = '82000000-0000-4000-8000-000000000102'::uuid),
+  'member',
+  'recurring approval never changes legal membership'
+);
+
+select is(
+  (select effective_payment_state
+   from public.get_billing_workspace_payments(
+     '82000000-0000-4000-8000-000000000001'::uuid
+   )
+   where obligation_id = '82000000-0000-4000-8000-000000000201'::uuid),
+  'settled',
+  'payments refresh from the settled obligation state'
+);
+
+select is(
+  (select decision_reason
+   from public.reject_recurring_payment_claim(
+     '82000000-0000-4000-8000-000000000302'::uuid,
+     '  Retry   with   the   correct   payer  '
+   )),
+  'Retry with the correct payer',
+  'recurring rejection normalizes and preserves its reason'
+);
+
+select is(
+  (select status::text
+   from public.payment_obligations
+   where id = '82000000-0000-4000-8000-000000000202'::uuid),
+  'available',
+  'recurring rejection leaves the obligation actionable'
+);
+
+select is(
+  (select decision_applied_now
+   from public.reject_recurring_payment_claim(
+     '82000000-0000-4000-8000-000000000302'::uuid,
+     'Retry with the correct payer'
+   )),
+  false,
+  'identical recurring rejection retries are idempotent'
+);
+
+set local role postgres;
+
+select throws_ok(
+  $$select * from public.reject_recurring_payment_claim(
+    '82000000-0000-4000-8000-000000000302'::uuid,
+    'Different reason'
+  )$$,
+  '40001',
+  'This claim was already rejected with a different reason. Refresh before deciding.',
+  'a conflicting recurring rejection cannot rewrite history'
+);
+
+set local role authenticated;
+
+select set_config(
+  'request.jwt.claim.sub',
+  '82000000-0000-4000-8000-000000000103',
+  true
+);
+
+select is(
+  (select count(*)::integer
+   from public.get_billing_workspace_queue(
+     '82000000-0000-4000-8000-000000000002'::uuid
+   )),
+  0,
+  'a group admin cannot list an association billing workspace'
+);
+
+select is(
+  (select count(*)::integer
+   from public.get_billing_workspace_claim_detail(
+     '82000000-0000-4000-8000-000000000301'::uuid
+   )),
+  0,
+  'a group admin cannot inspect an association claim'
+);
+
+select throws_ok(
+  $$select * from public.approve_recurring_payment_claim(
+    '82000000-0000-4000-8000-000000000301'::uuid
+  )$$,
+  '42501',
+  'Association admin access is required.',
+  'a group admin cannot decide an association claim'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
Closes #210

## Summary

- add an association-admin billing workspace with Queue, Payments, and Members views
- combine initial-admission and recurring claims while keeping purpose-specific review actions
- keep all reads and decisions organization-scoped, privacy-preserving, idempotent, conflict-safe, and auditable
- expose derived member financial standing without changing legal membership or recurring schedules
- preserve the existing member recurring static-PIX claim flow and refresh billing state after submission
- add indexes, generated Supabase types, and pgTAP coverage for scope, history, decisions, rejection retries, and conflict behavior

## Validation

- `supabase db lint --local --schema public --level error --fail-on error`
- `supabase test db --local` (135 tests)
- `pnpm --dir next exec tsc --noEmit`
- targeted ESLint for the new billing workspace files
- `pnpm --dir next build`