### PR TITLE
feat: send deduplicated contribution reminders

### DIFF
--- a/deploy-functions.sh
+++ b/deploy-functions.sh
@@ -20,6 +20,15 @@ npx supabase functions deploy stripe-webhook --no-verify-jwt
 echo -e "${GREEN}Deploying generate-renewal-payments...${NC}"
 npx supabase functions deploy generate-renewal-payments
 
+echo -e "${GREEN}Deploying contribution-reminder-enqueuer...${NC}"
+npx supabase functions deploy contribution-reminder-enqueuer
+
+echo -e "${GREEN}Deploying contribution-reminder-dispatcher...${NC}"
+npx supabase functions deploy contribution-reminder-dispatcher
+
+echo -e "${GREEN}Deploying contribution-reminder-receipts...${NC}"
+npx supabase functions deploy contribution-reminder-receipts
+
 echo -e "${GREEN}Deploying push-notification...${NC}"
 npx supabase functions deploy push-notification
 

--- a/expo/context/auth.tsx
+++ b/expo/context/auth.tsx
@@ -19,6 +19,7 @@ import { z } from 'zod';
 
 import { useMountEffect } from '~/hooks/use-mount-effect';
 import { useProfile, type Profile } from '~/hooks/use-profile';
+import { unregisterActivePushToken } from '~/lib/push-token-registration';
 import { supabase } from '~/lib/supabase';
 
 type AuthMethodResponse = Promise<
@@ -211,6 +212,12 @@ export function AuthProvider(props: React.PropsWithChildren) {
 
   const logout = useCallback(async (): AuthMethodResponse => {
     try {
+      try {
+        await unregisterActivePushToken();
+      } catch (error) {
+        console.warn('Failed to unregister the push token on logout:', error);
+      }
+
       const { error } = await supabase.auth.signOut();
       if (error) throw error;
       invalidateProfile();

--- a/expo/context/notifications.tsx
+++ b/expo/context/notifications.tsx
@@ -3,9 +3,10 @@ import Constants from 'expo-constants';
 import * as Device from 'expo-device';
 import * as Notifications from 'expo-notifications';
 import { Href, router } from 'expo-router';
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, { createContext, useContext, useState } from 'react';
 import { Platform } from 'react-native';
 
+import { useMountEffect } from '~/hooks/use-mount-effect';
 import { registerPushTokenForProfile } from '~/lib/push-token-registration';
 
 import { useAuth } from './auth';
@@ -128,7 +129,7 @@ export function NotificationProvider({
     Notifications.Notification | undefined
   >(undefined);
 
-  useEffect(() => {
+  useMountEffect(() => {
     registerForPushNotificationsAsync().then(
       (token) => token && setExpoPushToken(token),
     );
@@ -139,16 +140,10 @@ export function NotificationProvider({
       },
     );
 
-    const responseListener =
-      Notifications.addNotificationResponseReceivedListener((response) => {
-        console.log(response);
-      });
-
     return () => {
       notificationListener.remove();
-      responseListener.remove();
     };
-  }, []);
+  });
 
   useQuery({
     queryKey: ['push-token-registration', expoPushToken, profile?.id, locale],
@@ -184,7 +179,7 @@ export function NotificationProvider({
 }
 
 function useNotificationObserver() {
-  useEffect(() => {
+  useMountEffect(() => {
     let isMounted = true;
 
     function redirect(notification: Notifications.Notification) {
@@ -211,7 +206,7 @@ function useNotificationObserver() {
       isMounted = false;
       subscription.remove();
     };
-  }, []);
+  });
 }
 
 export function useNotification() {

--- a/expo/lib/push-token-registration.test.ts
+++ b/expo/lib/push-token-registration.test.ts
@@ -1,41 +1,22 @@
 import { supabase } from '~/lib/supabase';
 
-import { registerPushTokenForProfile } from './push-token-registration';
+import {
+  registerPushTokenForProfile,
+  unregisterActivePushToken,
+} from './push-token-registration';
 
-jest.mock('~/lib/supabase', () => {
-  const chain = {
-    eq: jest.fn(),
-    insert: jest.fn(),
-    maybeSingle: jest.fn(),
-    select: jest.fn(),
-    update: jest.fn(),
-  };
+jest.mock('~/lib/supabase', () => ({
+  supabase: { rpc: jest.fn() },
+}));
 
-  for (const method of ['eq', 'select', 'update'] as const) {
-    chain[method].mockReturnValue(chain);
-  }
+const mockRpc = jest.mocked(supabase.rpc);
 
-  return { supabase: { from: jest.fn(() => chain) } };
-});
-
-const mockFrom = jest.mocked(supabase.from);
-const mockChain = mockFrom('push_tokens') as unknown as {
-  eq: jest.Mock;
-  insert: jest.Mock;
-  maybeSingle: jest.Mock;
-  select: jest.Mock;
-  update: jest.Mock;
-};
-
-describe('registerPushTokenForProfile', () => {
+describe('push token ownership commands', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    for (const method of ['eq', 'select', 'update'] as const) {
-      mockChain[method].mockReturnValue(mockChain);
-    }
   });
 
-  it('does not insert an unowned token while the profile is unavailable', async () => {
+  it('does not register a token while the profile is unavailable', async () => {
     await expect(
       registerPushTokenForProfile({
         expoPushToken: 'ExponentPushToken[test]',
@@ -44,73 +25,62 @@ describe('registerPushTokenForProfile', () => {
       }),
     ).resolves.toBe('skipped');
 
-    expect(mockFrom).not.toHaveBeenCalled();
+    expect(mockRpc).not.toHaveBeenCalled();
   });
 
-  it('inserts a new token with its signed-in owner', async () => {
-    mockChain.maybeSingle.mockResolvedValue({ data: null, error: null });
-    mockChain.insert.mockResolvedValue({ error: null });
+  it('registers a new token through the authenticated command', async () => {
+    mockRpc.mockResolvedValue({ data: 'registered', error: null } as never);
 
     await expect(
       registerPushTokenForProfile({
         expoPushToken: 'ExponentPushToken[test]',
         locale: 'pt',
-        profileId: 'profile-1',
-      }),
-    ).resolves.toBe('inserted');
-
-    expect(mockChain.insert).toHaveBeenCalledWith({
-      language: 'pt',
-      profile_id: 'profile-1',
-      token: 'ExponentPushToken[test]',
-    });
-  });
-
-  it('updates only a token already owned by the signed-in profile', async () => {
-    mockChain.maybeSingle.mockResolvedValue({
-      data: { id: 12, profile_id: 'profile-1' },
-      error: null,
-    });
-
-    await expect(
-      registerPushTokenForProfile({
-        expoPushToken: 'ExponentPushToken[test]',
-        locale: 'en',
         profileId: 'profile-1',
       }),
     ).resolves.toBe('updated');
 
-    expect(mockChain.update).toHaveBeenCalledWith(
-      expect.objectContaining({ language: 'en' }),
-    );
-    expect(mockChain.eq).toHaveBeenLastCalledWith('id', 12);
+    expect(mockRpc).toHaveBeenCalledWith('register_push_token', {
+      p_language: 'pt',
+      p_token: 'ExponentPushToken[test]',
+    });
   });
 
-  it('does not reassign a token owned by another profile', async () => {
-    mockChain.maybeSingle.mockResolvedValue({
-      data: { id: 12, profile_id: 'profile-2' },
-      error: null,
+  it('uses the same command for repeated registration and account switching', async () => {
+    mockRpc.mockResolvedValue({ data: 'registered', error: null } as never);
+
+    await registerPushTokenForProfile({
+      expoPushToken: 'ExponentPushToken[test]',
+      locale: 'en',
+      profileId: 'profile-2',
     });
 
-    await expect(
-      registerPushTokenForProfile({
-        expoPushToken: 'ExponentPushToken[test]',
-        locale: 'pt',
-        profileId: 'profile-1',
-      }),
-    ).rejects.toThrow(
-      'This push token is already associated with a different profile.',
-    );
-
-    expect(mockChain.update).not.toHaveBeenCalled();
-    expect(mockChain.insert).not.toHaveBeenCalled();
+    expect(mockRpc).toHaveBeenLastCalledWith('register_push_token', {
+      p_language: 'en',
+      p_token: 'ExponentPushToken[test]',
+    });
   });
 
-  it('surfaces database failures', async () => {
-    mockChain.maybeSingle.mockResolvedValue({
+  it('unregisters the active token on logout', async () => {
+    mockRpc.mockResolvedValue({ data: 'registered', error: null } as never);
+    await registerPushTokenForProfile({
+      expoPushToken: 'ExponentPushToken[test]',
+      locale: 'pt',
+      profileId: 'profile-1',
+    });
+
+    mockRpc.mockResolvedValue({ data: true, error: null } as never);
+    await unregisterActivePushToken();
+
+    expect(mockRpc).toHaveBeenLastCalledWith('unregister_push_token', {
+      p_token: 'ExponentPushToken[test]',
+    });
+  });
+
+  it('surfaces registration failures', async () => {
+    mockRpc.mockResolvedValue({
       data: null,
-      error: { message: 'lookup failed' },
-    });
+      error: { message: 'registration failed' },
+    } as never);
 
     await expect(
       registerPushTokenForProfile({
@@ -118,6 +88,6 @@ describe('registerPushTokenForProfile', () => {
         locale: 'pt',
         profileId: 'profile-1',
       }),
-    ).rejects.toThrow('Could not look up the push token: lookup failed');
+    ).rejects.toThrow('Could not register the push token: registration failed');
   });
 });

--- a/expo/lib/push-token-registration.ts
+++ b/expo/lib/push-token-registration.ts
@@ -10,10 +10,12 @@ type PushTokenRegistration = {
 
 export type PushTokenRegistrationResult = 'inserted' | 'skipped' | 'updated';
 
+let activeExpoPushToken: string | null = null;
+
 /**
- * Associates a device token only after the signed-in profile is available.
- * Existing tokens are never reassigned client-side because the current RLS
- * policy intentionally permits updates only by the owning profile.
+ * Associates a device token through the authenticated database command. The
+ * command atomically transfers ownership when a shared device changes
+ * accounts, so the previous profile cannot keep receiving reminders.
  */
 export async function registerPushTokenForProfile({
   expoPushToken,
@@ -22,51 +24,30 @@ export async function registerPushTokenForProfile({
 }: PushTokenRegistration): Promise<PushTokenRegistrationResult> {
   if (!expoPushToken || !profileId) return 'skipped';
 
-  const { data: existingToken, error: selectError } = await supabase
-    .from('push_tokens')
-    .select('id, profile_id')
-    .eq('token', expoPushToken)
-    .maybeSingle();
-
-  if (selectError) {
-    throw new Error(`Could not look up the push token: ${selectError.message}`);
-  }
-
-  if (existingToken) {
-    if (existingToken.profile_id !== profileId) {
-      throw new Error(
-        'This push token is already associated with a different profile.',
-      );
-    }
-
-    const { error: updateError } = await supabase
-      .from('push_tokens')
-      .update({
-        language: locale,
-        created_at: new Date().toISOString(),
-      })
-      .eq('id', existingToken.id);
-
-    if (updateError) {
-      throw new Error(
-        `Could not update the push token: ${updateError.message}`,
-      );
-    }
-
-    return 'updated';
-  }
-
-  const { error: insertError } = await supabase.from('push_tokens').insert({
-    token: expoPushToken,
-    profile_id: profileId,
-    language: locale,
+  activeExpoPushToken = expoPushToken;
+  const { data, error } = await supabase.rpc('register_push_token', {
+    p_language: locale,
+    p_token: expoPushToken,
   });
 
-  if (insertError) {
-    throw new Error(
-      `Could not register the push token: ${insertError.message}`,
-    );
+  if (error) {
+    throw new Error(`Could not register the push token: ${error.message}`);
   }
 
-  return 'inserted';
+  return data === 'registered' ? 'updated' : 'inserted';
+}
+
+export async function unregisterActivePushToken(): Promise<void> {
+  if (!activeExpoPushToken) return;
+
+  const token = activeExpoPushToken;
+  const { error } = await supabase.rpc('unregister_push_token', {
+    p_token: token,
+  });
+
+  if (error) {
+    throw new Error(`Could not unregister the push token: ${error.message}`);
+  }
+
+  activeExpoPushToken = null;
 }

--- a/packages/database/database-generated.types.ts
+++ b/packages/database/database-generated.types.ts
@@ -77,6 +77,244 @@ export type Database = {
           },
         ]
       }
+      contribution_reminder_batch_events: {
+        Row: {
+          batch_id: string
+          created_at: string
+          event_id: string
+        }
+        Insert: {
+          batch_id: string
+          created_at?: string
+          event_id: string
+        }
+        Update: {
+          batch_id?: string
+          created_at?: string
+          event_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "contribution_reminder_batch_events_batch_id_fkey"
+            columns: ["batch_id"]
+            isOneToOne: false
+            referencedRelation: "contribution_reminder_batches"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "contribution_reminder_batch_events_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: true
+            referencedRelation: "contribution_reminder_events"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      contribution_reminder_batches: {
+        Row: {
+          attempt_count: number
+          created_at: string
+          delivered_at: string | null
+          delivery_window_on: string
+          id: string
+          last_failure_code: string | null
+          lease_expires_at: string | null
+          lease_token: string | null
+          next_attempt_at: string
+          organization_id: string
+          recipient_user_id: string
+          status: Database["public"]["Enums"]["contribution_reminder_batch_status_enum"]
+          updated_at: string
+        }
+        Insert: {
+          attempt_count?: number
+          created_at?: string
+          delivered_at?: string | null
+          delivery_window_on: string
+          id?: string
+          last_failure_code?: string | null
+          lease_expires_at?: string | null
+          lease_token?: string | null
+          next_attempt_at?: string
+          organization_id: string
+          recipient_user_id: string
+          status?: Database["public"]["Enums"]["contribution_reminder_batch_status_enum"]
+          updated_at?: string
+        }
+        Update: {
+          attempt_count?: number
+          created_at?: string
+          delivered_at?: string | null
+          delivery_window_on?: string
+          id?: string
+          last_failure_code?: string | null
+          lease_expires_at?: string | null
+          lease_token?: string | null
+          next_attempt_at?: string
+          organization_id?: string
+          recipient_user_id?: string
+          status?: Database["public"]["Enums"]["contribution_reminder_batch_status_enum"]
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "contribution_reminder_batches_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "contribution_reminder_batches_recipient_user_id_fkey"
+            columns: ["recipient_user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      contribution_reminder_delivery_attempts: {
+        Row: {
+          attempt_count: number
+          batch_id: string
+          created_at: string
+          expo_receipt_error_code: string | null
+          expo_receipt_status: string | null
+          expo_ticket_id: string | null
+          id: string
+          language: Database["public"]["Enums"]["language"] | null
+          lease_expires_at: string | null
+          lease_token: string | null
+          next_attempt_at: string
+          next_receipt_check_at: string | null
+          push_token_id: number | null
+          status: Database["public"]["Enums"]["contribution_reminder_attempt_status_enum"]
+          terminal_outcome: string | null
+          token: string
+          updated_at: string
+        }
+        Insert: {
+          attempt_count?: number
+          batch_id: string
+          created_at?: string
+          expo_receipt_error_code?: string | null
+          expo_receipt_status?: string | null
+          expo_ticket_id?: string | null
+          id?: string
+          language?: Database["public"]["Enums"]["language"] | null
+          lease_expires_at?: string | null
+          lease_token?: string | null
+          next_attempt_at?: string
+          next_receipt_check_at?: string | null
+          push_token_id?: number | null
+          status?: Database["public"]["Enums"]["contribution_reminder_attempt_status_enum"]
+          terminal_outcome?: string | null
+          token: string
+          updated_at?: string
+        }
+        Update: {
+          attempt_count?: number
+          batch_id?: string
+          created_at?: string
+          expo_receipt_error_code?: string | null
+          expo_receipt_status?: string | null
+          expo_ticket_id?: string | null
+          id?: string
+          language?: Database["public"]["Enums"]["language"] | null
+          lease_expires_at?: string | null
+          lease_token?: string | null
+          next_attempt_at?: string
+          next_receipt_check_at?: string | null
+          push_token_id?: number | null
+          status?: Database["public"]["Enums"]["contribution_reminder_attempt_status_enum"]
+          terminal_outcome?: string | null
+          token?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "contribution_reminder_delivery_attempts_batch_id_fkey"
+            columns: ["batch_id"]
+            isOneToOne: false
+            referencedRelation: "contribution_reminder_batches"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "contribution_reminder_delivery_attempts_push_token_id_fkey"
+            columns: ["push_token_id"]
+            isOneToOne: false
+            referencedRelation: "push_tokens"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      contribution_reminder_events: {
+        Row: {
+          created_at: string
+          delivered_at: string | null
+          delivery_window_on: string
+          id: string
+          obligation_id: string
+          organization_id: string
+          recipient_user_id: string
+          stage: Database["public"]["Enums"]["contribution_reminder_stage_enum"]
+          stage_on: string
+          status: Database["public"]["Enums"]["contribution_reminder_event_status_enum"]
+          suppression_reason: string | null
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          delivered_at?: string | null
+          delivery_window_on: string
+          id?: string
+          obligation_id: string
+          organization_id: string
+          recipient_user_id: string
+          stage: Database["public"]["Enums"]["contribution_reminder_stage_enum"]
+          stage_on: string
+          status?: Database["public"]["Enums"]["contribution_reminder_event_status_enum"]
+          suppression_reason?: string | null
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          delivered_at?: string | null
+          delivery_window_on?: string
+          id?: string
+          obligation_id?: string
+          organization_id?: string
+          recipient_user_id?: string
+          stage?: Database["public"]["Enums"]["contribution_reminder_stage_enum"]
+          stage_on?: string
+          status?: Database["public"]["Enums"]["contribution_reminder_event_status_enum"]
+          suppression_reason?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "contribution_reminder_events_obligation_id_fkey"
+            columns: ["obligation_id"]
+            isOneToOne: false
+            referencedRelation: "payment_obligations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "contribution_reminder_events_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "contribution_reminder_events_recipient_user_id_fkey"
+            columns: ["recipient_user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       contribution_schedules: {
         Row: {
           active: boolean
@@ -1151,6 +1389,7 @@ export type Database = {
           billing_due_day: number
           billing_lead_days: number
           billing_timezone: string
+          contribution_reminder_local_time: string
           created_at: string
           id: string
           membership_terms_version: string
@@ -1167,6 +1406,7 @@ export type Database = {
           billing_due_day?: number
           billing_lead_days?: number
           billing_timezone?: string
+          contribution_reminder_local_time?: string
           created_at?: string
           id?: string
           membership_terms_version?: string
@@ -1183,6 +1423,7 @@ export type Database = {
           billing_due_day?: number
           billing_lead_days?: number
           billing_timezone?: string
+          contribution_reminder_local_time?: string
           created_at?: string
           id?: string
           membership_terms_version?: string
@@ -1920,6 +2161,22 @@ export type Database = {
           isSetofReturn: false
         }
       }
+      claim_contribution_reminder_batches: {
+        Args: { p_lease_seconds?: number; p_limit?: number }
+        Returns: {
+          batch_id: string
+          lease_token: string
+        }[]
+      }
+      claim_contribution_reminder_receipts: {
+        Args: { p_lease_seconds?: number; p_limit?: number }
+        Returns: {
+          attempt_id: string
+          batch_id: string
+          expo_ticket_id: string
+          lease_token: string
+        }[]
+      }
       claim_initial_payment: {
         Args: {
           p_obligation_id: string
@@ -1955,6 +2212,36 @@ export type Database = {
       clamped_billing_date: {
         Args: { p_day: number; p_month: number; p_year: number }
         Returns: string
+      }
+      contribution_reminder_backoff: {
+        Args: { p_attempt_count: number }
+        Returns: unknown
+      }
+      contribution_reminder_delivery_at: {
+        Args: { p_local_time: string; p_stage_on: string; p_timezone: string }
+        Returns: string
+      }
+      contribution_reminder_stage_for_date: {
+        Args: { p_available_on: string; p_due_on: string; p_local_date: string }
+        Returns: Database["public"]["Enums"]["contribution_reminder_stage_enum"]
+      }
+      enqueue_contribution_reminder_events: {
+        Args: never
+        Returns: {
+          coalesced_count: number
+          created_count: number
+          skipped_count: number
+          suppressed_count: number
+        }[]
+      }
+      enqueue_contribution_reminder_events_at: {
+        Args: { p_as_of: string }
+        Returns: {
+          coalesced_count: number
+          created_count: number
+          skipped_count: number
+          suppressed_count: number
+        }[]
       }
       enqueue_festival_schedule_open_notifications: {
         Args: never
@@ -2011,34 +2298,34 @@ export type Database = {
         Args: { p_claim_id: string }
         Returns: {
           amount: number
-          approve_command: string | null
+          approve_command: string
           attempt_count: number
           audit_history: Json
           available_on: string
           claim_created_at: string
-          claim_decided_at: string | null
-          claim_decision_reason: string | null
+          claim_decided_at: string
+          claim_decision_reason: string
           claim_history: Json
           claim_id: string
           claim_status: Database["public"]["Enums"]["payment_claim_status_enum"]
           currency: string
           due_on: string
-          member_handle: string | null
-          member_name: string | null
-          member_profile_picture: string | null
+          member_handle: string
+          member_name: string
+          member_profile_picture: string
           member_user_id: string
           obligation_id: string
           organization_id: string
           organization_name: string
           organization_slug: string
-          payer_name: string | null
+          payer_name: string
           payer_type: Database["public"]["Enums"]["payment_claim_payer_type_enum"]
           period_end: string
           period_key: string
           period_start: string
           plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"]
           purpose: Database["public"]["Enums"]["payment_obligation_purpose_enum"]
-          reject_command: string | null
+          reject_command: string
         }[]
       }
       get_billing_workspace_members: {
@@ -2046,16 +2333,16 @@ export type Database = {
         Returns: {
           financial_standing: string
           joined_at: string
-          last_verified_contribution_at: string | null
-          member_handle: string | null
-          member_name: string | null
-          member_profile_picture: string | null
+          last_verified_contribution_at: string
+          member_handle: string
+          member_name: string
+          member_profile_picture: string
           member_role: Database["public"]["Enums"]["organization_role_enum"]
           member_user_id: string
-          next_due_on: string | null
-          oldest_attention_due_on: string | null
+          next_due_on: string
+          oldest_attention_due_on: string
           overdue_count: number
-          plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"] | null
+          plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"]
         }[]
       }
       get_billing_workspace_organizations: {
@@ -2076,16 +2363,16 @@ export type Database = {
           currency: string
           due_on: string
           effective_payment_state: string
-          last_decision_actor_name: string | null
-          last_decision_actor_user_id: string | null
-          last_decision_at: string | null
-          latest_claim_created_at: string | null
-          latest_claim_decided_at: string | null
-          latest_claim_decision_reason: string | null
-          latest_claim_id: string | null
-          latest_claim_status: Database["public"]["Enums"]["payment_claim_status_enum"] | null
-          member_handle: string | null
-          member_name: string | null
+          last_decision_actor_name: string
+          last_decision_actor_user_id: string
+          last_decision_at: string
+          latest_claim_created_at: string
+          latest_claim_decided_at: string
+          latest_claim_decision_reason: string
+          latest_claim_id: string
+          latest_claim_status: Database["public"]["Enums"]["payment_claim_status_enum"]
+          member_handle: string
+          member_name: string
           member_user_id: string
           obligation_id: string
           obligation_status: Database["public"]["Enums"]["payment_obligation_status_enum"]
@@ -2095,37 +2382,37 @@ export type Database = {
           period_start: string
           plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"]
           purpose: Database["public"]["Enums"]["payment_obligation_purpose_enum"]
-          settled_at: string | null
+          settled_at: string
         }[]
       }
       get_billing_workspace_queue: {
         Args: { p_organization_id: string }
         Returns: {
           amount: number
-          approve_command: string | null
+          approve_command: string
           attempt_count: number
           available_on: string
           claim_created_at: string
-          claim_decided_at: string | null
-          claim_decision_reason: string | null
+          claim_decided_at: string
+          claim_decision_reason: string
           claim_id: string
           claim_status: Database["public"]["Enums"]["payment_claim_status_enum"]
           currency: string
           due_on: string
-          member_handle: string | null
-          member_name: string | null
-          member_profile_picture: string | null
+          member_handle: string
+          member_name: string
+          member_profile_picture: string
           member_user_id: string
           obligation_id: string
           organization_id: string
-          payer_name: string | null
+          payer_name: string
           payer_type: Database["public"]["Enums"]["payment_claim_payer_type_enum"]
           period_end: string
           period_key: string
           period_start: string
           plan_type: Database["public"]["Enums"]["subscription_plan_type_enum"]
           purpose: Database["public"]["Enums"]["payment_obligation_purpose_enum"]
-          reject_command: string | null
+          reject_command: string
         }[]
       }
       get_crossing_time: {
@@ -2421,6 +2708,19 @@ export type Database = {
         Returns: string
       }
       normalize_profile_username: { Args: { value: string }; Returns: string }
+      prepare_contribution_reminder_batch: {
+        Args: {
+          p_batch_id: string
+          p_lease_seconds?: number
+          p_lease_token: string
+        }
+        Returns: {
+          batch_id: string
+          delivery_attempts: Json
+          delivery_window_on: string
+          organization_slug: string
+        }[]
+      }
       profile_stats: {
         Args: { username: string }
         Returns: {
@@ -2451,6 +2751,22 @@ export type Database = {
           result: string
         }[]
       }
+      record_contribution_reminder_receipts: {
+        Args: { p_receipts: Json }
+        Returns: number
+      }
+      record_contribution_reminder_send_failure: {
+        Args: {
+          p_batch_id: string
+          p_failure_code: string
+          p_lease_token: string
+        }
+        Returns: number
+      }
+      record_contribution_reminder_tickets: {
+        Args: { p_batch_id: string; p_lease_token: string; p_tickets: Json }
+        Returns: number
+      }
       recurring_due_date_on_or_after: {
         Args: {
           p_admission_date: string
@@ -2467,9 +2783,20 @@ export type Database = {
         }
         Returns: string
       }
+      refresh_contribution_reminder_batch: {
+        Args: { p_batch_id: string }
+        Returns: undefined
+      }
       regenerate_festival_schedule_window: {
         Args: { target_window_id: string }
         Returns: number
+      }
+      register_push_token: {
+        Args: {
+          p_language?: Database["public"]["Enums"]["language"]
+          p_token: string
+        }
+        Returns: string
       }
       reject_initial_claim: {
         Args: { p_claim_id: string; p_reason: string }
@@ -2533,6 +2860,7 @@ export type Database = {
           user_id: string
         }[]
       }
+      unregister_push_token: { Args: { p_token: string }; Returns: boolean }
       validate_locale_keys: { Args: { json_data: Json }; Returns: boolean }
     }
     Enums: {
@@ -2546,6 +2874,30 @@ export type Database = {
         | "o_pos"
         | "o_neg"
       contribution_cadence_enum: "monthly" | "annual"
+      contribution_reminder_attempt_status_enum:
+        | "pending"
+        | "leased"
+        | "ticketed"
+        | "retryable"
+        | "delivered"
+        | "terminal"
+      contribution_reminder_batch_status_enum:
+        | "pending"
+        | "leased"
+        | "awaiting_receipts"
+        | "retryable"
+        | "delivered"
+        | "no_device"
+        | "terminal"
+        | "suppressed"
+      contribution_reminder_event_status_enum:
+        | "pending"
+        | "delivered"
+        | "coalesced"
+        | "suppressed"
+        | "no_device"
+        | "exhausted"
+      contribution_reminder_stage_enum: "available" | "due" | "overdue"
       festival_schedule_booking_cancellation_source_enum:
         | "user"
         | "staff"
@@ -3262,6 +3614,33 @@ export const Constants = {
         "o_neg",
       ],
       contribution_cadence_enum: ["monthly", "annual"],
+      contribution_reminder_attempt_status_enum: [
+        "pending",
+        "leased",
+        "ticketed",
+        "retryable",
+        "delivered",
+        "terminal",
+      ],
+      contribution_reminder_batch_status_enum: [
+        "pending",
+        "leased",
+        "awaiting_receipts",
+        "retryable",
+        "delivered",
+        "no_device",
+        "terminal",
+        "suppressed",
+      ],
+      contribution_reminder_event_status_enum: [
+        "pending",
+        "delivered",
+        "coalesced",
+        "suppressed",
+        "no_device",
+        "exhausted",
+      ],
+      contribution_reminder_stage_enum: ["available", "due", "overdue"],
       festival_schedule_booking_cancellation_source_enum: [
         "user",
         "staff",

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -309,3 +309,21 @@ entrypoint = "./functions/start-subscription/index.ts"
 # Specifies static files to be bundled with the function. Supports glob patterns.
 # For example, if you want to serve static HTML pages in your function:
 # static_files = [ "./functions/start-subscription/*.html" ]
+
+[functions.contribution-reminder-enqueuer]
+enabled = true
+verify_jwt = true
+import_map = "./functions/contribution-reminder-enqueuer/deno.json"
+entrypoint = "./functions/contribution-reminder-enqueuer/index.ts"
+
+[functions.contribution-reminder-dispatcher]
+enabled = true
+verify_jwt = true
+import_map = "./functions/contribution-reminder-dispatcher/deno.json"
+entrypoint = "./functions/contribution-reminder-dispatcher/index.ts"
+
+[functions.contribution-reminder-receipts]
+enabled = true
+verify_jwt = true
+import_map = "./functions/contribution-reminder-receipts/deno.json"
+entrypoint = "./functions/contribution-reminder-receipts/index.ts"

--- a/supabase/functions/_shared/contribution-reminder.ts
+++ b/supabase/functions/_shared/contribution-reminder.ts
@@ -1,0 +1,67 @@
+import { corsHeaders } from "./cors.ts";
+
+export const CONTRIBUTION_REMINDER_ROUTE = "/(tabs)/organizations";
+
+export const CONTRIBUTION_REMINDER_COPY = {
+  en: {
+    body: "Open the association Ledger to review your account.",
+    title: "Association Ledger",
+  },
+  pt: {
+    body: "Abra o Ledger da associação para consultar sua conta.",
+    title: "Ledger da associação",
+  },
+} as const;
+
+export type ReminderLocale = keyof typeof CONTRIBUTION_REMINDER_COPY;
+
+export function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json", ...corsHeaders },
+  });
+}
+
+export function isTrustedScheduler(req: Request): boolean {
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  const authorization = req.headers.get("Authorization");
+
+  return Boolean(
+    serviceRoleKey && authorization === `Bearer ${serviceRoleKey}`,
+  );
+}
+
+export function classifyTransportFailure(error: unknown):
+  | "network"
+  | "rate_limit"
+  | "server" {
+  const message = error instanceof Error
+    ? error.message.toLowerCase()
+    : String(error).toLowerCase();
+
+  if (
+    message.includes("429") ||
+    message.includes("rate") ||
+    message.includes("too many")
+  ) {
+    return "rate_limit";
+  }
+
+  if (
+    message.includes("500") ||
+    message.includes("502") ||
+    message.includes("503") ||
+    message.includes("504") ||
+    message.includes("server")
+  ) {
+    return "server";
+  }
+
+  return "network";
+}
+
+export function normalizeLocale(
+  value: string | null | undefined,
+): ReminderLocale {
+  return value === "en" ? "en" : "pt";
+}

--- a/supabase/functions/contribution-reminder-dispatcher/deno.json
+++ b/supabase/functions/contribution-reminder-dispatcher/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@supabase": "jsr:@supabase/supabase-js@2.49.8"
+  }
+}

--- a/supabase/functions/contribution-reminder-dispatcher/deno.lock
+++ b/supabase/functions/contribution-reminder-dispatcher/deno.lock
@@ -1,0 +1,318 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@supabase/functions-js@*": "2.112.3",
+    "jsr:@supabase/supabase-js@2.49.8": "2.49.8",
+    "npm:@supabase/auth-js@2.69.1": "2.69.1",
+    "npm:@supabase/functions-js@2.4.4": "2.4.4",
+    "npm:@supabase/node-fetch@2.6.15": "2.6.15",
+    "npm:@supabase/postgrest-js@1.19.4": "1.19.4",
+    "npm:@supabase/realtime-js@2.11.2": "2.11.2",
+    "npm:@supabase/storage-js@2.7.1": "2.7.1",
+    "npm:expo-server-sdk@3.15.0": "3.15.0",
+    "npm:openai@^4.52.5": "4.104.0"
+  },
+  "jsr": {
+    "@supabase/functions-js@2.112.3": {
+      "integrity": "a61957d4fdadccbe858523bf1396c047a30927b3c0eceb1dab049266640286f3",
+      "dependencies": [
+        "npm:openai"
+      ]
+    },
+    "@supabase/supabase-js@2.49.8": {
+      "integrity": "fe1057c623e3297d627d8d795f8c8e7195b2973da8cec813f99e1484b6943b99",
+      "dependencies": [
+        "npm:@supabase/auth-js",
+        "npm:@supabase/functions-js@2.4.4",
+        "npm:@supabase/node-fetch",
+        "npm:@supabase/postgrest-js",
+        "npm:@supabase/realtime-js",
+        "npm:@supabase/storage-js"
+      ]
+    }
+  },
+  "npm": {
+    "@supabase/auth-js@2.69.1": {
+      "integrity": "sha512-FILtt5WjCNzmReeRLq5wRs3iShwmnWgBvxHfqapC/VoljJl+W8hDAyFmf1NVw3zH+ZjZ05AKxiKxVeb0HNWRMQ==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@supabase/functions-js@2.4.4": {
+      "integrity": "sha512-WL2p6r4AXNGwop7iwvul2BvOtuJ1YQy8EbOd0dhG1oN1q8el/BIRSFCFnWAMM/vJJlHWLi4ad22sKbKr9mvjoA==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@supabase/node-fetch@2.6.15": {
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "dependencies": [
+        "whatwg-url"
+      ]
+    },
+    "@supabase/postgrest-js@1.19.4": {
+      "integrity": "sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@supabase/realtime-js@2.11.2": {
+      "integrity": "sha512-u/XeuL2Y0QEhXSoIPZZwR6wMXgB+RQbJzG9VErA3VghVt7uRfSVsjeqd7m5GhX3JR6dM/WRmLbVR8URpDWG4+w==",
+      "dependencies": [
+        "@supabase/node-fetch",
+        "@types/phoenix",
+        "@types/ws",
+        "ws"
+      ]
+    },
+    "@supabase/storage-js@2.7.1": {
+      "integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@types/node-fetch@2.6.13": {
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "dependencies": [
+        "@types/node",
+        "form-data"
+      ]
+    },
+    "@types/node@18.19.130": {
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dependencies": [
+        "undici-types"
+      ]
+    },
+    "@types/phoenix@1.6.7": {
+      "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q=="
+    },
+    "@types/ws@8.18.1": {
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dependencies": [
+        "@types/node"
+      ]
+    },
+    "abort-controller@3.0.0": {
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": [
+        "event-target-shim"
+      ]
+    },
+    "agentkeepalive@4.6.0": {
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "dependencies": [
+        "humanize-ms"
+      ]
+    },
+    "asynckit@0.4.0": {
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "call-bind-apply-helpers@1.0.2": {
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": [
+        "es-errors",
+        "function-bind"
+      ]
+    },
+    "combined-stream@1.0.8": {
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": [
+        "delayed-stream"
+      ]
+    },
+    "delayed-stream@1.0.0": {
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+    },
+    "dunder-proto@1.0.1": {
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-errors",
+        "gopd"
+      ]
+    },
+    "err-code@2.0.3": {
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
+    },
+    "es-define-property@1.0.1": {
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+    },
+    "es-errors@1.3.0": {
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+    },
+    "es-object-atoms@1.1.2": {
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dependencies": [
+        "es-errors"
+      ]
+    },
+    "es-set-tostringtag@2.1.0": {
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dependencies": [
+        "es-errors",
+        "get-intrinsic",
+        "has-tostringtag",
+        "hasown"
+      ]
+    },
+    "event-target-shim@5.0.1": {
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
+    "expo-server-sdk@3.15.0": {
+      "integrity": "sha512-Y71mQ7yeDhq6miHzn4kwRQOjqvBBsWeFXvyS9PYc6uqO/+UiYvrw3vMQiQqRxg2y0qgn9jMsvjf8T+mukSH85A==",
+      "dependencies": [
+        "node-fetch",
+        "promise-limit",
+        "promise-retry"
+      ]
+    },
+    "form-data-encoder@1.7.2": {
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="
+    },
+    "form-data@4.0.6": {
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dependencies": [
+        "asynckit",
+        "combined-stream",
+        "es-set-tostringtag",
+        "hasown",
+        "mime-types"
+      ]
+    },
+    "formdata-node@4.4.1": {
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "dependencies": [
+        "node-domexception",
+        "web-streams-polyfill"
+      ]
+    },
+    "function-bind@1.1.2": {
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+    },
+    "get-intrinsic@1.3.0": {
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-define-property",
+        "es-errors",
+        "es-object-atoms",
+        "function-bind",
+        "get-proto",
+        "gopd",
+        "has-symbols",
+        "hasown",
+        "math-intrinsics"
+      ]
+    },
+    "get-proto@1.0.1": {
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": [
+        "dunder-proto",
+        "es-object-atoms"
+      ]
+    },
+    "gopd@1.2.0": {
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+    },
+    "has-symbols@1.1.0": {
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+    },
+    "has-tostringtag@1.0.2": {
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": [
+        "has-symbols"
+      ]
+    },
+    "hasown@2.0.4": {
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dependencies": [
+        "function-bind"
+      ]
+    },
+    "humanize-ms@1.2.1": {
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dependencies": [
+        "ms"
+      ]
+    },
+    "math-intrinsics@1.1.0": {
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+    },
+    "mime-db@1.52.0": {
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types@2.1.35": {
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": [
+        "mime-db"
+      ]
+    },
+    "ms@2.1.3": {
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node-domexception@1.0.0": {
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": true
+    },
+    "node-fetch@2.7.0": {
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": [
+        "whatwg-url"
+      ]
+    },
+    "openai@4.104.0": {
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "dependencies": [
+        "@types/node",
+        "@types/node-fetch",
+        "abort-controller",
+        "agentkeepalive",
+        "form-data-encoder",
+        "formdata-node",
+        "node-fetch"
+      ],
+      "bin": true
+    },
+    "promise-limit@2.7.0": {
+      "integrity": "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw=="
+    },
+    "promise-retry@2.0.1": {
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "dependencies": [
+        "err-code",
+        "retry"
+      ]
+    },
+    "retry@0.12.0": {
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="
+    },
+    "tr46@0.0.3": {
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "undici-types@5.26.5": {
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
+    "web-streams-polyfill@4.0.0-beta.3": {
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="
+    },
+    "webidl-conversions@3.0.1": {
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url@5.0.0": {
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": [
+        "tr46",
+        "webidl-conversions"
+      ]
+    },
+    "ws@8.21.3": {
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@supabase/supabase-js@2.49.8"
+    ]
+  }
+}

--- a/supabase/functions/contribution-reminder-dispatcher/index.ts
+++ b/supabase/functions/contribution-reminder-dispatcher/index.ts
@@ -1,0 +1,260 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+
+import { Expo, type ExpoPushMessage } from "npm:expo-server-sdk@3.15.0";
+
+import { supabaseAdmin } from "../_shared/supabase-admin.ts";
+import {
+  classifyTransportFailure,
+  CONTRIBUTION_REMINDER_COPY,
+  CONTRIBUTION_REMINDER_ROUTE,
+  isTrustedScheduler,
+  jsonResponse,
+  normalizeLocale,
+} from "../_shared/contribution-reminder.ts";
+
+type ClaimedBatch = {
+  batch_id: string;
+  lease_token: string;
+};
+
+type DeliveryAttempt = {
+  attempt_id: string;
+  language: string | null;
+  token: string;
+};
+
+type PreparedBatch = {
+  batch_id: string;
+  delivery_attempts: DeliveryAttempt[];
+  delivery_window_on: string;
+  organization_slug: string;
+};
+
+type TicketResult = {
+  attempt_id: string;
+  error_code: string | null;
+  expo_ticket_id: string | null;
+  status: "error" | "ok";
+};
+
+const expo = new Expo({ useFcmV1: true });
+
+function parseAttempts(value: unknown): DeliveryAttempt[] {
+  return Array.isArray(value) ? value as DeliveryAttempt[] : [];
+}
+
+function parseClaimedBatches(value: unknown): ClaimedBatch[] {
+  return Array.isArray(value) ? value as ClaimedBatch[] : [];
+}
+
+async function recordTickets(
+  batch: ClaimedBatch,
+  tickets: TicketResult[],
+) {
+  if (tickets.length === 0) return;
+
+  const { error } = await supabaseAdmin.rpc(
+    "record_contribution_reminder_tickets",
+    {
+      p_batch_id: batch.batch_id,
+      p_lease_token: batch.lease_token,
+      p_tickets: tickets,
+    },
+  );
+
+  if (error) throw error;
+}
+
+async function dispatchBatch(batch: ClaimedBatch): Promise<{
+  batches: number;
+  failed: number;
+  messages: number;
+  ticketed: number;
+}> {
+  const { data, error } = await supabaseAdmin.rpc(
+    "prepare_contribution_reminder_batch",
+    {
+      p_batch_id: batch.batch_id,
+      p_lease_token: batch.lease_token,
+      p_lease_seconds: 180,
+    },
+  );
+
+  if (error) throw error;
+
+  const prepared = (data?.[0] ?? null) as PreparedBatch | null;
+  if (!prepared) {
+    return { batches: 0, failed: 0, messages: 0, ticketed: 0 };
+  }
+
+  const attempts = parseAttempts(prepared.delivery_attempts);
+  if (attempts.length === 0) {
+    return { batches: 1, failed: 0, messages: 0, ticketed: 0 };
+  }
+
+  const messages: Array<
+    { attempt: DeliveryAttempt; message: ExpoPushMessage }
+  > = [];
+  const tickets: TicketResult[] = [];
+
+  for (const attempt of attempts) {
+    if (!Expo.isExpoPushToken(attempt.token)) {
+      tickets.push({
+        attempt_id: attempt.attempt_id,
+        error_code: "InvalidPushToken",
+        expo_ticket_id: null,
+        status: "error",
+      });
+      continue;
+    }
+
+    const locale = normalizeLocale(attempt.language);
+    const copy = CONTRIBUTION_REMINDER_COPY[locale];
+    messages.push({
+      attempt,
+      message: {
+        to: attempt.token,
+        sound: "default",
+        priority: "high",
+        title: copy.title,
+        body: copy.body,
+        data: {
+          type: "contribution_reminder",
+          organization_slug: prepared.organization_slug,
+          url: CONTRIBUTION_REMINDER_ROUTE,
+        },
+      },
+    });
+  }
+
+  let failed = 0;
+  let ticketed = 0;
+  let messageOffset = 0;
+
+  try {
+    for (
+      const chunk of expo.chunkPushNotifications(
+        messages.map(({ message }) => message),
+      )
+    ) {
+      const chunkResults = await expo.sendPushNotificationsAsync(chunk);
+
+      chunkResults.forEach((ticket, index) => {
+        const attempt = messages[messageOffset + index]?.attempt;
+        if (!attempt) return;
+
+        if (ticket.status === "ok") {
+          ticketed += 1;
+          tickets.push({
+            attempt_id: attempt.attempt_id,
+            error_code: null,
+            expo_ticket_id: ticket.id,
+            status: "ok",
+          });
+          return;
+        }
+
+        failed += 1;
+        tickets.push({
+          attempt_id: attempt.attempt_id,
+          error_code: ticket.details?.error ?? "ExpoTicketError",
+          expo_ticket_id: null,
+          status: "error",
+        });
+      });
+
+      for (let index = chunkResults.length; index < chunk.length; index += 1) {
+        const attempt = messages[messageOffset + index]?.attempt;
+        if (!attempt) continue;
+
+        failed += 1;
+        tickets.push({
+          attempt_id: attempt.attempt_id,
+          error_code: "Network",
+          expo_ticket_id: null,
+          status: "error",
+        });
+      }
+
+      messageOffset += chunk.length;
+    }
+  } catch (error) {
+    await recordTickets(batch, tickets);
+    await supabaseAdmin.rpc("record_contribution_reminder_send_failure", {
+      p_batch_id: batch.batch_id,
+      p_failure_code: classifyTransportFailure(error),
+      p_lease_token: batch.lease_token,
+    });
+    return {
+      batches: 1,
+      failed: failed + 1,
+      messages: attempts.length,
+      ticketed,
+    };
+  }
+
+  await recordTickets(batch, tickets);
+
+  return {
+    batches: 1,
+    failed,
+    messages: attempts.length,
+    ticketed,
+  };
+}
+
+Deno.serve(async (req) => {
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "Only POST is supported." }, 405);
+  }
+
+  if (!isTrustedScheduler(req)) {
+    return jsonResponse({ error: "Scheduler authorization is required." }, 401);
+  }
+
+  const { data, error } = await supabaseAdmin.rpc(
+    "claim_contribution_reminder_batches",
+    { p_limit: 20, p_lease_seconds: 180 },
+  );
+
+  if (error) {
+    console.error("Contribution reminder batch claim failed", {
+      error: error.message,
+    });
+    return jsonResponse(
+      { error: "Contribution reminder dispatch failed." },
+      500,
+    );
+  }
+
+  const batches = parseClaimedBatches(data);
+  const summary = {
+    batches: 0,
+    failed: 0,
+    messages: 0,
+    ticketed: 0,
+  };
+
+  for (const batch of batches) {
+    try {
+      const result = await dispatchBatch(batch);
+      summary.batches += result.batches;
+      summary.failed += result.failed;
+      summary.messages += result.messages;
+      summary.ticketed += result.ticketed;
+    } catch (error) {
+      summary.failed += 1;
+      console.error("Contribution reminder batch dispatch failed", {
+        error: error instanceof Error ? error.message : "Unknown error",
+      });
+      await supabaseAdmin.rpc("record_contribution_reminder_send_failure", {
+        p_batch_id: batch.batch_id,
+        p_failure_code: classifyTransportFailure(error),
+        p_lease_token: batch.lease_token,
+      });
+    }
+  }
+
+  console.log("Contribution reminder dispatch complete", summary);
+  return jsonResponse(summary);
+});

--- a/supabase/functions/contribution-reminder-dispatcher/index.ts
+++ b/supabase/functions/contribution-reminder-dispatcher/index.ts
@@ -130,17 +130,45 @@ async function dispatchBatch(batch: ClaimedBatch): Promise<{
   let failed = 0;
   let ticketed = 0;
   let messageOffset = 0;
+  const chunks = expo
+    .chunkPushNotifications(messages.map(({ message }) => message))
+    .map((chunk) => {
+      const chunkWithOffset = { chunk, messageOffset };
+      messageOffset += chunk.length;
+      return chunkWithOffset;
+    });
+  let transportFailure: unknown = null;
 
   try {
-    for (
-      const chunk of expo.chunkPushNotifications(
-        messages.map(({ message }) => message),
-      )
-    ) {
-      const chunkResults = await expo.sendPushNotificationsAsync(chunk);
+    const chunkResults = await Promise.all(
+      chunks.map(async ({ chunk, messageOffset: chunkOffset }) => {
+        try {
+          return {
+            chunk,
+            messageOffset: chunkOffset,
+            results: await expo.sendPushNotificationsAsync(chunk),
+            error: null,
+          };
+        } catch (error) {
+          return {
+            chunk,
+            messageOffset: chunkOffset,
+            results: null,
+            error,
+          };
+        }
+      }),
+    );
 
-      chunkResults.forEach((ticket, index) => {
-        const attempt = messages[messageOffset + index]?.attempt;
+    for (const chunkResult of chunkResults) {
+      if (chunkResult.results === null) {
+        transportFailure ??= chunkResult.error ?? new Error("Expo send failed");
+        failed += 1;
+        continue;
+      }
+
+      chunkResult.results.forEach((ticket, index) => {
+        const attempt = messages[chunkResult.messageOffset + index]?.attempt;
         if (!attempt) return;
 
         if (ticket.status === "ok") {
@@ -163,8 +191,12 @@ async function dispatchBatch(batch: ClaimedBatch): Promise<{
         });
       });
 
-      for (let index = chunkResults.length; index < chunk.length; index += 1) {
-        const attempt = messages[messageOffset + index]?.attempt;
+      for (
+        let index = chunkResult.results.length;
+        index < chunkResult.chunk.length;
+        index += 1
+      ) {
+        const attempt = messages[chunkResult.messageOffset + index]?.attempt;
         if (!attempt) continue;
 
         failed += 1;
@@ -175,8 +207,6 @@ async function dispatchBatch(batch: ClaimedBatch): Promise<{
           status: "error",
         });
       }
-
-      messageOffset += chunk.length;
     }
   } catch (error) {
     await recordTickets(batch, tickets);
@@ -188,6 +218,21 @@ async function dispatchBatch(batch: ClaimedBatch): Promise<{
     return {
       batches: 1,
       failed: failed + 1,
+      messages: attempts.length,
+      ticketed,
+    };
+  }
+
+  if (transportFailure !== null) {
+    await recordTickets(batch, tickets);
+    await supabaseAdmin.rpc("record_contribution_reminder_send_failure", {
+      p_batch_id: batch.batch_id,
+      p_failure_code: classifyTransportFailure(transportFailure),
+      p_lease_token: batch.lease_token,
+    });
+    return {
+      batches: 1,
+      failed,
       messages: attempts.length,
       ticketed,
     };
@@ -235,24 +280,34 @@ Deno.serve(async (req) => {
     ticketed: 0,
   };
 
-  for (const batch of batches) {
-    try {
-      const result = await dispatchBatch(batch);
-      summary.batches += result.batches;
-      summary.failed += result.failed;
-      summary.messages += result.messages;
-      summary.ticketed += result.ticketed;
-    } catch (error) {
+  const dispatchResults = await Promise.all(
+    batches.map(async (batch) => {
+      try {
+        return { result: await dispatchBatch(batch) };
+      } catch (error) {
+        console.error("Contribution reminder batch dispatch failed", {
+          error: error instanceof Error ? error.message : "Unknown error",
+        });
+        await supabaseAdmin.rpc("record_contribution_reminder_send_failure", {
+          p_batch_id: batch.batch_id,
+          p_failure_code: classifyTransportFailure(error),
+          p_lease_token: batch.lease_token,
+        });
+        return { result: null };
+      }
+    }),
+  );
+
+  for (const { result } of dispatchResults) {
+    if (!result) {
       summary.failed += 1;
-      console.error("Contribution reminder batch dispatch failed", {
-        error: error instanceof Error ? error.message : "Unknown error",
-      });
-      await supabaseAdmin.rpc("record_contribution_reminder_send_failure", {
-        p_batch_id: batch.batch_id,
-        p_failure_code: classifyTransportFailure(error),
-        p_lease_token: batch.lease_token,
-      });
+      continue;
     }
+
+    summary.batches += result.batches;
+    summary.failed += result.failed;
+    summary.messages += result.messages;
+    summary.ticketed += result.ticketed;
   }
 
   console.log("Contribution reminder dispatch complete", summary);

--- a/supabase/functions/contribution-reminder-enqueuer/deno.json
+++ b/supabase/functions/contribution-reminder-enqueuer/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@supabase": "jsr:@supabase/supabase-js@2.49.8"
+  }
+}

--- a/supabase/functions/contribution-reminder-enqueuer/deno.lock
+++ b/supabase/functions/contribution-reminder-enqueuer/deno.lock
@@ -1,0 +1,293 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@supabase/functions-js@*": "2.112.3",
+    "jsr:@supabase/supabase-js@2.49.8": "2.49.8",
+    "npm:@supabase/auth-js@2.69.1": "2.69.1",
+    "npm:@supabase/functions-js@2.4.4": "2.4.4",
+    "npm:@supabase/node-fetch@2.6.15": "2.6.15",
+    "npm:@supabase/postgrest-js@1.19.4": "1.19.4",
+    "npm:@supabase/realtime-js@2.11.2": "2.11.2",
+    "npm:@supabase/storage-js@2.7.1": "2.7.1",
+    "npm:openai@^4.52.5": "4.104.0"
+  },
+  "jsr": {
+    "@supabase/functions-js@2.112.3": {
+      "integrity": "a61957d4fdadccbe858523bf1396c047a30927b3c0eceb1dab049266640286f3",
+      "dependencies": [
+        "npm:openai"
+      ]
+    },
+    "@supabase/supabase-js@2.49.8": {
+      "integrity": "fe1057c623e3297d627d8d795f8c8e7195b2973da8cec813f99e1484b6943b99",
+      "dependencies": [
+        "npm:@supabase/auth-js",
+        "npm:@supabase/functions-js@2.4.4",
+        "npm:@supabase/node-fetch",
+        "npm:@supabase/postgrest-js",
+        "npm:@supabase/realtime-js",
+        "npm:@supabase/storage-js"
+      ]
+    }
+  },
+  "npm": {
+    "@supabase/auth-js@2.69.1": {
+      "integrity": "sha512-FILtt5WjCNzmReeRLq5wRs3iShwmnWgBvxHfqapC/VoljJl+W8hDAyFmf1NVw3zH+ZjZ05AKxiKxVeb0HNWRMQ==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@supabase/functions-js@2.4.4": {
+      "integrity": "sha512-WL2p6r4AXNGwop7iwvul2BvOtuJ1YQy8EbOd0dhG1oN1q8el/BIRSFCFnWAMM/vJJlHWLi4ad22sKbKr9mvjoA==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@supabase/node-fetch@2.6.15": {
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "dependencies": [
+        "whatwg-url"
+      ]
+    },
+    "@supabase/postgrest-js@1.19.4": {
+      "integrity": "sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@supabase/realtime-js@2.11.2": {
+      "integrity": "sha512-u/XeuL2Y0QEhXSoIPZZwR6wMXgB+RQbJzG9VErA3VghVt7uRfSVsjeqd7m5GhX3JR6dM/WRmLbVR8URpDWG4+w==",
+      "dependencies": [
+        "@supabase/node-fetch",
+        "@types/phoenix",
+        "@types/ws",
+        "ws"
+      ]
+    },
+    "@supabase/storage-js@2.7.1": {
+      "integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@types/node-fetch@2.6.13": {
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "dependencies": [
+        "@types/node",
+        "form-data"
+      ]
+    },
+    "@types/node@18.19.130": {
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dependencies": [
+        "undici-types"
+      ]
+    },
+    "@types/phoenix@1.6.7": {
+      "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q=="
+    },
+    "@types/ws@8.18.1": {
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dependencies": [
+        "@types/node"
+      ]
+    },
+    "abort-controller@3.0.0": {
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": [
+        "event-target-shim"
+      ]
+    },
+    "agentkeepalive@4.6.0": {
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "dependencies": [
+        "humanize-ms"
+      ]
+    },
+    "asynckit@0.4.0": {
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "call-bind-apply-helpers@1.0.2": {
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": [
+        "es-errors",
+        "function-bind"
+      ]
+    },
+    "combined-stream@1.0.8": {
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": [
+        "delayed-stream"
+      ]
+    },
+    "delayed-stream@1.0.0": {
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+    },
+    "dunder-proto@1.0.1": {
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-errors",
+        "gopd"
+      ]
+    },
+    "es-define-property@1.0.1": {
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+    },
+    "es-errors@1.3.0": {
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+    },
+    "es-object-atoms@1.1.2": {
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dependencies": [
+        "es-errors"
+      ]
+    },
+    "es-set-tostringtag@2.1.0": {
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dependencies": [
+        "es-errors",
+        "get-intrinsic",
+        "has-tostringtag",
+        "hasown"
+      ]
+    },
+    "event-target-shim@5.0.1": {
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
+    "form-data-encoder@1.7.2": {
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="
+    },
+    "form-data@4.0.6": {
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dependencies": [
+        "asynckit",
+        "combined-stream",
+        "es-set-tostringtag",
+        "hasown",
+        "mime-types"
+      ]
+    },
+    "formdata-node@4.4.1": {
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "dependencies": [
+        "node-domexception",
+        "web-streams-polyfill"
+      ]
+    },
+    "function-bind@1.1.2": {
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+    },
+    "get-intrinsic@1.3.0": {
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-define-property",
+        "es-errors",
+        "es-object-atoms",
+        "function-bind",
+        "get-proto",
+        "gopd",
+        "has-symbols",
+        "hasown",
+        "math-intrinsics"
+      ]
+    },
+    "get-proto@1.0.1": {
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": [
+        "dunder-proto",
+        "es-object-atoms"
+      ]
+    },
+    "gopd@1.2.0": {
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+    },
+    "has-symbols@1.1.0": {
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+    },
+    "has-tostringtag@1.0.2": {
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": [
+        "has-symbols"
+      ]
+    },
+    "hasown@2.0.4": {
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dependencies": [
+        "function-bind"
+      ]
+    },
+    "humanize-ms@1.2.1": {
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dependencies": [
+        "ms"
+      ]
+    },
+    "math-intrinsics@1.1.0": {
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+    },
+    "mime-db@1.52.0": {
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types@2.1.35": {
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": [
+        "mime-db"
+      ]
+    },
+    "ms@2.1.3": {
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node-domexception@1.0.0": {
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": true
+    },
+    "node-fetch@2.7.0": {
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": [
+        "whatwg-url"
+      ]
+    },
+    "openai@4.104.0": {
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "dependencies": [
+        "@types/node",
+        "@types/node-fetch",
+        "abort-controller",
+        "agentkeepalive",
+        "form-data-encoder",
+        "formdata-node",
+        "node-fetch"
+      ],
+      "bin": true
+    },
+    "tr46@0.0.3": {
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "undici-types@5.26.5": {
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
+    "web-streams-polyfill@4.0.0-beta.3": {
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="
+    },
+    "webidl-conversions@3.0.1": {
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url@5.0.0": {
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": [
+        "tr46",
+        "webidl-conversions"
+      ]
+    },
+    "ws@8.21.3": {
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@supabase/supabase-js@2.49.8"
+    ]
+  }
+}

--- a/supabase/functions/contribution-reminder-enqueuer/index.ts
+++ b/supabase/functions/contribution-reminder-enqueuer/index.ts
@@ -1,0 +1,54 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+
+import { supabaseAdmin } from "../_shared/supabase-admin.ts";
+import {
+  isTrustedScheduler,
+  jsonResponse,
+} from "../_shared/contribution-reminder.ts";
+
+type EnqueueResult = {
+  coalesced_count: number;
+  created_count: number;
+  skipped_count: number;
+  suppressed_count: number;
+};
+
+Deno.serve(async (req) => {
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "Only POST is supported." }, 405);
+  }
+
+  if (!isTrustedScheduler(req)) {
+    return jsonResponse({ error: "Scheduler authorization is required." }, 401);
+  }
+
+  const { data, error } = await supabaseAdmin.rpc(
+    "enqueue_contribution_reminder_events",
+  );
+
+  if (error) {
+    console.error("Contribution reminder enqueue failed", {
+      error: error.message,
+    });
+    return jsonResponse(
+      { error: "Contribution reminder enqueue failed." },
+      500,
+    );
+  }
+
+  const result = (data?.[0] ?? {
+    coalesced_count: 0,
+    created_count: 0,
+    skipped_count: 0,
+    suppressed_count: 0,
+  }) as EnqueueResult;
+
+  console.log("Contribution reminder enqueue complete", {
+    coalesced: result.coalesced_count,
+    created: result.created_count,
+    skipped: result.skipped_count,
+    suppressed: result.suppressed_count,
+  });
+
+  return jsonResponse({ ...result });
+});

--- a/supabase/functions/contribution-reminder-receipts/deno.json
+++ b/supabase/functions/contribution-reminder-receipts/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@supabase": "jsr:@supabase/supabase-js@2.49.8"
+  }
+}

--- a/supabase/functions/contribution-reminder-receipts/deno.lock
+++ b/supabase/functions/contribution-reminder-receipts/deno.lock
@@ -1,0 +1,318 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@supabase/functions-js@*": "2.112.3",
+    "jsr:@supabase/supabase-js@2.49.8": "2.49.8",
+    "npm:@supabase/auth-js@2.69.1": "2.69.1",
+    "npm:@supabase/functions-js@2.4.4": "2.4.4",
+    "npm:@supabase/node-fetch@2.6.15": "2.6.15",
+    "npm:@supabase/postgrest-js@1.19.4": "1.19.4",
+    "npm:@supabase/realtime-js@2.11.2": "2.11.2",
+    "npm:@supabase/storage-js@2.7.1": "2.7.1",
+    "npm:expo-server-sdk@3.15.0": "3.15.0",
+    "npm:openai@^4.52.5": "4.104.0"
+  },
+  "jsr": {
+    "@supabase/functions-js@2.112.3": {
+      "integrity": "a61957d4fdadccbe858523bf1396c047a30927b3c0eceb1dab049266640286f3",
+      "dependencies": [
+        "npm:openai"
+      ]
+    },
+    "@supabase/supabase-js@2.49.8": {
+      "integrity": "fe1057c623e3297d627d8d795f8c8e7195b2973da8cec813f99e1484b6943b99",
+      "dependencies": [
+        "npm:@supabase/auth-js",
+        "npm:@supabase/functions-js@2.4.4",
+        "npm:@supabase/node-fetch",
+        "npm:@supabase/postgrest-js",
+        "npm:@supabase/realtime-js",
+        "npm:@supabase/storage-js"
+      ]
+    }
+  },
+  "npm": {
+    "@supabase/auth-js@2.69.1": {
+      "integrity": "sha512-FILtt5WjCNzmReeRLq5wRs3iShwmnWgBvxHfqapC/VoljJl+W8hDAyFmf1NVw3zH+ZjZ05AKxiKxVeb0HNWRMQ==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@supabase/functions-js@2.4.4": {
+      "integrity": "sha512-WL2p6r4AXNGwop7iwvul2BvOtuJ1YQy8EbOd0dhG1oN1q8el/BIRSFCFnWAMM/vJJlHWLi4ad22sKbKr9mvjoA==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@supabase/node-fetch@2.6.15": {
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "dependencies": [
+        "whatwg-url"
+      ]
+    },
+    "@supabase/postgrest-js@1.19.4": {
+      "integrity": "sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@supabase/realtime-js@2.11.2": {
+      "integrity": "sha512-u/XeuL2Y0QEhXSoIPZZwR6wMXgB+RQbJzG9VErA3VghVt7uRfSVsjeqd7m5GhX3JR6dM/WRmLbVR8URpDWG4+w==",
+      "dependencies": [
+        "@supabase/node-fetch",
+        "@types/phoenix",
+        "@types/ws",
+        "ws"
+      ]
+    },
+    "@supabase/storage-js@2.7.1": {
+      "integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@types/node-fetch@2.6.13": {
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "dependencies": [
+        "@types/node",
+        "form-data"
+      ]
+    },
+    "@types/node@18.19.130": {
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dependencies": [
+        "undici-types"
+      ]
+    },
+    "@types/phoenix@1.6.7": {
+      "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q=="
+    },
+    "@types/ws@8.18.1": {
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dependencies": [
+        "@types/node"
+      ]
+    },
+    "abort-controller@3.0.0": {
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": [
+        "event-target-shim"
+      ]
+    },
+    "agentkeepalive@4.6.0": {
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "dependencies": [
+        "humanize-ms"
+      ]
+    },
+    "asynckit@0.4.0": {
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "call-bind-apply-helpers@1.0.2": {
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": [
+        "es-errors",
+        "function-bind"
+      ]
+    },
+    "combined-stream@1.0.8": {
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": [
+        "delayed-stream"
+      ]
+    },
+    "delayed-stream@1.0.0": {
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+    },
+    "dunder-proto@1.0.1": {
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-errors",
+        "gopd"
+      ]
+    },
+    "err-code@2.0.3": {
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
+    },
+    "es-define-property@1.0.1": {
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+    },
+    "es-errors@1.3.0": {
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+    },
+    "es-object-atoms@1.1.2": {
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dependencies": [
+        "es-errors"
+      ]
+    },
+    "es-set-tostringtag@2.1.0": {
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dependencies": [
+        "es-errors",
+        "get-intrinsic",
+        "has-tostringtag",
+        "hasown"
+      ]
+    },
+    "event-target-shim@5.0.1": {
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
+    "expo-server-sdk@3.15.0": {
+      "integrity": "sha512-Y71mQ7yeDhq6miHzn4kwRQOjqvBBsWeFXvyS9PYc6uqO/+UiYvrw3vMQiQqRxg2y0qgn9jMsvjf8T+mukSH85A==",
+      "dependencies": [
+        "node-fetch",
+        "promise-limit",
+        "promise-retry"
+      ]
+    },
+    "form-data-encoder@1.7.2": {
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="
+    },
+    "form-data@4.0.6": {
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dependencies": [
+        "asynckit",
+        "combined-stream",
+        "es-set-tostringtag",
+        "hasown",
+        "mime-types"
+      ]
+    },
+    "formdata-node@4.4.1": {
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "dependencies": [
+        "node-domexception",
+        "web-streams-polyfill"
+      ]
+    },
+    "function-bind@1.1.2": {
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+    },
+    "get-intrinsic@1.3.0": {
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-define-property",
+        "es-errors",
+        "es-object-atoms",
+        "function-bind",
+        "get-proto",
+        "gopd",
+        "has-symbols",
+        "hasown",
+        "math-intrinsics"
+      ]
+    },
+    "get-proto@1.0.1": {
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": [
+        "dunder-proto",
+        "es-object-atoms"
+      ]
+    },
+    "gopd@1.2.0": {
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+    },
+    "has-symbols@1.1.0": {
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+    },
+    "has-tostringtag@1.0.2": {
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": [
+        "has-symbols"
+      ]
+    },
+    "hasown@2.0.4": {
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dependencies": [
+        "function-bind"
+      ]
+    },
+    "humanize-ms@1.2.1": {
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dependencies": [
+        "ms"
+      ]
+    },
+    "math-intrinsics@1.1.0": {
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+    },
+    "mime-db@1.52.0": {
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types@2.1.35": {
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": [
+        "mime-db"
+      ]
+    },
+    "ms@2.1.3": {
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node-domexception@1.0.0": {
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": true
+    },
+    "node-fetch@2.7.0": {
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": [
+        "whatwg-url"
+      ]
+    },
+    "openai@4.104.0": {
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "dependencies": [
+        "@types/node",
+        "@types/node-fetch",
+        "abort-controller",
+        "agentkeepalive",
+        "form-data-encoder",
+        "formdata-node",
+        "node-fetch"
+      ],
+      "bin": true
+    },
+    "promise-limit@2.7.0": {
+      "integrity": "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw=="
+    },
+    "promise-retry@2.0.1": {
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "dependencies": [
+        "err-code",
+        "retry"
+      ]
+    },
+    "retry@0.12.0": {
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="
+    },
+    "tr46@0.0.3": {
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "undici-types@5.26.5": {
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
+    "web-streams-polyfill@4.0.0-beta.3": {
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="
+    },
+    "webidl-conversions@3.0.1": {
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url@5.0.0": {
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": [
+        "tr46",
+        "webidl-conversions"
+      ]
+    },
+    "ws@8.21.3": {
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@supabase/supabase-js@2.49.8"
+    ]
+  }
+}

--- a/supabase/functions/contribution-reminder-receipts/index.ts
+++ b/supabase/functions/contribution-reminder-receipts/index.ts
@@ -1,0 +1,137 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+
+import { Expo } from "npm:expo-server-sdk@3.15.0";
+
+import { supabaseAdmin } from "../_shared/supabase-admin.ts";
+import {
+  classifyTransportFailure,
+  isTrustedScheduler,
+  jsonResponse,
+} from "../_shared/contribution-reminder.ts";
+
+type ClaimedReceipt = {
+  attempt_id: string;
+  batch_id: string;
+  expo_ticket_id: string;
+  lease_token: string;
+};
+
+type ReceiptResult = {
+  attempt_id: string;
+  error_code: string | null;
+  lease_token: string;
+  status: "error" | "ok";
+};
+
+const expo = new Expo({ useFcmV1: true });
+
+function parseClaimedReceipts(value: unknown): ClaimedReceipt[] {
+  return Array.isArray(value) ? value as ClaimedReceipt[] : [];
+}
+
+async function recordReceipts(receipts: ReceiptResult[]) {
+  if (receipts.length === 0) return;
+
+  const { error } = await supabaseAdmin.rpc(
+    "record_contribution_reminder_receipts",
+    { p_receipts: receipts },
+  );
+
+  if (error) throw error;
+}
+
+Deno.serve(async (req) => {
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "Only POST is supported." }, 405);
+  }
+
+  if (!isTrustedScheduler(req)) {
+    return jsonResponse({ error: "Scheduler authorization is required." }, 401);
+  }
+
+  const { data, error } = await supabaseAdmin.rpc(
+    "claim_contribution_reminder_receipts",
+    { p_limit: 100, p_lease_seconds: 180 },
+  );
+
+  if (error) {
+    console.error("Contribution reminder receipt claim failed", {
+      error: error.message,
+    });
+    return jsonResponse(
+      { error: "Contribution reminder receipts failed." },
+      500,
+    );
+  }
+
+  const claimed = parseClaimedReceipts(data);
+  if (claimed.length === 0) {
+    return jsonResponse({ claimed: 0, delivered: 0, failed: 0 });
+  }
+
+  const receipts: ReceiptResult[] = [];
+  const ticketIds = claimed.map(({ expo_ticket_id }) => expo_ticket_id);
+
+  try {
+    const expoReceipts = await expo.getPushNotificationReceiptsAsync(ticketIds);
+
+    for (const receipt of claimed) {
+      const result = expoReceipts[receipt.expo_ticket_id];
+      if (!result) {
+        receipts.push({
+          attempt_id: receipt.attempt_id,
+          error_code: "Network",
+          lease_token: receipt.lease_token,
+          status: "error",
+        });
+        continue;
+      }
+
+      if (result.status === "ok") {
+        receipts.push({
+          attempt_id: receipt.attempt_id,
+          error_code: null,
+          lease_token: receipt.lease_token,
+          status: "ok",
+        });
+      } else {
+        receipts.push({
+          attempt_id: receipt.attempt_id,
+          error_code: result.details?.error ?? "ExpoReceiptError",
+          lease_token: receipt.lease_token,
+          status: "error",
+        });
+      }
+    }
+  } catch (error) {
+    const failureCode = classifyTransportFailure(error);
+    for (const receipt of claimed) {
+      receipts.push({
+        attempt_id: receipt.attempt_id,
+        error_code: failureCode,
+        lease_token: receipt.lease_token,
+        status: "error",
+      });
+    }
+  }
+
+  try {
+    await recordReceipts(receipts);
+  } catch (error) {
+    console.error("Contribution reminder receipts could not be persisted", {
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+    return jsonResponse(
+      { error: "Contribution reminder receipts failed." },
+      500,
+    );
+  }
+
+  const delivered = receipts.filter((receipt) =>
+    receipt.status === "ok"
+  ).length;
+  const failed = receipts.length - delivered;
+  const summary = { claimed: claimed.length, delivered, failed };
+  console.log("Contribution reminder receipt reconciliation complete", summary);
+  return jsonResponse(summary);
+});

--- a/supabase/functions/generate-renewal-payments/README.md
+++ b/supabase/functions/generate-renewal-payments/README.md
@@ -21,10 +21,18 @@ the reviewed, unambiguous mappings with the same command set to `true`.
 
 ## Push delivery
 
-The app's existing notification pipeline expects an `INSERT` Database Webhook
-on `public.notifications` to call the `push-notification` Edge Function. Ensure
-that webhook is configured in each deployed Supabase project; webhook
-configuration is managed outside this repository.
+Contribution reminders use the private outbox workflow in issue #211. The
+`contribution-reminder-enqueuer` polls for the latest useful logical stage, the
+`contribution-reminder-dispatcher` leases one physical member/association
+window and sends a generic Ledger deep link, and
+`contribution-reminder-receipts` reconciles Expo tickets and retires invalid
+tokens. These jobs are scheduled from the migration and use the Vault
+`project_url` and `secret_key` values.
+
+The legacy `daily-renewal-check` job and its immediate renewal-notification
+behavior were removed by the recurring-obligation cutover. Keep the general
+`public.notifications` webhook for unrelated product notifications, but do
+not use it for contribution reminders.
 
 ## Deployment
 

--- a/supabase/migrations/20260827000000_contribution_reminders.sql
+++ b/supabase/migrations/20260827000000_contribution_reminders.sql
@@ -1,0 +1,1656 @@
+-- Issue #211: private, durable contribution reminder outbox.
+--
+-- Logical reminder events are deliberately separate from public.notifications.
+-- The tables below are private service data: clients can only register and
+-- unregister their own push token through authenticated commands.
+
+alter table public.organizations
+  add column if not exists contribution_reminder_local_time
+    time without time zone not null default '09:00:00'::time;
+
+comment on column public.organizations.contribution_reminder_local_time is
+  'Local delivery time for private contribution reminders. The initial default is 09:00.';
+
+do $$
+begin
+  create type public.contribution_reminder_stage_enum as enum (
+    'available',
+    'due',
+    'overdue'
+  );
+exception
+  when duplicate_object then null;
+end;
+$$;
+
+do $$
+begin
+  create type public.contribution_reminder_event_status_enum as enum (
+    'pending',
+    'delivered',
+    'coalesced',
+    'suppressed',
+    'no_device',
+    'exhausted'
+  );
+exception
+  when duplicate_object then null;
+end;
+$$;
+
+do $$
+begin
+  create type public.contribution_reminder_batch_status_enum as enum (
+    'pending',
+    'leased',
+    'awaiting_receipts',
+    'retryable',
+    'delivered',
+    'no_device',
+    'terminal',
+    'suppressed'
+  );
+exception
+  when duplicate_object then null;
+end;
+$$;
+
+do $$
+begin
+  create type public.contribution_reminder_attempt_status_enum as enum (
+    'pending',
+    'leased',
+    'ticketed',
+    'retryable',
+    'delivered',
+    'terminal'
+  );
+exception
+  when duplicate_object then null;
+end;
+$$;
+
+create table if not exists public.contribution_reminder_events (
+  id uuid primary key default gen_random_uuid(),
+  organization_id uuid not null references public.organizations(id) on delete cascade,
+  obligation_id uuid not null references public.payment_obligations(id) on delete cascade,
+  recipient_user_id uuid not null references public.profiles(id) on delete cascade,
+  stage public.contribution_reminder_stage_enum not null,
+  stage_on date not null,
+  delivery_window_on date not null,
+  status public.contribution_reminder_event_status_enum not null default 'pending',
+  suppression_reason text,
+  created_at timestamp with time zone not null default timezone('utc'::text, now()),
+  updated_at timestamp with time zone not null default timezone('utc'::text, now()),
+  delivered_at timestamp with time zone,
+  unique (obligation_id, recipient_user_id, stage)
+);
+
+comment on table public.contribution_reminder_events is
+  'Private logical contribution reminder events. One row exists per obligation, recipient, and stage.';
+
+create table if not exists public.contribution_reminder_batches (
+  id uuid primary key default gen_random_uuid(),
+  organization_id uuid not null references public.organizations(id) on delete cascade,
+  recipient_user_id uuid not null references public.profiles(id) on delete cascade,
+  delivery_window_on date not null,
+  status public.contribution_reminder_batch_status_enum not null default 'pending',
+  lease_token uuid,
+  lease_expires_at timestamp with time zone,
+  attempt_count integer not null default 0 check (attempt_count >= 0),
+  next_attempt_at timestamp with time zone not null default timezone('utc'::text, now()),
+  last_failure_code text,
+  created_at timestamp with time zone not null default timezone('utc'::text, now()),
+  updated_at timestamp with time zone not null default timezone('utc'::text, now()),
+  delivered_at timestamp with time zone,
+  unique (organization_id, recipient_user_id, delivery_window_on)
+);
+
+comment on table public.contribution_reminder_batches is
+  'Private physical delivery windows. Several logical events share at most one batch per member and association window.';
+
+create table if not exists public.contribution_reminder_batch_events (
+  batch_id uuid not null references public.contribution_reminder_batches(id) on delete cascade,
+  event_id uuid not null references public.contribution_reminder_events(id) on delete cascade,
+  created_at timestamp with time zone not null default timezone('utc'::text, now()),
+  primary key (batch_id, event_id),
+  unique (event_id)
+);
+
+create table if not exists public.contribution_reminder_delivery_attempts (
+  id uuid primary key default gen_random_uuid(),
+  batch_id uuid not null references public.contribution_reminder_batches(id) on delete cascade,
+  push_token_id bigint references public.push_tokens(id) on delete set null,
+  token text not null,
+  language public.language,
+  status public.contribution_reminder_attempt_status_enum not null default 'pending',
+  attempt_count integer not null default 0 check (attempt_count >= 0),
+  lease_token uuid,
+  lease_expires_at timestamp with time zone,
+  next_attempt_at timestamp with time zone not null default timezone('utc'::text, now()),
+  expo_ticket_id text,
+  expo_receipt_status text,
+  expo_receipt_error_code text,
+  terminal_outcome text,
+  created_at timestamp with time zone not null default timezone('utc'::text, now()),
+  updated_at timestamp with time zone not null default timezone('utc'::text, now()),
+  next_receipt_check_at timestamp with time zone,
+  unique (batch_id, token)
+);
+
+comment on table public.contribution_reminder_delivery_attempts is
+  'Private at-least-once delivery state for one reminder batch and one device token.';
+
+create index if not exists contribution_reminder_events_pending_idx
+  on public.contribution_reminder_events (
+    delivery_window_on,
+    organization_id,
+    recipient_user_id,
+    created_at,
+    id
+  )
+  where status = 'pending'::public.contribution_reminder_event_status_enum;
+
+create index if not exists contribution_reminder_events_obligation_idx
+  on public.contribution_reminder_events (obligation_id, status, stage);
+
+create index if not exists contribution_reminder_batches_due_idx
+  on public.contribution_reminder_batches (
+    next_attempt_at,
+    delivery_window_on,
+    organization_id,
+    recipient_user_id,
+    id
+  )
+  where status in (
+    'pending'::public.contribution_reminder_batch_status_enum,
+    'retryable'::public.contribution_reminder_batch_status_enum
+  );
+
+create index if not exists contribution_reminder_batch_events_event_idx
+  on public.contribution_reminder_batch_events (event_id, batch_id);
+
+create index if not exists contribution_reminder_attempts_due_idx
+  on public.contribution_reminder_delivery_attempts (
+    next_attempt_at,
+    batch_id,
+    status,
+    id
+  );
+
+create index if not exists contribution_reminder_attempts_receipts_idx
+  on public.contribution_reminder_delivery_attempts (
+    next_receipt_check_at,
+    status,
+    id
+  )
+  where status = 'ticketed'::public.contribution_reminder_attempt_status_enum;
+
+create index if not exists contribution_reminder_attempts_expired_receipt_leases_idx
+  on public.contribution_reminder_delivery_attempts (lease_expires_at, id)
+  where status = 'leased'::public.contribution_reminder_attempt_status_enum
+    and expo_ticket_id is not null;
+
+alter table public.contribution_reminder_events enable row level security;
+alter table public.contribution_reminder_batches enable row level security;
+alter table public.contribution_reminder_batch_events enable row level security;
+alter table public.contribution_reminder_delivery_attempts enable row level security;
+
+revoke all on table public.contribution_reminder_events
+  from public, anon, authenticated;
+revoke all on table public.contribution_reminder_batches
+  from public, anon, authenticated;
+revoke all on table public.contribution_reminder_batch_events
+  from public, anon, authenticated;
+revoke all on table public.contribution_reminder_delivery_attempts
+  from public, anon, authenticated;
+grant all on table public.contribution_reminder_events to service_role;
+grant all on table public.contribution_reminder_batches to service_role;
+grant all on table public.contribution_reminder_batch_events to service_role;
+grant all on table public.contribution_reminder_delivery_attempts to service_role;
+
+-- Push tokens are private device ownership data. Existing public policies are
+-- removed before the authenticated command functions below are exposed.
+drop policy if exists "Allow all users to read push tokens" on public.push_tokens;
+drop policy if exists "Allow all users to insert push tokens" on public.push_tokens;
+drop policy if exists "Allow authenticated users to update their own push tokens"
+  on public.push_tokens;
+revoke all on table public.push_tokens from public, anon, authenticated;
+grant all on table public.push_tokens to service_role;
+
+create or replace function public.contribution_reminder_stage_for_date(
+  p_available_on date,
+  p_due_on date,
+  p_local_date date
+)
+returns public.contribution_reminder_stage_enum
+language sql
+immutable
+set search_path = ''
+as $$
+  select case
+    when p_local_date >= p_due_on + 7 then
+      'overdue'::public.contribution_reminder_stage_enum
+    when p_local_date >= p_due_on then
+      'due'::public.contribution_reminder_stage_enum
+    when p_local_date >= p_available_on then
+      'available'::public.contribution_reminder_stage_enum
+    else null
+  end;
+$$;
+
+create or replace function public.contribution_reminder_delivery_at(
+  p_stage_on date,
+  p_timezone text,
+  p_local_time time without time zone
+)
+returns timestamp with time zone
+language sql
+immutable
+set search_path = ''
+as $$
+  select (
+    p_stage_on::timestamp
+      + (p_local_time - time '00:00:00')
+  ) at time zone p_timezone;
+$$;
+
+create or replace function public.contribution_reminder_backoff(
+  p_attempt_count integer
+)
+returns interval
+language sql
+immutable
+set search_path = ''
+as $$
+  select make_interval(
+    secs => least(
+      3600::double precision,
+      60::double precision * power(
+        2::double precision,
+        greatest(coalesce(p_attempt_count, 1) - 1, 0)
+      )
+    )
+  );
+$$;
+
+revoke all on function public.contribution_reminder_stage_for_date(date, date, date)
+  from public, anon, authenticated, service_role;
+revoke all on function public.contribution_reminder_delivery_at(
+  date, text, time without time zone
+) from public, anon, authenticated, service_role;
+revoke all on function public.contribution_reminder_backoff(integer)
+  from public, anon, authenticated, service_role;
+grant execute on function public.contribution_reminder_stage_for_date(date, date, date)
+  to postgres;
+grant execute on function public.contribution_reminder_delivery_at(
+  date, text, time without time zone
+) to postgres;
+grant execute on function public.contribution_reminder_backoff(integer)
+  to postgres;
+
+create or replace function public.register_push_token(
+  p_token text,
+  p_language public.language default null
+)
+returns text
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  actor_id uuid := (select auth.uid());
+  normalized_token text := nullif(btrim(p_token), '');
+begin
+  if actor_id is null then
+    raise exception 'Authentication is required.' using errcode = '42501';
+  end if;
+
+  if normalized_token is null or char_length(normalized_token) > 512 then
+    raise exception 'A valid push token is required.' using errcode = '22023';
+  end if;
+
+  insert into public.push_tokens (token, profile_id, language, created_at)
+  values (normalized_token, actor_id, p_language, clock_timestamp())
+  on conflict (token) do update
+  set
+    profile_id = excluded.profile_id,
+    language = excluded.language,
+    created_at = clock_timestamp();
+
+  return 'registered';
+end;
+$$;
+
+comment on function public.register_push_token(text, public.language) is
+  'Associates one device token with the currently authenticated profile, replacing a previous owner for account switching.';
+
+create or replace function public.unregister_push_token(
+  p_token text
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  actor_id uuid := (select auth.uid());
+  removed_id bigint;
+begin
+  if actor_id is null then
+    raise exception 'Authentication is required.' using errcode = '42501';
+  end if;
+
+  delete from public.push_tokens
+  where token = nullif(btrim(p_token), '')
+    and profile_id = actor_id
+  returning id into removed_id;
+
+  return removed_id is not null;
+end;
+$$;
+
+comment on function public.unregister_push_token(text) is
+  'Removes one device token only when it is owned by the currently authenticated profile.';
+
+revoke all on function public.register_push_token(text, public.language)
+  from public, anon;
+revoke all on function public.unregister_push_token(text)
+  from public, anon;
+grant execute on function public.register_push_token(text, public.language)
+  to authenticated, service_role;
+grant execute on function public.unregister_push_token(text)
+  to authenticated, service_role;
+
+create or replace function public.enqueue_contribution_reminder_events_at(
+  p_as_of timestamp with time zone
+)
+returns table (
+  created_count integer,
+  skipped_count integer,
+  suppressed_count integer,
+  coalesced_count integer
+)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  evaluated_at timestamp with time zone := coalesce(p_as_of, clock_timestamp());
+  obligation_record record;
+  stage_value public.contribution_reminder_stage_enum;
+  stage_on_value date;
+  local_date_value date;
+  delivery_at_value timestamp with time zone;
+  inserted_event public.contribution_reminder_events%rowtype;
+  existing_event public.contribution_reminder_events%rowtype;
+  batch_record public.contribution_reminder_batches%rowtype;
+  affected_count integer;
+begin
+  if evaluated_at is null then
+    raise exception 'The reminder evaluation clock is required.' using errcode = '22023';
+  end if;
+
+  created_count := 0;
+  skipped_count := 0;
+  suppressed_count := 0;
+  coalesced_count := 0;
+
+  update public.contribution_reminder_events event_record
+  set
+    status = 'suppressed'::public.contribution_reminder_event_status_enum,
+    suppression_reason = case
+      when po.status = 'settled'::public.payment_obligation_status_enum
+        then 'obligation_settled'
+      when po.status = 'void'::public.payment_obligation_status_enum
+        then 'obligation_void'
+      when exists (
+        select 1
+        from public.payment_claims pc
+        where pc.obligation_id = po.id
+          and pc.status = 'under_review'::public.payment_claim_status_enum
+      ) then 'claim_under_review'
+      else 'membership_not_active'
+    end,
+    updated_at = clock_timestamp()
+  from public.payment_obligations po
+  where event_record.obligation_id = po.id
+    and event_record.status = 'pending'::public.contribution_reminder_event_status_enum
+    and (
+      po.status in (
+        'settled'::public.payment_obligation_status_enum,
+        'void'::public.payment_obligation_status_enum
+      )
+      or exists (
+        select 1
+        from public.payment_claims pc
+        where pc.obligation_id = po.id
+          and pc.status = 'under_review'::public.payment_claim_status_enum
+      )
+      or not exists (
+        select 1
+        from public.organization_members om
+        join public.subscriptions s
+          on s.organization_id = om.organization_id
+          and s.user_id = om.user_id
+          and s.status = 'active'::public.subscription_status_enum
+        where om.organization_id = po.organization_id
+          and om.user_id = po.user_id
+          and om.role in (
+            'admin'::public.organization_role_enum,
+            'member'::public.organization_role_enum
+          )
+      )
+    );
+  get diagnostics affected_count = row_count;
+  suppressed_count := suppressed_count + affected_count;
+
+  for obligation_record in
+    select
+      po.id,
+      po.organization_id,
+      po.user_id,
+      po.available_on,
+      po.due_on,
+      coalesce(po.billing_timezone, o.billing_timezone) as billing_timezone,
+      o.contribution_reminder_local_time
+    from public.payment_obligations po
+    join public.organizations o on o.id = po.organization_id
+    join public.organization_members om
+      on om.organization_id = po.organization_id
+      and om.user_id = po.user_id
+      and om.role in (
+        'admin'::public.organization_role_enum,
+        'member'::public.organization_role_enum
+      )
+    join public.subscriptions s
+      on s.organization_id = po.organization_id
+      and s.user_id = po.user_id
+      and s.status = 'active'::public.subscription_status_enum
+    where po.purpose = 'recurring'::public.payment_obligation_purpose_enum
+      and po.status not in (
+        'settled'::public.payment_obligation_status_enum,
+        'void'::public.payment_obligation_status_enum
+      )
+      and o.organization_type = 'association'::public.organization_type_enum
+      and not exists (
+        select 1
+        from public.payment_claims pc
+        where pc.obligation_id = po.id
+          and pc.status = 'under_review'::public.payment_claim_status_enum
+      )
+    order by po.organization_id, po.user_id, po.due_on, po.id
+  loop
+    local_date_value := timezone(
+      obligation_record.billing_timezone,
+      evaluated_at
+    )::date;
+    stage_value := public.contribution_reminder_stage_for_date(
+      obligation_record.available_on,
+      obligation_record.due_on,
+      local_date_value
+    );
+
+    if stage_value is null then
+      skipped_count := skipped_count + 1;
+      continue;
+    end if;
+
+    stage_on_value := case stage_value
+      when 'available'::public.contribution_reminder_stage_enum
+        then obligation_record.available_on
+      when 'due'::public.contribution_reminder_stage_enum
+        then obligation_record.due_on
+      else obligation_record.due_on + 7
+    end;
+
+    delivery_at_value := public.contribution_reminder_delivery_at(
+      stage_on_value,
+      obligation_record.billing_timezone,
+      obligation_record.contribution_reminder_local_time
+    );
+
+    if evaluated_at < delivery_at_value then
+      skipped_count := skipped_count + 1;
+      continue;
+    end if;
+
+    update public.contribution_reminder_events event_record
+    set
+      status = 'suppressed'::public.contribution_reminder_event_status_enum,
+      suppression_reason = 'superseded_by_newer_stage',
+      updated_at = clock_timestamp()
+    where event_record.obligation_id = obligation_record.id
+      and event_record.recipient_user_id = obligation_record.user_id
+      and event_record.status = 'pending'::public.contribution_reminder_event_status_enum
+      and event_record.stage < stage_value;
+    get diagnostics affected_count = row_count;
+    suppressed_count := suppressed_count + affected_count;
+
+    inserted_event := null;
+    existing_event := null;
+    insert into public.contribution_reminder_events (
+      organization_id,
+      obligation_id,
+      recipient_user_id,
+      stage,
+      stage_on,
+      delivery_window_on,
+      status
+    )
+    values (
+      obligation_record.organization_id,
+      obligation_record.id,
+      obligation_record.user_id,
+      stage_value,
+      stage_on_value,
+      local_date_value,
+      'pending'::public.contribution_reminder_event_status_enum
+    )
+    on conflict (obligation_id, recipient_user_id, stage)
+    do nothing
+    returning * into inserted_event;
+
+    if inserted_event.id is null then
+      select event_record.*
+      into existing_event
+      from public.contribution_reminder_events event_record
+      where event_record.obligation_id = obligation_record.id
+        and event_record.recipient_user_id = obligation_record.user_id
+        and event_record.stage = stage_value;
+    else
+      created_count := created_count + 1;
+      existing_event := inserted_event;
+    end if;
+
+    if existing_event.status <>
+      'pending'::public.contribution_reminder_event_status_enum then
+      continue;
+    end if;
+
+    batch_record := null;
+    insert into public.contribution_reminder_batches (
+      organization_id,
+      recipient_user_id,
+      delivery_window_on
+    )
+    values (
+      obligation_record.organization_id,
+      obligation_record.user_id,
+      local_date_value
+    )
+    on conflict (organization_id, recipient_user_id, delivery_window_on)
+    do update set updated_at = clock_timestamp()
+    returning * into batch_record;
+
+    insert into public.contribution_reminder_batch_events (batch_id, event_id)
+    values (batch_record.id, existing_event.id)
+    on conflict (event_id) do nothing;
+
+    if batch_record.status =
+      'delivered'::public.contribution_reminder_batch_status_enum then
+      update public.contribution_reminder_events
+      set
+        status = 'coalesced'::public.contribution_reminder_event_status_enum,
+        suppression_reason = 'coalesced_into_completed_window',
+        updated_at = clock_timestamp()
+      where id = existing_event.id
+        and status = 'pending'::public.contribution_reminder_event_status_enum;
+      if found then
+        coalesced_count := coalesced_count + 1;
+      end if;
+    elsif batch_record.status =
+      'no_device'::public.contribution_reminder_batch_status_enum then
+      update public.contribution_reminder_events
+      set
+        status = 'no_device'::public.contribution_reminder_event_status_enum,
+        suppression_reason = 'no_current_device',
+        updated_at = clock_timestamp()
+      where id = existing_event.id
+        and status = 'pending'::public.contribution_reminder_event_status_enum;
+    elsif batch_record.status =
+      'terminal'::public.contribution_reminder_batch_status_enum then
+      update public.contribution_reminder_events
+      set
+        status = 'exhausted'::public.contribution_reminder_event_status_enum,
+        suppression_reason = 'delivery_exhausted',
+        updated_at = clock_timestamp()
+      where id = existing_event.id
+        and status = 'pending'::public.contribution_reminder_event_status_enum;
+    elsif batch_record.status =
+      'suppressed'::public.contribution_reminder_batch_status_enum then
+      update public.contribution_reminder_events
+      set
+        status = 'suppressed'::public.contribution_reminder_event_status_enum,
+        suppression_reason = 'batch_suppressed',
+        updated_at = clock_timestamp()
+      where id = existing_event.id
+        and status = 'pending'::public.contribution_reminder_event_status_enum;
+    end if;
+  end loop;
+
+  update public.contribution_reminder_batches queued_batch
+  set
+    status = 'suppressed'::public.contribution_reminder_batch_status_enum,
+    last_failure_code = 'no_pending_events',
+    updated_at = clock_timestamp()
+  where queued_batch.status =
+      'pending'::public.contribution_reminder_batch_status_enum
+    and not exists (
+      select 1
+      from public.contribution_reminder_batch_events batch_event
+      join public.contribution_reminder_events event_record
+        on event_record.id = batch_event.event_id
+      where batch_event.batch_id = queued_batch.id
+        and event_record.status =
+          'pending'::public.contribution_reminder_event_status_enum
+    )
+    and not exists (
+      select 1
+      from public.contribution_reminder_delivery_attempts delivery_attempt
+      where delivery_attempt.batch_id = queued_batch.id
+    );
+  return next;
+end;
+$$;
+
+create or replace function public.enqueue_contribution_reminder_events()
+returns table (
+  created_count integer,
+  skipped_count integer,
+  suppressed_count integer,
+  coalesced_count integer
+)
+language sql
+security definer
+set search_path = ''
+as $$
+  select *
+  from public.enqueue_contribution_reminder_events_at(clock_timestamp());
+$$;
+
+comment on function public.enqueue_contribution_reminder_events() is
+  'Trusted scheduler command that creates only the latest useful reminder stage for each eligible recurring obligation.';
+
+revoke all on function public.enqueue_contribution_reminder_events_at(timestamp with time zone)
+  from public, anon, authenticated, service_role;
+revoke all on function public.enqueue_contribution_reminder_events()
+  from public, anon, authenticated;
+grant execute on function public.enqueue_contribution_reminder_events_at(timestamp with time zone)
+  to postgres;
+grant execute on function public.enqueue_contribution_reminder_events()
+  to service_role;
+
+create or replace function public.refresh_contribution_reminder_batch(
+  p_batch_id uuid
+)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  has_pending boolean;
+  has_waiting boolean;
+  has_delivered boolean;
+  has_attempts boolean;
+  next_retry timestamp with time zone;
+begin
+  select
+    exists (
+      select 1
+      from public.contribution_reminder_delivery_attempts da
+      where da.batch_id = p_batch_id
+        and da.status in (
+          'pending'::public.contribution_reminder_attempt_status_enum,
+          'retryable'::public.contribution_reminder_attempt_status_enum
+        )
+    ),
+    exists (
+      select 1
+      from public.contribution_reminder_delivery_attempts da
+      where da.batch_id = p_batch_id
+        and da.status in (
+          'leased'::public.contribution_reminder_attempt_status_enum,
+          'ticketed'::public.contribution_reminder_attempt_status_enum
+        )
+    ),
+    exists (
+      select 1
+      from public.contribution_reminder_delivery_attempts da
+      where da.batch_id = p_batch_id
+        and da.status = 'delivered'::public.contribution_reminder_attempt_status_enum
+    ),
+    exists (
+      select 1
+      from public.contribution_reminder_delivery_attempts da
+      where da.batch_id = p_batch_id
+    )
+  into has_pending, has_waiting, has_delivered, has_attempts;
+
+  if has_pending and has_waiting then
+    update public.contribution_reminder_batches
+    set
+      status = 'awaiting_receipts'::public.contribution_reminder_batch_status_enum,
+      next_attempt_at = coalesce(
+        (
+          select min(da.next_attempt_at)
+          from public.contribution_reminder_delivery_attempts da
+          where da.batch_id = p_batch_id
+            and da.status = 'retryable'::public.contribution_reminder_attempt_status_enum
+        ),
+        clock_timestamp()
+      ),
+      updated_at = clock_timestamp()
+    where id = p_batch_id;
+    return;
+  end if;
+
+  if has_waiting then
+    update public.contribution_reminder_batches
+    set
+      status = 'awaiting_receipts'::public.contribution_reminder_batch_status_enum,
+      updated_at = clock_timestamp()
+    where id = p_batch_id;
+    return;
+  end if;
+
+  if has_pending then
+    select min(da.next_attempt_at)
+    into next_retry
+    from public.contribution_reminder_delivery_attempts da
+    where da.batch_id = p_batch_id
+      and da.status in (
+        'pending'::public.contribution_reminder_attempt_status_enum,
+        'retryable'::public.contribution_reminder_attempt_status_enum
+      );
+
+    update public.contribution_reminder_batches
+    set
+      status = 'retryable'::public.contribution_reminder_batch_status_enum,
+      next_attempt_at = coalesce(next_retry, clock_timestamp()),
+      updated_at = clock_timestamp()
+    where id = p_batch_id;
+    return;
+  end if;
+
+  if has_delivered then
+    update public.contribution_reminder_batches
+    set
+      status = 'delivered'::public.contribution_reminder_batch_status_enum,
+      delivered_at = coalesce(delivered_at, clock_timestamp()),
+      updated_at = clock_timestamp()
+    where id = p_batch_id;
+
+    update public.contribution_reminder_events event_record
+    set
+      status = 'delivered'::public.contribution_reminder_event_status_enum,
+      delivered_at = coalesce(delivered_at, clock_timestamp()),
+      updated_at = clock_timestamp()
+    where event_record.id in (
+      select event_id
+      from public.contribution_reminder_batch_events batch_event
+      where batch_event.batch_id = p_batch_id
+    )
+      and event_record.status = 'pending'::public.contribution_reminder_event_status_enum;
+    return;
+  end if;
+
+  if has_attempts then
+    update public.contribution_reminder_batches
+    set
+      status = 'terminal'::public.contribution_reminder_batch_status_enum,
+      updated_at = clock_timestamp()
+    where id = p_batch_id;
+
+    update public.contribution_reminder_events event_record
+    set
+      status = 'exhausted'::public.contribution_reminder_event_status_enum,
+      suppression_reason = 'delivery_exhausted',
+      updated_at = clock_timestamp()
+    where event_record.id in (
+      select event_id
+      from public.contribution_reminder_batch_events batch_event
+      where batch_event.batch_id = p_batch_id
+    )
+      and event_record.status = 'pending'::public.contribution_reminder_event_status_enum;
+  end if;
+end;
+$$;
+
+revoke all on function public.refresh_contribution_reminder_batch(uuid)
+  from public, anon, authenticated, service_role;
+grant execute on function public.refresh_contribution_reminder_batch(uuid)
+  to postgres;
+
+create or replace function public.claim_contribution_reminder_batches(
+  p_limit integer default 20,
+  p_lease_seconds integer default 120
+)
+returns table (
+  batch_id uuid,
+  lease_token uuid
+)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  batch_record public.contribution_reminder_batches%rowtype;
+  lease_value uuid;
+  limit_value integer := greatest(1, least(coalesce(p_limit, 20), 100));
+  lease_interval interval := make_interval(
+    secs => greatest(30, least(coalesce(p_lease_seconds, 120), 900))
+  );
+begin
+  for batch_record in
+    select b.*
+    from public.contribution_reminder_batches b
+    where (
+      b.status in (
+        'pending'::public.contribution_reminder_batch_status_enum,
+        'retryable'::public.contribution_reminder_batch_status_enum
+      )
+      and b.next_attempt_at <= clock_timestamp()
+      or (
+        b.status = 'leased'::public.contribution_reminder_batch_status_enum
+        and b.lease_expires_at < clock_timestamp()
+        and not exists (
+          select 1
+          from public.contribution_reminder_delivery_attempts da
+          where da.batch_id = b.id
+            and da.status = 'ticketed'::public.contribution_reminder_attempt_status_enum
+        )
+      )
+    )
+    order by b.delivery_window_on, b.organization_id, b.recipient_user_id, b.id
+    limit limit_value
+    for update skip locked
+  loop
+    lease_value := gen_random_uuid();
+
+    update public.contribution_reminder_batches
+    set
+      status = 'leased'::public.contribution_reminder_batch_status_enum,
+      lease_token = lease_value,
+      lease_expires_at = clock_timestamp() + lease_interval,
+      attempt_count = attempt_count + 1,
+      updated_at = clock_timestamp()
+    where id = batch_record.id;
+
+    batch_id := batch_record.id;
+    lease_token := lease_value;
+    return next;
+  end loop;
+end;
+$$;
+
+comment on function public.claim_contribution_reminder_batches(integer, integer) is
+  'Claims private reminder batches with SKIP LOCKED so concurrent dispatchers do not process the same batch.';
+
+revoke all on function public.claim_contribution_reminder_batches(integer, integer)
+  from public, anon, authenticated;
+grant execute on function public.claim_contribution_reminder_batches(integer, integer)
+  to service_role;
+
+create or replace function public.prepare_contribution_reminder_batch(
+  p_batch_id uuid,
+  p_lease_token uuid,
+  p_lease_seconds integer default 120
+)
+returns table (
+  batch_id uuid,
+  organization_slug text,
+  delivery_window_on date,
+  delivery_attempts jsonb
+)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  batch_record public.contribution_reminder_batches%rowtype;
+  lease_interval interval := make_interval(
+    secs => greatest(30, least(coalesce(p_lease_seconds, 120), 900))
+  );
+  token_count integer;
+  active_event_count integer;
+  attempt_count_value integer;
+  slug_value text;
+begin
+  select b.*
+  into batch_record
+  from public.contribution_reminder_batches b
+  where b.id = p_batch_id
+    and b.status = 'leased'::public.contribution_reminder_batch_status_enum
+    and b.lease_token = p_lease_token
+    and b.lease_expires_at > clock_timestamp()
+  for update;
+
+  if not found then
+    return;
+  end if;
+
+  update public.contribution_reminder_events event_record
+  set
+    status = 'suppressed'::public.contribution_reminder_event_status_enum,
+    suppression_reason = case
+      when po.status = 'settled'::public.payment_obligation_status_enum
+        then 'obligation_settled'
+      when po.status = 'void'::public.payment_obligation_status_enum
+        then 'obligation_void'
+      when exists (
+        select 1
+        from public.payment_claims pc
+        where pc.obligation_id = po.id
+          and pc.status = 'under_review'::public.payment_claim_status_enum
+      ) then 'claim_under_review'
+      else 'membership_not_active'
+    end,
+    updated_at = clock_timestamp()
+  from public.contribution_reminder_batch_events batch_event
+  join public.contribution_reminder_events batch_event_record
+    on batch_event_record.id = batch_event.event_id
+  join public.payment_obligations po on po.id = batch_event_record.obligation_id
+  where batch_event.batch_id = p_batch_id
+    and event_record.id = batch_event.event_id
+    and event_record.status = 'pending'::public.contribution_reminder_event_status_enum
+    and (
+      po.status in (
+        'settled'::public.payment_obligation_status_enum,
+        'void'::public.payment_obligation_status_enum
+      )
+      or exists (
+        select 1
+        from public.payment_claims pc
+        where pc.obligation_id = po.id
+          and pc.status = 'under_review'::public.payment_claim_status_enum
+      )
+      or not exists (
+        select 1
+        from public.organization_members om
+        join public.subscriptions s
+          on s.organization_id = om.organization_id
+          and s.user_id = om.user_id
+          and s.status = 'active'::public.subscription_status_enum
+        where om.organization_id = po.organization_id
+          and om.user_id = po.user_id
+          and om.role in (
+            'admin'::public.organization_role_enum,
+            'member'::public.organization_role_enum
+          )
+      )
+    );
+
+  select count(*)
+  into active_event_count
+  from public.contribution_reminder_batch_events batch_event
+  join public.contribution_reminder_events event_record
+    on event_record.id = batch_event.event_id
+  where batch_event.batch_id = p_batch_id
+    and event_record.status = 'pending'::public.contribution_reminder_event_status_enum;
+
+  if active_event_count = 0 then
+    update public.contribution_reminder_batches
+    set
+      status = 'suppressed'::public.contribution_reminder_batch_status_enum,
+      lease_token = null,
+      lease_expires_at = null,
+      updated_at = clock_timestamp()
+    where id = p_batch_id;
+    return;
+  end if;
+
+  select o.slug
+  into slug_value
+  from public.organizations o
+  where o.id = batch_record.organization_id
+    and o.organization_type = 'association'::public.organization_type_enum;
+
+  if slug_value is null then
+    update public.contribution_reminder_batches
+    set
+      status = 'suppressed'::public.contribution_reminder_batch_status_enum,
+      last_failure_code = 'organization_unavailable',
+      lease_token = null,
+      lease_expires_at = null,
+      updated_at = clock_timestamp()
+    where id = p_batch_id;
+    return;
+  end if;
+
+  update public.contribution_reminder_delivery_attempts da
+  set
+    status = 'terminal'::public.contribution_reminder_attempt_status_enum,
+    terminal_outcome = 'token_no_longer_owned',
+    lease_token = null,
+    lease_expires_at = null,
+    updated_at = clock_timestamp()
+  where da.batch_id = p_batch_id
+    and da.status in (
+      'pending'::public.contribution_reminder_attempt_status_enum,
+      'retryable'::public.contribution_reminder_attempt_status_enum,
+      'leased'::public.contribution_reminder_attempt_status_enum
+    )
+    and not exists (
+      select 1
+      from public.push_tokens pt
+      where pt.token = da.token
+        and pt.profile_id = batch_record.recipient_user_id
+    );
+
+  insert into public.contribution_reminder_delivery_attempts (
+    batch_id,
+    push_token_id,
+    token,
+    language,
+    status,
+    next_attempt_at
+  )
+  select
+    p_batch_id,
+    pt.id,
+    pt.token,
+    pt.language,
+    'pending'::public.contribution_reminder_attempt_status_enum,
+    clock_timestamp()
+  from public.push_tokens pt
+  where pt.profile_id = batch_record.recipient_user_id
+  on conflict on constraint contribution_reminder_delivery_attempts_batch_id_token_key
+  do update
+  set
+    push_token_id = excluded.push_token_id,
+    language = excluded.language,
+    updated_at = clock_timestamp();
+
+  select count(*)
+  into token_count
+  from public.push_tokens pt
+  where pt.profile_id = batch_record.recipient_user_id;
+
+  if token_count = 0 then
+    update public.contribution_reminder_batches
+    set
+      status = 'no_device'::public.contribution_reminder_batch_status_enum,
+      lease_token = null,
+      lease_expires_at = null,
+      updated_at = clock_timestamp()
+    where id = p_batch_id;
+
+    update public.contribution_reminder_events event_record
+    set
+      status = 'no_device'::public.contribution_reminder_event_status_enum,
+      suppression_reason = 'no_current_device',
+      updated_at = clock_timestamp()
+    where event_record.id in (
+      select event_id
+      from public.contribution_reminder_batch_events batch_event
+      where batch_event.batch_id = p_batch_id
+    )
+      and event_record.status = 'pending'::public.contribution_reminder_event_status_enum;
+    return;
+  end if;
+
+  with candidates as (
+    select da.id
+    from public.contribution_reminder_delivery_attempts da
+    where da.batch_id = p_batch_id
+      and da.status in (
+        'pending'::public.contribution_reminder_attempt_status_enum,
+        'retryable'::public.contribution_reminder_attempt_status_enum,
+        'leased'::public.contribution_reminder_attempt_status_enum
+      )
+      and (
+        da.status in (
+          'pending'::public.contribution_reminder_attempt_status_enum,
+          'retryable'::public.contribution_reminder_attempt_status_enum
+        )
+        and da.next_attempt_at <= clock_timestamp()
+        or da.status = 'leased'::public.contribution_reminder_attempt_status_enum
+          and da.lease_expires_at < clock_timestamp()
+      )
+      and exists (
+        select 1
+        from public.push_tokens pt
+        where pt.token = da.token
+          and pt.profile_id = batch_record.recipient_user_id
+      )
+    order by da.id
+    for update skip locked
+  )
+  update public.contribution_reminder_delivery_attempts da
+  set
+    status = 'leased'::public.contribution_reminder_attempt_status_enum,
+    lease_token = p_lease_token,
+    lease_expires_at = clock_timestamp() + lease_interval,
+    attempt_count = da.attempt_count + 1,
+    updated_at = clock_timestamp()
+  where da.id in (select id from candidates);
+
+  select count(*)
+  into attempt_count_value
+  from public.contribution_reminder_delivery_attempts da
+  where da.batch_id = p_batch_id
+    and da.status = 'leased'::public.contribution_reminder_attempt_status_enum
+    and da.lease_token = p_lease_token;
+
+  if attempt_count_value = 0 then
+    perform public.refresh_contribution_reminder_batch(p_batch_id);
+    return;
+  end if;
+
+  batch_id := p_batch_id;
+  organization_slug := slug_value;
+  delivery_window_on := batch_record.delivery_window_on;
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'attempt_id', da.id,
+        'token', da.token,
+        'language', da.language
+      )
+      order by da.id
+    ),
+    '[]'::jsonb
+  )
+  into delivery_attempts
+  from public.contribution_reminder_delivery_attempts da
+  where da.batch_id = p_batch_id
+    and da.status = 'leased'::public.contribution_reminder_attempt_status_enum
+    and da.lease_token = p_lease_token;
+  return next;
+end;
+$$;
+
+revoke all on function public.prepare_contribution_reminder_batch(uuid, uuid, integer)
+  from public, anon, authenticated;
+grant execute on function public.prepare_contribution_reminder_batch(uuid, uuid, integer)
+  to service_role;
+
+create or replace function public.record_contribution_reminder_tickets(
+  p_batch_id uuid,
+  p_lease_token uuid,
+  p_tickets jsonb
+)
+returns integer
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  ticket_record record;
+  updated_count integer := 0;
+  changed_count integer;
+  normalized_error text;
+begin
+  for ticket_record in
+    select *
+    from jsonb_to_recordset(coalesce(p_tickets, '[]'::jsonb)) as ticket(
+      attempt_id uuid,
+      status text,
+      expo_ticket_id text,
+      error_code text
+    )
+  loop
+    normalized_error := lower(
+      replace(coalesce(ticket_record.error_code, ''), '_', '')
+    );
+
+    if ticket_record.status = 'ok'
+      and nullif(ticket_record.expo_ticket_id, '') is not null then
+      update public.contribution_reminder_delivery_attempts da
+      set
+        status = 'ticketed'::public.contribution_reminder_attempt_status_enum,
+        expo_ticket_id = ticket_record.expo_ticket_id,
+        expo_receipt_status = null,
+        expo_receipt_error_code = null,
+        terminal_outcome = null,
+        lease_token = null,
+        lease_expires_at = null,
+        next_receipt_check_at = clock_timestamp() + interval '1 minute',
+        updated_at = clock_timestamp()
+      where da.id = ticket_record.attempt_id
+        and da.batch_id = p_batch_id
+        and da.status = 'leased'::public.contribution_reminder_attempt_status_enum
+        and da.lease_token = p_lease_token;
+      get diagnostics changed_count = row_count;
+      updated_count := updated_count + changed_count;
+    else
+      update public.contribution_reminder_delivery_attempts da
+      set
+        status = case
+          when normalized_error in (
+            'toomanyrequests',
+            'ratelimited',
+            'messagerateexceeded',
+            'serviceunavailable',
+            'internalservererror',
+            'timeout',
+            'network'
+          ) and da.attempt_count < 5
+            then 'retryable'::public.contribution_reminder_attempt_status_enum
+          else 'terminal'::public.contribution_reminder_attempt_status_enum
+        end,
+        expo_receipt_status = 'error',
+        expo_receipt_error_code = nullif(ticket_record.error_code, ''),
+        terminal_outcome = case
+          when normalized_error = 'devicenotregistered'
+            then 'device_not_registered'
+          when normalized_error in (
+            'toomanyrequests',
+            'ratelimited',
+            'messagerateexceeded',
+            'serviceunavailable',
+            'internalservererror',
+            'timeout',
+            'network'
+          ) and da.attempt_count < 5 then null
+          when da.attempt_count >= 5 then 'retry_exhausted'
+          else 'expo_ticket_error'
+        end,
+        next_attempt_at = case
+          when normalized_error in (
+            'toomanyrequests',
+            'ratelimited',
+            'messagerateexceeded',
+            'serviceunavailable',
+            'internalservererror',
+            'timeout',
+            'network'
+          ) and da.attempt_count < 5
+            then clock_timestamp() + public.contribution_reminder_backoff(da.attempt_count)
+          else da.next_attempt_at
+        end,
+        lease_token = null,
+        lease_expires_at = null,
+        updated_at = clock_timestamp()
+      where da.id = ticket_record.attempt_id
+        and da.batch_id = p_batch_id
+        and da.status = 'leased'::public.contribution_reminder_attempt_status_enum
+        and da.lease_token = p_lease_token;
+      get diagnostics changed_count = row_count;
+      updated_count := updated_count + changed_count;
+
+      if normalized_error = 'devicenotregistered'
+        or normalized_error = 'invalidpushtoken'
+        or normalized_error = 'invalidtoken' then
+        delete from public.push_tokens pt
+        where exists (
+          select 1
+          from public.contribution_reminder_delivery_attempts da
+          where da.id = ticket_record.attempt_id
+            and da.batch_id = p_batch_id
+            and da.token = pt.token
+        );
+      end if;
+    end if;
+  end loop;
+
+  update public.contribution_reminder_batches
+  set
+    status = 'awaiting_receipts'::public.contribution_reminder_batch_status_enum,
+    lease_token = null,
+    lease_expires_at = null,
+    updated_at = clock_timestamp()
+  where id = p_batch_id
+    and status = 'leased'::public.contribution_reminder_batch_status_enum;
+
+  perform public.refresh_contribution_reminder_batch(p_batch_id);
+  return updated_count;
+end;
+$$;
+
+revoke all on function public.record_contribution_reminder_tickets(uuid, uuid, jsonb)
+  from public, anon, authenticated;
+grant execute on function public.record_contribution_reminder_tickets(uuid, uuid, jsonb)
+  to service_role;
+
+create or replace function public.record_contribution_reminder_send_failure(
+  p_batch_id uuid,
+  p_lease_token uuid,
+  p_failure_code text
+)
+returns integer
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  updated_count integer;
+begin
+  update public.contribution_reminder_delivery_attempts da
+  set
+    status = case
+      when da.attempt_count < 5
+        then 'retryable'::public.contribution_reminder_attempt_status_enum
+      else 'terminal'::public.contribution_reminder_attempt_status_enum
+    end,
+    expo_receipt_status = 'send_error',
+    expo_receipt_error_code = case
+      when p_failure_code in ('network', 'rate_limit', 'server')
+        then p_failure_code
+      else 'unknown'
+    end,
+    terminal_outcome = case
+      when da.attempt_count >= 5 then 'retry_exhausted'
+      else null
+    end,
+    next_attempt_at = case
+      when da.attempt_count < 5
+        then clock_timestamp() + public.contribution_reminder_backoff(da.attempt_count)
+      else da.next_attempt_at
+    end,
+    lease_token = null,
+    lease_expires_at = null,
+    updated_at = clock_timestamp()
+  where da.batch_id = p_batch_id
+    and da.status = 'leased'::public.contribution_reminder_attempt_status_enum
+    and da.lease_token = p_lease_token;
+  get diagnostics updated_count = row_count;
+
+  update public.contribution_reminder_batches
+  set
+    status = 'retryable'::public.contribution_reminder_batch_status_enum,
+    last_failure_code = case
+      when p_failure_code in ('network', 'rate_limit', 'server') then p_failure_code
+      else 'unknown'
+    end,
+    lease_token = null,
+    lease_expires_at = null,
+    updated_at = clock_timestamp()
+  where id = p_batch_id
+    and status = 'leased'::public.contribution_reminder_batch_status_enum;
+
+  perform public.refresh_contribution_reminder_batch(p_batch_id);
+  return updated_count;
+end;
+$$;
+
+revoke all on function public.record_contribution_reminder_send_failure(uuid, uuid, text)
+  from public, anon, authenticated;
+grant execute on function public.record_contribution_reminder_send_failure(uuid, uuid, text)
+  to service_role;
+
+create or replace function public.claim_contribution_reminder_receipts(
+  p_limit integer default 100,
+  p_lease_seconds integer default 120
+)
+returns table (
+  attempt_id uuid,
+  batch_id uuid,
+  lease_token uuid,
+  expo_ticket_id text
+)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  attempt_record public.contribution_reminder_delivery_attempts%rowtype;
+  lease_value uuid;
+  limit_value integer := greatest(1, least(coalesce(p_limit, 100), 500));
+  lease_interval interval := make_interval(
+    secs => greatest(30, least(coalesce(p_lease_seconds, 120), 900))
+  );
+begin
+  for attempt_record in
+    select da.*
+    from public.contribution_reminder_delivery_attempts da
+    join public.contribution_reminder_batches b on b.id = da.batch_id
+    where b.status = 'awaiting_receipts'::public.contribution_reminder_batch_status_enum
+      and (
+        (
+          da.status = 'ticketed'::public.contribution_reminder_attempt_status_enum
+          and da.next_receipt_check_at <= clock_timestamp()
+        )
+        or (
+          da.status = 'leased'::public.contribution_reminder_attempt_status_enum
+          and da.lease_expires_at < clock_timestamp()
+        )
+      )
+    order by da.next_receipt_check_at, da.id
+    limit limit_value
+    for update of da skip locked
+  loop
+    lease_value := gen_random_uuid();
+    update public.contribution_reminder_delivery_attempts da
+    set
+      status = 'leased'::public.contribution_reminder_attempt_status_enum,
+      lease_token = lease_value,
+      lease_expires_at = clock_timestamp() + lease_interval,
+      updated_at = clock_timestamp()
+    where da.id = attempt_record.id;
+
+    attempt_id := attempt_record.id;
+    batch_id := attempt_record.batch_id;
+    lease_token := lease_value;
+    expo_ticket_id := attempt_record.expo_ticket_id;
+    return next;
+  end loop;
+end;
+$$;
+
+revoke all on function public.claim_contribution_reminder_receipts(integer, integer)
+  from public, anon, authenticated;
+grant execute on function public.claim_contribution_reminder_receipts(integer, integer)
+  to service_role;
+
+create or replace function public.record_contribution_reminder_receipts(
+  p_receipts jsonb
+)
+returns integer
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  receipt_record record;
+  updated_count integer := 0;
+  changed_count integer;
+  normalized_error text;
+  batch_id_value uuid;
+begin
+  for receipt_record in
+    select *
+    from jsonb_to_recordset(coalesce(p_receipts, '[]'::jsonb)) as receipt(
+      attempt_id uuid,
+      lease_token uuid,
+      status text,
+      error_code text
+    )
+  loop
+    normalized_error := lower(
+      replace(coalesce(receipt_record.error_code, ''), '_', '')
+    );
+
+    select da.batch_id
+    into batch_id_value
+    from public.contribution_reminder_delivery_attempts da
+    where da.id = receipt_record.attempt_id
+      and da.status = 'leased'::public.contribution_reminder_attempt_status_enum
+      and da.lease_token = receipt_record.lease_token;
+
+    if batch_id_value is null then
+      continue;
+    end if;
+
+    if receipt_record.status = 'ok' then
+      update public.contribution_reminder_delivery_attempts da
+      set
+        status = 'delivered'::public.contribution_reminder_attempt_status_enum,
+        expo_receipt_status = 'ok',
+        expo_receipt_error_code = null,
+        terminal_outcome = null,
+        lease_token = null,
+        lease_expires_at = null,
+        next_receipt_check_at = null,
+        updated_at = clock_timestamp()
+      where da.id = receipt_record.attempt_id
+        and da.status = 'leased'::public.contribution_reminder_attempt_status_enum
+        and da.lease_token = receipt_record.lease_token;
+      get diagnostics changed_count = row_count;
+      updated_count := updated_count + changed_count;
+    else
+      update public.contribution_reminder_delivery_attempts da
+      set
+        status = case
+          when normalized_error in (
+            'toomanyrequests',
+            'ratelimited',
+            'messagerateexceeded',
+            'serviceunavailable',
+            'internalservererror',
+            'timeout',
+            'network'
+          ) and da.attempt_count < 5
+            then 'retryable'::public.contribution_reminder_attempt_status_enum
+          else 'terminal'::public.contribution_reminder_attempt_status_enum
+        end,
+        expo_receipt_status = 'error',
+        expo_receipt_error_code = nullif(receipt_record.error_code, ''),
+        terminal_outcome = case
+          when normalized_error = 'devicenotregistered'
+            then 'device_not_registered'
+          when normalized_error in (
+            'toomanyrequests',
+            'ratelimited',
+            'messagerateexceeded',
+            'serviceunavailable',
+            'internalservererror',
+            'timeout',
+            'network'
+          ) and da.attempt_count < 5 then null
+          when da.attempt_count >= 5 then 'retry_exhausted'
+          else 'expo_receipt_error'
+        end,
+        next_attempt_at = case
+          when normalized_error in (
+            'toomanyrequests',
+            'ratelimited',
+            'messagerateexceeded',
+            'serviceunavailable',
+            'internalservererror',
+            'timeout',
+            'network'
+          ) and da.attempt_count < 5
+            then clock_timestamp() + public.contribution_reminder_backoff(da.attempt_count)
+          else da.next_attempt_at
+        end,
+        lease_token = null,
+        lease_expires_at = null,
+        next_receipt_check_at = null,
+        updated_at = clock_timestamp()
+      where da.id = receipt_record.attempt_id
+        and da.status = 'leased'::public.contribution_reminder_attempt_status_enum
+        and da.lease_token = receipt_record.lease_token;
+      get diagnostics changed_count = row_count;
+      updated_count := updated_count + changed_count;
+
+      if normalized_error = 'devicenotregistered'
+        or normalized_error = 'invalidpushtoken'
+        or normalized_error = 'invalidtoken' then
+        delete from public.push_tokens pt
+        where exists (
+          select 1
+          from public.contribution_reminder_delivery_attempts da
+          where da.id = receipt_record.attempt_id
+            and da.token = pt.token
+        );
+      end if;
+    end if;
+
+    perform public.refresh_contribution_reminder_batch(batch_id_value);
+  end loop;
+
+  return updated_count;
+end;
+$$;
+
+revoke all on function public.record_contribution_reminder_receipts(jsonb)
+  from public, anon, authenticated;
+grant execute on function public.record_contribution_reminder_receipts(jsonb)
+  to service_role;
+
+-- The old daily-renewal-check job was removed by the recurring-obligation
+-- cutover. These jobs are the only reminder recovery contract: enqueueing,
+-- dispatching, and receipt reconciliation all poll the durable outbox.
+do $$
+begin
+  if to_regclass('cron.job') is not null then
+    if not exists (
+      select 1 from cron.job
+      where jobname = 'contribution-reminder-enqueuer'
+    ) then
+      perform cron.schedule(
+        'contribution-reminder-enqueuer',
+        '*/15 * * * *',
+        $cron$
+        select net.http_post(
+          url := (select decrypted_secret from vault.decrypted_secrets where name = 'project_url')
+            || '/functions/v1/contribution-reminder-enqueuer',
+          headers := jsonb_build_object(
+            'Content-Type', 'application/json',
+            'Authorization', 'Bearer ' || (
+              select decrypted_secret
+              from vault.decrypted_secrets
+              where name = 'secret_key'
+            )
+          ),
+          body := '{}'::jsonb
+        ) as request_id;
+        $cron$
+      );
+    end if;
+
+    if not exists (
+      select 1 from cron.job
+      where jobname = 'contribution-reminder-dispatcher'
+    ) then
+      perform cron.schedule(
+        'contribution-reminder-dispatcher',
+        '* * * * *',
+        $cron$
+        select net.http_post(
+          url := (select decrypted_secret from vault.decrypted_secrets where name = 'project_url')
+            || '/functions/v1/contribution-reminder-dispatcher',
+          headers := jsonb_build_object(
+            'Content-Type', 'application/json',
+            'Authorization', 'Bearer ' || (
+              select decrypted_secret
+              from vault.decrypted_secrets
+              where name = 'secret_key'
+            )
+          ),
+          body := '{}'::jsonb
+        ) as request_id;
+        $cron$
+      );
+    end if;
+
+    if not exists (
+      select 1 from cron.job
+      where jobname = 'contribution-reminder-receipts'
+    ) then
+      perform cron.schedule(
+        'contribution-reminder-receipts',
+        '* * * * *',
+        $cron$
+        select net.http_post(
+          url := (select decrypted_secret from vault.decrypted_secrets where name = 'project_url')
+            || '/functions/v1/contribution-reminder-receipts',
+          headers := jsonb_build_object(
+            'Content-Type', 'application/json',
+            'Authorization', 'Bearer ' || (
+              select decrypted_secret
+              from vault.decrypted_secrets
+              where name = 'secret_key'
+            )
+          ),
+          body := '{}'::jsonb
+        ) as request_id;
+        $cron$
+      );
+    end if;
+  end if;
+end;
+$$;

--- a/supabase/tests/contribution_reminders_test.sql
+++ b/supabase/tests/contribution_reminders_test.sql
@@ -1,0 +1,822 @@
+begin;
+
+select * from no_plan();
+
+select is(
+  public.contribution_reminder_stage_for_date(
+    '2026-08-16'::date,
+    '2026-08-23'::date,
+    '2026-08-16'::date
+  ),
+  'available'::public.contribution_reminder_stage_enum,
+  'the available stage starts on the snapshotted available date'
+);
+
+select is(
+  public.contribution_reminder_stage_for_date(
+    '2026-08-16'::date,
+    '2026-08-23'::date,
+    '2026-08-30'::date
+  ),
+  'overdue'::public.contribution_reminder_stage_enum,
+  'the overdue stage starts seven calendar days after due_on'
+);
+
+select is(
+  public.contribution_reminder_delivery_at(
+    '2026-08-23'::date,
+    'America/Sao_Paulo',
+    '09:00:00'::time
+  ),
+  '2026-08-23 12:00:00+00'::timestamp with time zone,
+  'delivery uses the obligation timezone and organization-local time'
+);
+
+select is(
+  public.contribution_reminder_backoff(1),
+  '00:01:00'::interval,
+  'the first retry waits one minute'
+);
+
+select is(
+  public.contribution_reminder_backoff(10),
+  '01:00:00'::interval,
+  'retry backoff is capped at one hour'
+);
+
+insert into public.organizations (
+  id,
+  name,
+  slug,
+  organization_type,
+  billing_currency,
+  billing_timezone,
+  billing_due_day,
+  billing_lead_days,
+  contribution_reminder_local_time,
+  monthly_price_amount,
+  monthly_pix_copy_paste
+)
+values (
+  '83000000-0000-4000-8000-000000000001'::uuid,
+  'Reminder Association',
+  'reminder-association',
+  'association'::public.organization_type_enum,
+  'BRL',
+  'America/Sao_Paulo',
+  23,
+  7,
+  '09:00:00'::time,
+  12500,
+  '000201reminder-test-pix'
+);
+
+insert into auth.users (
+  id,
+  aud,
+  role,
+  email,
+  email_confirmed_at,
+  raw_user_meta_data,
+  created_at,
+  updated_at
+)
+values
+  (
+    '83000000-0000-4000-8000-000000000101'::uuid,
+    'authenticated',
+    'authenticated',
+    'reminder-member@example.com',
+    timezone('utc'::text, now()),
+    '{"full_name":"Reminder Member"}'::jsonb,
+    timezone('utc'::text, now()),
+    timezone('utc'::text, now())
+  ),
+  (
+    '83000000-0000-4000-8000-000000000102'::uuid,
+    'authenticated',
+    'authenticated',
+    'reminder-no-device@example.com',
+    timezone('utc'::text, now()),
+    '{"full_name":"Reminder No Device"}'::jsonb,
+    timezone('utc'::text, now()),
+    timezone('utc'::text, now())
+  ),
+  (
+    '83000000-0000-4000-8000-000000000103'::uuid,
+    'authenticated',
+    'authenticated',
+    'reminder-review@example.com',
+    timezone('utc'::text, now()),
+    '{"full_name":"Reminder Review"}'::jsonb,
+    timezone('utc'::text, now()),
+    timezone('utc'::text, now())
+  );
+
+insert into public.profiles (id, name, username)
+values
+  (
+    '83000000-0000-4000-8000-000000000101'::uuid,
+    'Reminder Member',
+    '@reminder_member'
+  ),
+  (
+    '83000000-0000-4000-8000-000000000102'::uuid,
+    'Reminder No Device',
+    '@reminder_no_device'
+  ),
+  (
+    '83000000-0000-4000-8000-000000000103'::uuid,
+    'Reminder Review',
+    '@reminder_review'
+  )
+on conflict (id) do update
+set name = excluded.name,
+    username = excluded.username;
+
+insert into public.organization_members (organization_id, user_id, role)
+values
+  (
+    '83000000-0000-4000-8000-000000000001'::uuid,
+    '83000000-0000-4000-8000-000000000101'::uuid,
+    'member'::public.organization_role_enum
+  ),
+  (
+    '83000000-0000-4000-8000-000000000001'::uuid,
+    '83000000-0000-4000-8000-000000000102'::uuid,
+    'member'::public.organization_role_enum
+  ),
+  (
+    '83000000-0000-4000-8000-000000000001'::uuid,
+    '83000000-0000-4000-8000-000000000103'::uuid,
+    'member'::public.organization_role_enum
+  );
+
+insert into public.subscriptions (
+  organization_id,
+  user_id,
+  plan_type,
+  status,
+  current_period_end
+)
+values
+  (
+    '83000000-0000-4000-8000-000000000001'::uuid,
+    '83000000-0000-4000-8000-000000000101'::uuid,
+    'monthly'::public.subscription_plan_type_enum,
+    'active'::public.subscription_status_enum,
+    '2026-09-30 12:00:00+00'::timestamp with time zone
+  ),
+  (
+    '83000000-0000-4000-8000-000000000001'::uuid,
+    '83000000-0000-4000-8000-000000000102'::uuid,
+    'monthly'::public.subscription_plan_type_enum,
+    'active'::public.subscription_status_enum,
+    '2026-09-30 12:00:00+00'::timestamp with time zone
+  ),
+  (
+    '83000000-0000-4000-8000-000000000001'::uuid,
+    '83000000-0000-4000-8000-000000000103'::uuid,
+    'monthly'::public.subscription_plan_type_enum,
+    'active'::public.subscription_status_enum,
+    '2026-09-30 12:00:00+00'::timestamp with time zone
+  );
+
+insert into public.payment_obligations (
+  id,
+  organization_id,
+  user_id,
+  application_revision_id,
+  purpose,
+  status,
+  plan_type,
+  amount,
+  currency,
+  payment_method,
+  pix_copy_paste,
+  available_at,
+  schedule_id,
+  period_key,
+  period_start,
+  period_end,
+  available_on,
+  due_on,
+  billing_timezone,
+  billing_due_day,
+  billing_lead_days,
+  organization_name_snapshot,
+  organization_slug_snapshot
+)
+values
+  (
+    '83000000-0000-4000-8000-000000000301'::uuid,
+    '83000000-0000-4000-8000-000000000001'::uuid,
+    '83000000-0000-4000-8000-000000000101'::uuid,
+    null,
+    'recurring'::public.payment_obligation_purpose_enum,
+    'available'::public.payment_obligation_status_enum,
+    'monthly'::public.subscription_plan_type_enum,
+    12500,
+    'BRL',
+    'manual_pix',
+    '000201reminder-301',
+    '2026-08-16 12:00:00+00'::timestamp with time zone,
+    (select id from public.contribution_schedules
+     where organization_id = '83000000-0000-4000-8000-000000000001'::uuid
+       and user_id = '83000000-0000-4000-8000-000000000101'::uuid),
+    '2026-08-301',
+    '2026-08-16'::date,
+    '2026-09-15'::date,
+    '2026-08-16'::date,
+    '2026-08-23'::date,
+    'America/Sao_Paulo',
+    23,
+    7,
+    'Reminder Association',
+    'reminder-association'
+  ),
+  (
+    '83000000-0000-4000-8000-000000000302'::uuid,
+    '83000000-0000-4000-8000-000000000001'::uuid,
+    '83000000-0000-4000-8000-000000000101'::uuid,
+    null,
+    'recurring'::public.payment_obligation_purpose_enum,
+    'available'::public.payment_obligation_status_enum,
+    'monthly'::public.subscription_plan_type_enum,
+    12500,
+    'BRL',
+    'manual_pix',
+    '000201reminder-302',
+    '2026-08-16 12:00:00+00'::timestamp with time zone,
+    (select id from public.contribution_schedules
+     where organization_id = '83000000-0000-4000-8000-000000000001'::uuid
+       and user_id = '83000000-0000-4000-8000-000000000101'::uuid),
+    '2026-08-302',
+    '2026-08-16'::date,
+    '2026-09-15'::date,
+    '2026-08-16'::date,
+    '2026-08-23'::date,
+    'America/Sao_Paulo',
+    23,
+    7,
+    'Reminder Association',
+    'reminder-association'
+  ),
+  (
+    '83000000-0000-4000-8000-000000000303'::uuid,
+    '83000000-0000-4000-8000-000000000001'::uuid,
+    '83000000-0000-4000-8000-000000000102'::uuid,
+    null,
+    'recurring'::public.payment_obligation_purpose_enum,
+    'available'::public.payment_obligation_status_enum,
+    'monthly'::public.subscription_plan_type_enum,
+    12500,
+    'BRL',
+    'manual_pix',
+    '000201reminder-303',
+    '2026-08-16 12:00:00+00'::timestamp with time zone,
+    (select id from public.contribution_schedules
+     where organization_id = '83000000-0000-4000-8000-000000000001'::uuid
+       and user_id = '83000000-0000-4000-8000-000000000102'::uuid),
+    '2026-08-303',
+    '2026-08-16'::date,
+    '2026-09-15'::date,
+    '2026-08-16'::date,
+    '2026-08-23'::date,
+    'America/Sao_Paulo',
+    23,
+    7,
+    'Reminder Association',
+    'reminder-association'
+  ),
+  (
+    '83000000-0000-4000-8000-000000000304'::uuid,
+    '83000000-0000-4000-8000-000000000001'::uuid,
+    '83000000-0000-4000-8000-000000000103'::uuid,
+    null,
+    'recurring'::public.payment_obligation_purpose_enum,
+    'available'::public.payment_obligation_status_enum,
+    'monthly'::public.subscription_plan_type_enum,
+    12500,
+    'BRL',
+    'manual_pix',
+    '000201reminder-304',
+    '2026-08-16 12:00:00+00'::timestamp with time zone,
+    (select id from public.contribution_schedules
+     where organization_id = '83000000-0000-4000-8000-000000000001'::uuid
+       and user_id = '83000000-0000-4000-8000-000000000103'::uuid),
+    '2026-08-304',
+    '2026-08-16'::date,
+    '2026-09-15'::date,
+    '2026-08-16'::date,
+    '2026-08-23'::date,
+    'America/Sao_Paulo',
+    23,
+    7,
+    'Reminder Association',
+    'reminder-association'
+  );
+
+select is(
+  (select created_count
+   from public.enqueue_contribution_reminder_events_at(
+     '2026-08-16 12:00:00+00'::timestamp with time zone
+   )),
+  4,
+  'the first scheduler pass creates one logical event per current obligation'
+);
+
+select is(
+  (select count(*)::integer from public.contribution_reminder_events),
+  4,
+  'the outbox stores four logical events after the first pass'
+);
+
+insert into public.payment_claims (
+  id,
+  obligation_id,
+  organization_id,
+  claimant_user_id,
+  payer_type,
+  status
+)
+values (
+  '83000000-0000-4000-8000-000000000401'::uuid,
+  '83000000-0000-4000-8000-000000000304'::uuid,
+  '83000000-0000-4000-8000-000000000001'::uuid,
+  '83000000-0000-4000-8000-000000000103'::uuid,
+  'applicant'::public.payment_claim_payer_type_enum,
+  'under_review'::public.payment_claim_status_enum
+);
+
+insert into public.push_tokens (token, profile_id, language)
+values (
+  'ExponentPushToken[830-member-device]',
+  '83000000-0000-4000-8000-000000000101'::uuid,
+  'en'::public.language
+);
+
+select is(
+  (select created_count
+   from public.enqueue_contribution_reminder_events_at(
+     '2026-08-16 12:00:00+00'::timestamp with time zone
+   )),
+  0,
+  'repeating the scheduler pass is idempotent'
+);
+
+select is(
+  (select created_count
+   from public.enqueue_contribution_reminder_events_at(
+     '2026-08-23 12:00:00+00'::timestamp with time zone
+   )),
+  3,
+  'the due pass creates only the latest useful stage and skips the under-review obligation'
+);
+
+select is(
+  (select status::text
+   from public.contribution_reminder_events
+   where obligation_id = '83000000-0000-4000-8000-000000000301'::uuid
+     and stage = 'available'::public.contribution_reminder_stage_enum),
+  'suppressed',
+  'a superseded available event is suppressed'
+);
+
+select is(
+  (select status::text
+   from public.contribution_reminder_events
+   where obligation_id = '83000000-0000-4000-8000-000000000301'::uuid
+     and stage = 'due'::public.contribution_reminder_stage_enum),
+  'pending',
+  'the due event remains pending until delivery completes'
+);
+
+select is(
+  (select status::text
+   from public.contribution_reminder_events
+   where obligation_id = '83000000-0000-4000-8000-000000000304'::uuid
+     and stage = 'available'::public.contribution_reminder_stage_enum),
+  'suppressed',
+  'a claim entering review suppresses its pending reminder'
+);
+
+select is(
+  (select suppression_reason
+   from public.contribution_reminder_events
+   where obligation_id = '83000000-0000-4000-8000-000000000304'::uuid
+     and stage = 'available'::public.contribution_reminder_stage_enum),
+  'claim_under_review',
+  'the suppression reason records the trusted claim state'
+);
+
+create temporary table reminder_batch_claims on commit drop as
+select *
+from public.claim_contribution_reminder_batches(20, 180);
+
+select is(
+  (select count(*)::integer from reminder_batch_claims),
+  2,
+  'only batches with a current pending event are claimable'
+);
+
+select is(
+  (select count(*)::integer
+   from public.claim_contribution_reminder_batches(20, 180)),
+  0,
+  'a second dispatcher cannot claim batches while the first lease is active'
+);
+
+create temporary table reminder_prepared on commit drop as
+select
+  batch.recipient_user_id,
+  batch.delivery_window_on,
+  claim.batch_id,
+  claim.lease_token,
+  prepared.delivery_attempts
+from reminder_batch_claims claim
+join public.contribution_reminder_batches batch
+  on batch.id = claim.batch_id
+cross join lateral public.prepare_contribution_reminder_batch(
+  claim.batch_id,
+  claim.lease_token,
+  180
+) prepared
+where batch.delivery_window_on = '2026-08-23'::date;
+
+select is(
+  (select count(*)::integer from reminder_prepared),
+  1,
+  'the dispatcher prepares the device-backed batch and closes the no-device batch'
+);
+
+select is(
+  (select status::text
+   from public.contribution_reminder_batches
+   where organization_id = '83000000-0000-4000-8000-000000000001'::uuid
+     and recipient_user_id = '83000000-0000-4000-8000-000000000102'::uuid
+     and delivery_window_on = '2026-08-23'::date),
+  'no_device',
+  'a member without a device reaches an explicit no-device outcome'
+);
+
+select is(
+  (select status::text
+   from public.contribution_reminder_events
+   where obligation_id = '83000000-0000-4000-8000-000000000303'::uuid
+     and stage = 'due'::public.contribution_reminder_stage_enum),
+  'no_device',
+  'the logical event records the no-device outcome without sending repeatedly'
+);
+
+create temporary table reminder_ticket_inputs on commit drop as
+select
+  prepared.batch_id,
+  prepared.lease_token,
+  (attempt ->> 'attempt_id')::uuid as attempt_id
+from reminder_prepared prepared
+cross join lateral jsonb_array_elements(prepared.delivery_attempts) attempt;
+
+select is(
+  (select public.record_contribution_reminder_tickets(
+    ticket.batch_id,
+    ticket.lease_token,
+    jsonb_build_array(
+      jsonb_build_object(
+        'attempt_id', ticket.attempt_id,
+        'status', 'ok',
+        'expo_ticket_id', 'ticket-830-member',
+        'error_code', null
+      )
+    )
+  )
+  from reminder_ticket_inputs ticket),
+  1,
+  'the dispatcher persists one Expo ticket for the physical batch'
+);
+
+select is(
+  (select count(*)::integer
+   from public.contribution_reminder_delivery_attempts
+   where batch_id = (select batch_id from reminder_prepared)),
+  1,
+  'two logical events coalesce into one device delivery attempt'
+);
+
+update public.contribution_reminder_delivery_attempts
+set status = 'leased'::public.contribution_reminder_attempt_status_enum,
+    lease_token = gen_random_uuid(),
+    lease_expires_at = clock_timestamp() - interval '1 second'
+where batch_id = (select batch_id from reminder_prepared);
+
+create temporary table reminder_receipt_claims on commit drop as
+select *
+from public.claim_contribution_reminder_receipts(20, 180);
+
+select is(
+  (select count(*)::integer from reminder_receipt_claims),
+  1,
+  'the receipt worker reclaims an expired receipt lease'
+);
+
+select is(
+  (select public.record_contribution_reminder_receipts(
+    coalesce(
+      (
+        select jsonb_agg(
+          jsonb_build_object(
+            'attempt_id', receipt.attempt_id,
+            'lease_token', receipt.lease_token,
+            'status', 'ok',
+            'error_code', null
+          )
+        )
+        from reminder_receipt_claims receipt
+      ),
+      '[]'::jsonb
+    )
+  )),
+  1,
+  'a successful Expo receipt completes the physical attempt'
+);
+
+select is(
+  (select status::text
+   from public.contribution_reminder_batches
+   where id = (select batch_id from reminder_prepared)),
+  'delivered',
+  'the batch becomes delivered after receipt reconciliation'
+);
+
+select is(
+  (select count(*)::integer
+   from public.contribution_reminder_events
+   where organization_id = '83000000-0000-4000-8000-000000000001'::uuid
+     and recipient_user_id = '83000000-0000-4000-8000-000000000101'::uuid
+     and status = 'delivered'::public.contribution_reminder_event_status_enum),
+  2,
+  'all coalesced logical events become delivered together'
+);
+
+insert into public.payment_obligations (
+  id,
+  organization_id,
+  user_id,
+  application_revision_id,
+  purpose,
+  status,
+  plan_type,
+  amount,
+  currency,
+  payment_method,
+  pix_copy_paste,
+  available_at,
+  schedule_id,
+  period_key,
+  period_start,
+  period_end,
+  available_on,
+  due_on,
+  billing_timezone,
+  billing_due_day,
+  billing_lead_days,
+  organization_name_snapshot,
+  organization_slug_snapshot
+)
+select
+  '83000000-0000-4000-8000-000000000305'::uuid,
+  po.organization_id,
+  po.user_id,
+  null,
+  'recurring'::public.payment_obligation_purpose_enum,
+  'available'::public.payment_obligation_status_enum,
+  po.plan_type,
+  po.amount,
+  po.currency,
+  po.payment_method,
+  '000201reminder-305',
+  '2026-08-24 12:00:00+00'::timestamp with time zone,
+  po.schedule_id,
+  '2026-08-305',
+  '2026-08-24'::date,
+  '2026-09-23'::date,
+  '2026-08-24'::date,
+  '2026-08-31'::date,
+  po.billing_timezone,
+  po.billing_due_day,
+  po.billing_lead_days,
+  po.organization_name_snapshot,
+  po.organization_slug_snapshot
+from public.payment_obligations po
+where po.id = '83000000-0000-4000-8000-000000000301'::uuid;
+
+select is(
+  (select created_count
+   from public.enqueue_contribution_reminder_events_at(
+     '2026-08-24 12:00:00+00'::timestamp with time zone
+   )),
+  1,
+  'a newly materialized obligation can still be enqueued at its current stage'
+);
+
+update public.payment_obligations
+set status = 'settled'::public.payment_obligation_status_enum,
+    settled_at = '2026-08-24 13:30:00+00'::timestamp with time zone
+where id = '83000000-0000-4000-8000-000000000305'::uuid;
+
+select is(
+  (select suppressed_count
+   from public.enqueue_contribution_reminder_events_at(
+     '2026-08-24 13:30:00+00'::timestamp with time zone
+   )),
+  1,
+  'settlement immediately suppresses a pending reminder event'
+);
+
+update public.payment_claims
+set status = 'rejected'::public.payment_claim_status_enum,
+    decided_at = '2026-08-23 14:00:00+00'::timestamp with time zone,
+    decision_reason = 'The claim could not be verified.'
+where id = '83000000-0000-4000-8000-000000000401'::uuid;
+
+update public.payment_obligations
+set status = 'settled'::public.payment_obligation_status_enum
+where id in (
+  '83000000-0000-4000-8000-000000000301'::uuid,
+  '83000000-0000-4000-8000-000000000302'::uuid,
+  '83000000-0000-4000-8000-000000000303'::uuid
+);
+
+select is(
+  (select created_count
+   from public.enqueue_contribution_reminder_events_at(
+     '2026-08-30 12:00:00+00'::timestamp with time zone
+   )),
+  1,
+  'a rejected claim permits the next future stage'
+);
+
+select is(
+  (select count(*)::integer
+   from public.contribution_reminder_events
+   where obligation_id = '83000000-0000-4000-8000-000000000304'::uuid
+     and stage = 'available'::public.contribution_reminder_stage_enum),
+  1,
+  'the original available event is retained as suppressed history'
+);
+
+select is(
+  (select count(*)::integer
+   from public.contribution_reminder_events
+   where obligation_id = '83000000-0000-4000-8000-000000000304'::uuid
+     and stage = 'due'::public.contribution_reminder_stage_enum),
+  0,
+  'a rejected claim does not replay an earlier due stage'
+);
+
+select is(
+  (select status::text
+   from public.contribution_reminder_events
+   where obligation_id = '83000000-0000-4000-8000-000000000304'::uuid
+     and stage = 'overdue'::public.contribution_reminder_stage_enum),
+  'pending',
+  'a rejected claim can create the current overdue stage'
+);
+
+insert into public.push_tokens (token, profile_id, language)
+values (
+  'ExponentPushToken[830-review-device]',
+  '83000000-0000-4000-8000-000000000103'::uuid,
+  'pt'::public.language
+);
+
+create temporary table reminder_overdue_claims on commit drop as
+select *
+from public.claim_contribution_reminder_batches(20, 180);
+
+create temporary table reminder_overdue_prepared on commit drop as
+select
+  claim.batch_id,
+  claim.lease_token,
+  prepared.delivery_attempts
+from reminder_overdue_claims claim
+cross join lateral public.prepare_contribution_reminder_batch(
+  claim.batch_id,
+  claim.lease_token,
+  180
+) prepared;
+
+select is(
+  (select count(*)::integer from reminder_overdue_prepared),
+  1,
+  'the next stage can be prepared after a rejected claim'
+);
+
+create temporary table reminder_overdue_ticket_inputs on commit drop as
+select
+  prepared.batch_id,
+  prepared.lease_token,
+  (attempt ->> 'attempt_id')::uuid as attempt_id
+from reminder_overdue_prepared prepared
+cross join lateral jsonb_array_elements(prepared.delivery_attempts) attempt;
+
+select is(
+  (select public.record_contribution_reminder_tickets(
+    ticket.batch_id,
+    ticket.lease_token,
+    jsonb_build_array(
+      jsonb_build_object(
+        'attempt_id', ticket.attempt_id,
+        'status', 'error',
+        'expo_ticket_id', null,
+        'error_code', 'DeviceNotRegistered'
+      )
+    )
+  )
+  from reminder_overdue_ticket_inputs ticket),
+  1,
+  'a permanent Expo device error is persisted as a terminal attempt'
+);
+
+select is(
+  (select count(*)::integer
+   from public.push_tokens
+   where token = 'ExponentPushToken[830-review-device]'),
+  0,
+  'DeviceNotRegistered retires the token from future delivery'
+);
+
+select is(
+  (select status::text
+   from public.contribution_reminder_events
+   where obligation_id = '83000000-0000-4000-8000-000000000304'::uuid
+     and stage = 'overdue'::public.contribution_reminder_stage_enum),
+  'exhausted',
+  'a permanent device error exhausts the logical event without retrying'
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.role', 'authenticated', true);
+select set_config(
+  'request.jwt.claim.sub',
+  '83000000-0000-4000-8000-000000000101',
+  true
+);
+
+select throws_ok(
+  $$select count(*) from public.contribution_reminder_events$$,
+  '42501',
+  'permission denied for table contribution_reminder_events',
+  'clients cannot read the private reminder outbox'
+);
+
+select throws_ok(
+  $$select count(*) from public.push_tokens$$,
+  '42501',
+  'permission denied for table push_tokens',
+  'clients cannot read device ownership rows directly'
+);
+
+select is(
+  public.register_push_token(
+    'ExponentPushToken[830-account-switch]',
+    'pt'::public.language
+  ),
+  'registered',
+  'authenticated clients register tokens through the command boundary'
+);
+
+select set_config(
+  'request.jwt.claim.sub',
+  '83000000-0000-4000-8000-000000000102',
+  true
+);
+
+select is(
+  public.register_push_token(
+    'ExponentPushToken[830-account-switch]',
+    'en'::public.language
+  ),
+  'registered',
+  'account switching transfers token ownership through the command boundary'
+);
+
+set local role postgres;
+
+select is(
+  (select profile_id
+   from public.push_tokens
+   where token = 'ExponentPushToken[830-account-switch]'),
+  '83000000-0000-4000-8000-000000000102'::uuid,
+  'the token has one current authenticated owner'
+);
+
+set local role authenticated;
+select is(
+  public.unregister_push_token('ExponentPushToken[830-account-switch]'),
+  true,
+  'authenticated logout unregisters the active token'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary
- add a private, typed contribution-reminder outbox with unique logical stages and coalesced delivery windows
- add leased Expo dispatch and receipt reconciliation workers with bounded retries, token retirement, and safe Ledger deep links
- route authenticated token ownership through RPC commands and remove direct push-token access from clients
- replace the legacy immediate-renewal reminder path with scheduled outbox jobs

## Verification
- Supabase pgTAP: 175 tests passing
- Supabase public-schema lint passing
- Edge functions format/type checks passing
- Expo TypeScript, targeted lint, and push-token tests passing

Closes #211